### PR TITLE
Fix Dockerfile by adjusting COPY commands

### DIFF
--- a/file-server/Dockerfile
+++ b/file-server/Dockerfile
@@ -9,12 +9,12 @@ LABEL version="1.0.0"
 WORKDIR /app
 
 # Copy requirements and install dependencies
-COPY file-server/requirements.txt .
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application code
-COPY file-server/app.py .
-COPY file-server/mcp_tools.py .
+COPY app.py .
+COPY mcp_tools.py .
 
 # MCP API Key for authorization
 ENV MCP_API_KEY=dockerai-mcp-a673c7ee472b8d2ace6c6809ed9e08fd


### PR DESCRIPTION
The file-server Dockerfile uses paths prefixed with file-server/ but the build context is already set to ./file-server, causing the build to fail. Removed the redundant prefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build configuration by updating how application dependencies and source files are referenced during the container image build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->