### PR TITLE
Fix: Remove passwordless sudo from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -131,9 +131,8 @@ RUN python3 --version && \
 # Many scripts and tools expect 'python' command to be available
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
-# Create a non-root user with sudo access FIRST
-RUN useradd -m -s /bin/bash assistant && \
-    echo "assistant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+# Create a non-root assistant user
+RUN useradd -m -s /bin/bash assistant
 
 # Configure npm global directory and sudo to preserve needed ENV variables
 RUN mkdir -p /usr/local/lib/node_modules_global && \


### PR DESCRIPTION
## Summary
Brief description of changes.

## Changes
- ...

## Testing
- [ ] `./tests/test-no-corporate.sh` passes
- [ ] `./tests/test-project-structure.sh` passes
- [ ] `./tests/test-docker-image.sh` passes (if Dockerfile changed)
- [ ] `docker compose up` works end-to-end


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container user configuration. The assistant user environment no longer includes elevated system privileges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->