### PR TITLE
feat: extract system prompt to server endpoint (Phase 01, v0.8.12.7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,15 @@ MCP_PORT=8081
 # TOOL_RESULT_MAX_CHARS=50000
 # TOOL_RESULT_PREVIEW_CHARS=2000
 
+# === Optional: External skill provider ===
+# URL of an external service that returns per-user skill configuration for
+# the /system-prompt endpoint. When empty (default), the orchestrator falls
+# back to DEFAULT_PUBLIC_SKILLS — the stock community skill set — without
+# contacting any external service. Wire this only if you run your own
+# skill/settings provider (out of scope for the community image).
+# MCP_TOKENS_URL=
+# MCP_TOKENS_API_KEY=
+
 # === Optional: Vision API (for describe-image skill) ===
 # VISION_API_KEY=
 # VISION_API_URL=https://api.openai.com/v1

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,10 @@ skills_archive.zip
 FIXES_*.md
 demo-recordings/
 POST.md
+
+# GSD planning artefacts — private mirror only (see GitLab remote `private`).
+# The public GitHub repo must not carry planning/roadmap/phase context:
+# it includes decision logs, port analyses, and internal-fork references that
+# are operational noise for external contributors. History was rewritten to
+# remove .planning/ — do not commit it back here.
+.planning/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v0.8.12.7 (2026-04-12)
+
+### Features
+- **System prompt extraction**: the ~460-line hardcoded Computer Use system prompt has been moved from `computer_link_filter` into the orchestrator's `GET /system-prompt` endpoint (ported from the internal fork's v3.7/v3.8 architecture). The server now performs full substitution: `{file_base_url}`, `{archive_url}`, `{chat_id}` placeholders from an optional `chat_id` query param, and the `<available_skills>` XML block from an optional `user_email` query param. Per-user skill lookup falls back gracefully to `DEFAULT_PUBLIC_SKILLS` when no external skill provider is configured (community default).
+- **Filter rewrite (v3.0.2 → v3.1.0)**: `openwebui/functions/computer_link_filter.py` is now a thin HTTP client — it fetches the fully-baked prompt from the server and injects it as-is. No more client-side URL substitution. File size dropped from 636 lines to under 250.
+- **LRU cache with stale-cache fallback**: the filter keeps an `OrderedDict` LRU keyed by `chat_id`, 5-minute TTL, max 100 entries, O(1) eviction. On fetch failure (server down, timeout, non-200), it serves the stale entry for the same chat if present; otherwise it skips injection (same safe no-op path as the missing-`chat_id` case). No broken URLs ever reach the model.
+- **New Valve `SYSTEM_PROMPT_URL`**: optional override for the endpoint URL (empty = derive from `FILE_SERVER_URL`).
+
+### Tests
+- 5 new pinning tests in `tests/orchestrator/test_system_prompt_endpoint.py` cover the `/system-prompt` contract: `chat_id` substitution, `user_email` default-skills fallback, legacy `file_base_url` / `archive_url` params, no-param degraded path, `text/plain` content-type.
+- 7 new cache tests in `tests/test_filter.py::SystemPromptFetchCache`: fresh fetch populates cache, cache hit within TTL skips HTTP, TTL expiry triggers refetch, LRU eviction at 100 entries, stale-cache fallback on server down, cold-cache skip when server down, `user_email` propagation to query string.
+- The 7 pre-existing filter tests continue to pass. Two of them (which reach the injection path) now use a `setUp` fixture that mocks `urllib.request.urlopen`.
+
+### Documentation
+- `.env.example` now documents `MCP_TOKENS_URL` (optional external skill-provider URL; empty default → graceful fallback to `DEFAULT_PUBLIC_SKILLS`).
+
+### Code removed
+- Filter's hardcoded ~460-line prompt f-string.
+- Filter's client-side URL substitution (`{file_base_url}` / `{archive_url}` / `{chat_id}` replacement).
+- Filter's timestamp-based file-injection heuristic (handled natively by Open WebUI middleware).
+
 ## v0.8.12.6 (2026-04-04)
 
 ### Features

--- a/computer-use-server/docker_manager.py
+++ b/computer-use-server/docker_manager.py
@@ -53,7 +53,7 @@ MCP_TOKENS_API_KEY = os.getenv("MCP_TOKENS_API_KEY", "")
 
 # Sub-agent configuration
 SUB_AGENT_DEFAULT_MODEL = os.getenv("SUB_AGENT_DEFAULT_MODEL", "sonnet")
-SUB_AGENT_MAX_TURNS = int(os.getenv("SUB_AGENT_MAX_TURNS", "50"))
+SUB_AGENT_MAX_TURNS = int(os.getenv("SUB_AGENT_MAX_TURNS", "25"))
 SUB_AGENT_TIMEOUT = int(os.getenv("SUB_AGENT_TIMEOUT", "3600"))
 
 # Anthropic API (shared LiteLLM proxy key — fallback when no header provided)

--- a/computer-use-server/mcp_tools.py
+++ b/computer-use-server/mcp_tools.py
@@ -768,16 +768,20 @@ async def sub_agent(
     resume_session_id: str = ""
 ) -> str:
     """
-    Delegate complex, multi-step tasks to an autonomous sub-agent.
+    COSTLY: Spawns a separate Claude CLI session with its own API budget.
+    Use ONLY as a last resort for complex CODE tasks requiring 10+ iterative tool calls.
 
-    Use this tool when a task requires:
-    - Creating complex presentations or documents
-    - Multiple coordinated file operations (multi-file refactoring)
-    - Iterative work cycles (run tests, fix, repeat)
-    - Research and information gathering
-    - Complex analysis with automatic fixes
+    Justified uses:
+    - Multi-file refactoring (5+ files) with test verification loops
+    - Complex code review with automatic fixes across many files
+    - Iterative test-fix cycles (run tests, analyze, fix, re-run until pass)
 
-    Do NOT use for simple tasks you can do directly in 1-2 tool calls.
+    Do NOT use for (handle these yourself):
+    - Tasks completable in under 8 tool calls
+    - Creating presentations, documents, spreadsheets
+    - Web research or information gathering
+    - Simple code review, documentation, or analysis
+    - Git operations or simple file edits
 
     Args:
         task: Detailed description of the task for the sub-agent to accomplish

--- a/computer-use-server/mcp_tools.py
+++ b/computer-use-server/mcp_tools.py
@@ -777,7 +777,7 @@ async def sub_agent(
     - Iterative test-fix cycles (run tests, analyze, fix, re-run until pass)
 
     Do NOT use for (handle these yourself):
-    - Tasks completable in under 8 tool calls
+    - Tasks completable in fewer than 10 tool calls
     - Creating presentations, documents, spreadsheets
     - Web research or information gathering
     - Simple code review, documentation, or analysis

--- a/computer-use-server/skill_manager.py
+++ b/computer-use-server/skill_manager.py
@@ -114,10 +114,11 @@ NATIVE_PROMPT_DESCRIPTIONS: dict[str, str] = {
         "script first before any GitLab operation."
     ),
     "sub-agent": (
-        "Delegate complex tasks to autonomous sub-agent. Use for: creating "
-        "presentations, multi-file refactoring, code review, Git operations, "
-        "research, documentation. The sub-agent can iterate on tasks until "
-        "completion and works in an isolated environment with full tool access."
+        "COSTLY: Spawns a separate Claude CLI session (high API usage). "
+        "Use ONLY for complex CODE tasks requiring 10+ iterative tool calls: "
+        "multi-file refactoring with test loops, code review with fixes across "
+        "many files, iterative test-fix cycles. "
+        "Do NOT use for: presentations, research, documentation, simple edits, Git ops."
     ),
     "describe-image": (
         "Describe images (charts, diagrams, tables, screenshots) using Vision AI. "

--- a/computer-use-server/system_prompt.py
+++ b/computer-use-server/system_prompt.py
@@ -73,7 +73,7 @@ Available tools:
 * str_replace - Edit existing files
 * file_create - Create new files
 * view - Read files and directories
-* sub_agent - Delegate complex tasks to autonomous sub-agent
+* sub_agent - COSTLY: Spawns separate Claude session. Use ONLY for complex code tasks requiring 10+ iterative tool calls (multi-file refactoring with tests, test-fix cycles). Do NOT use for presentations, research, docs, or tasks under 8 tool calls
 Working directory: `/home/assistant` (use for all temporary work)
 File system resets between tasks.
 Your ability to create files like docx, pptx, xlsx is marketed in the product to the user as 'create files' feature preview. You can create files like docx, pptx, xlsx and provide download links so the user can save them or upload them to google drive.
@@ -144,16 +144,25 @@ Search tips:
 </search_instructions>
 
 <sub_agent_delegation>
-You have access to `sub_agent` tool that can handle complex, multi-step tasks autonomously.
-Use sub_agent when task requires:
-- Creating complex presentations (pptx) or documents
-- Research and information gathering from the web
-- Multiple coordinated file operations (multi-file refactoring)
-- Iterative work (run tests, fix, repeat until success)
-- Complex Git workflows (rebases, cherry-picks, conflict resolution)
-- Deep code analysis with automatic fixes
+You have access to `sub_agent` tool. WARNING: It spawns a SEPARATE Claude CLI session that consumes significant API resources. Treat it as a LAST RESORT, not a convenience.
 
-Do NOT delegate simple tasks you can do directly in 1-2 tool calls.
+Use sub_agent ONLY for CODE-RELATED tasks that require 10+ iterative tool calls:
+- Multi-file refactoring (5+ files) with test verification loops
+- Complex code review with automatic fixes across multiple files
+- Iterative test-fix cycles (run tests → analyze failures → fix → re-run until pass)
+
+Do NOT delegate — handle these yourself:
+- ANY task completable in 1-8 tool calls
+- Creating presentations, documents, spreadsheets (do it yourself)
+- Web research or information gathering (use web search directly)
+- Simple code review or analysis (read files and respond)
+- Documentation or report writing
+- Git operations (commits, merges, rebases)
+- Single-file or few-file edits
+
+Only delegate non-code tasks (presentations, research, etc.) if the user EXPLICITLY asks you to use sub_agent.
+
+When in doubt, do the task yourself.
 
 Sub-agent returns `session_id` which can be used with `resume_session_id` parameter to continue interrupted sessions.
 
@@ -480,7 +489,7 @@ Explore GitLab repositories using glab CLI and git commands. Use when user asks 
 sub-agent
 </name>
 <description>
-Delegate complex tasks to autonomous sub-agent. Use for: creating presentations, multi-file refactoring, code review, Git operations, research, documentation. The sub-agent can iterate on tasks until completion and works in an isolated environment with full tool access.
+COSTLY: Spawns separate Claude CLI session. Use ONLY for complex CODE tasks requiring 10+ iterative tool calls (multi-file refactoring with tests, code review with fixes, test-fix cycles). Do NOT use for presentations, research, documentation, or tasks under 8 tool calls.
 </description>
 <location>
 /mnt/skills/public/sub-agent/SKILL.md

--- a/computer-use-server/system_prompt.py
+++ b/computer-use-server/system_prompt.py
@@ -73,7 +73,7 @@ Available tools:
 * str_replace - Edit existing files
 * file_create - Create new files
 * view - Read files and directories
-* sub_agent - COSTLY: Spawns separate Claude session. Use ONLY for complex code tasks requiring 10+ iterative tool calls (multi-file refactoring with tests, test-fix cycles). Do NOT use for presentations, research, docs, or any task completable in fewer than 10 tool calls
+* sub_agent - COSTLY: Spawns separate Claude session. Use ONLY for complex code tasks requiring 10+ iterative tool calls (multi-file refactoring with tests, test-fix cycles). Do NOT use for presentations, research, docs, or any task completable in fewer than 10 tool calls unless the user explicitly asks
 Working directory: `/home/assistant` (use for all temporary work)
 File system resets between tasks.
 Your ability to create files like docx, pptx, xlsx is marketed in the product to the user as 'create files' feature preview. You can create files like docx, pptx, xlsx and provide download links so the user can save them or upload them to google drive.
@@ -489,7 +489,7 @@ Explore GitLab repositories using glab CLI and git commands. Use when user asks 
 sub-agent
 </name>
 <description>
-COSTLY: Spawns separate Claude CLI session. Use ONLY for complex CODE tasks requiring 10+ iterative tool calls (multi-file refactoring with tests, code review with fixes, test-fix cycles). Do NOT use for presentations, research, documentation, or any task completable in fewer than 10 tool calls.
+COSTLY: Spawns separate Claude CLI session. Use ONLY for complex CODE tasks requiring 10+ iterative tool calls (multi-file refactoring with tests, code review with fixes, test-fix cycles). Do NOT use for presentations, research, documentation, or any task completable in fewer than 10 tool calls unless the user explicitly asks.
 </description>
 <location>
 /mnt/skills/public/sub-agent/SKILL.md

--- a/computer-use-server/system_prompt.py
+++ b/computer-use-server/system_prompt.py
@@ -73,7 +73,7 @@ Available tools:
 * str_replace - Edit existing files
 * file_create - Create new files
 * view - Read files and directories
-* sub_agent - COSTLY: Spawns separate Claude session. Use ONLY for complex code tasks requiring 10+ iterative tool calls (multi-file refactoring with tests, test-fix cycles). Do NOT use for presentations, research, docs, or tasks under 8 tool calls
+* sub_agent - COSTLY: Spawns separate Claude session. Use ONLY for complex code tasks requiring 10+ iterative tool calls (multi-file refactoring with tests, test-fix cycles). Do NOT use for presentations, research, docs, or any task completable in fewer than 10 tool calls
 Working directory: `/home/assistant` (use for all temporary work)
 File system resets between tasks.
 Your ability to create files like docx, pptx, xlsx is marketed in the product to the user as 'create files' feature preview. You can create files like docx, pptx, xlsx and provide download links so the user can save them or upload them to google drive.
@@ -152,7 +152,7 @@ Use sub_agent ONLY for CODE-RELATED tasks that require 10+ iterative tool calls:
 - Iterative test-fix cycles (run tests → analyze failures → fix → re-run until pass)
 
 Do NOT delegate — handle these yourself:
-- ANY task completable in 1-8 tool calls
+- ANY task completable in fewer than 10 tool calls
 - Creating presentations, documents, spreadsheets (do it yourself)
 - Web research or information gathering (use web search directly)
 - Simple code review or analysis (read files and respond)
@@ -489,7 +489,7 @@ Explore GitLab repositories using glab CLI and git commands. Use when user asks 
 sub-agent
 </name>
 <description>
-COSTLY: Spawns separate Claude CLI session. Use ONLY for complex CODE tasks requiring 10+ iterative tool calls (multi-file refactoring with tests, code review with fixes, test-fix cycles). Do NOT use for presentations, research, documentation, or tasks under 8 tool calls.
+COSTLY: Spawns separate Claude CLI session. Use ONLY for complex CODE tasks requiring 10+ iterative tool calls (multi-file refactoring with tests, code review with fixes, test-fix cycles). Do NOT use for presentations, research, documentation, or any task completable in fewer than 10 tool calls.
 </description>
 <location>
 /mnt/skills/public/sub-agent/SKILL.md

--- a/openwebui/functions/computer_link_filter.py
+++ b/openwebui/functions/computer_link_filter.py
@@ -204,7 +204,16 @@ class Filter:
 
         if system_msg_idx is not None:
             existing_content = messages[system_msg_idx].get("content", "")
-            match = re.search(TEMPLATE_PATTERN, existing_content, re.MULTILINE)
+            # Some Open WebUI flows deliver structured content (e.g. a list of
+            # multimodal parts) instead of a plain string. re.search would
+            # crash in that case — skip template detection and fall through to
+            # the append branch, which handles arbitrary existing_content via
+            # string concatenation (str() coercion there is safe for the
+            # downstream LLM which only reads strings anyway).
+            if isinstance(existing_content, str):
+                match = re.search(TEMPLATE_PATTERN, existing_content, re.MULTILINE)
+            else:
+                match = None
             if match:
                 # Inject BEFORE the block containing the template variable
                 block_start = _find_block_start(existing_content, match.start())
@@ -216,8 +225,14 @@ class Filter:
                     + existing_content[block_start:]
                 )
             else:
-                # No template vars -> append
-                messages[system_msg_idx]["content"] = existing_content + "\n\n" + system_prompt
+                # No template vars (or non-string content) -> append as plain string.
+                # When existing_content is a list of multimodal parts, coerce to
+                # str() first so the LLM still sees the Computer Use prompt; the
+                # original structured content is preserved via the repr.
+                if isinstance(existing_content, str):
+                    messages[system_msg_idx]["content"] = existing_content + "\n\n" + system_prompt
+                else:
+                    messages[system_msg_idx]["content"] = str(existing_content) + "\n\n" + system_prompt
         else:
             messages.insert(0, {"role": "system", "content": system_prompt})
 

--- a/openwebui/functions/computer_link_filter.py
+++ b/openwebui/functions/computer_link_filter.py
@@ -119,6 +119,18 @@ class Filter:
         base_url = self.valves.SYSTEM_PROMPT_URL or (
             self.valves.FILE_SERVER_URL.rstrip("/") + "/system-prompt"
         )
+
+        # Only http(s) is a valid orchestrator transport. Reject file://, ftp://,
+        # data://, etc. — otherwise a misconfigured Valve could read arbitrary
+        # local files through urlopen (ruff S310).
+        parsed = urllib.parse.urlparse(base_url)
+        if parsed.scheme not in ("http", "https"):
+            print(
+                f"[ComputerUseFilter] Unsupported system prompt URL scheme: "
+                f"{parsed.scheme!r} (expected http/https)"
+            )
+            return cached[1] if cached else None
+
         params = {}
         if chat_id:
             params["chat_id"] = chat_id
@@ -129,7 +141,7 @@ class Filter:
         try:
             req = urllib.request.Request(url, method="GET")
             req.add_header("Accept", "text/plain")
-            with urllib.request.urlopen(req, timeout=10) as resp:
+            with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310 — scheme validated above
                 prompt = resp.read().decode("utf-8")
 
             # Cache the ready-to-use prompt (server baked everything)
@@ -142,7 +154,11 @@ class Filter:
 
             return prompt
 
-        except Exception as e:
+        except (urllib.error.URLError, TimeoutError, UnicodeDecodeError) as e:
+            # Narrow to real transport/decoding failures. Broader Exception
+            # would swallow configuration bugs (e.g. attribute errors on the
+            # Valves model) behind the stale-cache fallback and make them
+            # invisible (ruff BLE001).
             print(f"[ComputerUseFilter] Failed to fetch system prompt: {e}")
             # Stale-cache fallback (any age) when available
             if cached:

--- a/openwebui/functions/computer_link_filter.py
+++ b/openwebui/functions/computer_link_filter.py
@@ -95,14 +95,20 @@ class Filter:
             return body
 
 
+        # Get chat_id for file URLs — skip injection entirely when absent,
+        # otherwise the prompt would ship with empty /files/ placeholders and the
+        # model would generate broken download links.
+        chat_id = __metadata__.get("chat_id") if __metadata__ else None
+        if not chat_id:
+            return body
+
         # Get files from metadata
         metadata_files = __metadata__.get("files", []) if __metadata__ else []
         messages = body.get("messages", [])
 
-        # Get chat_id for file URLs
-        chat_id = __metadata__.get("chat_id") if __metadata__ else None
-        file_base_url = f"{self.valves.FILE_SERVER_URL}/files/{chat_id}" if chat_id else ""
-        archive_url = f"{file_base_url}/archive" if chat_id else ""
+        server_url = self.valves.FILE_SERVER_URL.rstrip("/")
+        file_base_url = f"{server_url}/files/{chat_id}"
+        archive_url = f"{file_base_url}/archive"
 
         system_prompt = f"""
 <computer_use>
@@ -610,8 +616,8 @@ Do not attempt to edit, create, or delete files in these directories. If You nee
         if not chat_id:
             return body
 
-        # Pattern to find file server links
-        file_url_pattern = re.escape(self.valves.FILE_SERVER_URL) + r'/files/[^/]+/[^\s\)]+'
+        server_url = self.valves.FILE_SERVER_URL.rstrip("/")
+        file_url_pattern = re.escape(server_url) + r'/files/[^/]+/[^\s\)]+'
 
         messages = body.get("messages", [])
 
@@ -621,7 +627,7 @@ Do not attempt to edit, create, or delete files in these directories. If You nee
             if content and isinstance(content, str):
                 # Check if content has file server links
                 if re.search(file_url_pattern, content):
-                    archive_url = f"{self.valves.FILE_SERVER_URL}/files/{chat_id}/archive"
+                    archive_url = f"{server_url}/files/{chat_id}/archive"
                     # Add archive button if not already present
                     if archive_url not in content:
                         archive_button = f"\n\n---\n[{self.valves.ARCHIVE_BUTTON_TEXT}]({archive_url})"

--- a/openwebui/functions/computer_link_filter.py
+++ b/openwebui/functions/computer_link_filter.py
@@ -92,23 +92,27 @@ class Filter:
 
     def __init__(self):
         self.valves = self.Valves()
-        # Per-chat LRU cache: chat_id -> (monotonic_fetched_at, prompt_text)
-        self._prompt_cache: OrderedDict[str, tuple[float, str]] = OrderedDict()
+        # Per-(chat, user) LRU cache: (chat_id, user_email) -> (monotonic_fetched_at, prompt_text)
+        # Keyed by user identity too because the server bakes a user-specific <available_skills>
+        # block when user_email is supplied — sharing across users would leak skills and
+        # break correctness when two users hit the same chat_id.
+        self._prompt_cache: OrderedDict[tuple[str, str], tuple[float, str]] = OrderedDict()
 
     def _fetch_system_prompt(self, chat_id: str, user_email: str = "") -> Optional[str]:
         """
-        Fetch system prompt from the orchestrator with per-chat caching.
+        Fetch system prompt from the orchestrator with per-(chat, user) caching.
 
         Returns the prompt string on success, or on stale-cache fallback if the fetch
         failed but a previous entry exists. Returns None when the cache is cold AND
         the server is unreachable — caller must skip injection in that case.
         """
         now = time.time()
-        cached = self._prompt_cache.get(chat_id)
+        cache_key = (chat_id, user_email)
+        cached = self._prompt_cache.get(cache_key)
 
         # Cache hit within TTL
         if cached and (now - cached[0]) < _PROMPT_TTL_SECONDS:
-            self._prompt_cache.move_to_end(chat_id)
+            self._prompt_cache.move_to_end(cache_key)
             return cached[1]
 
         # Build URL (resolved at request time so Valves updates are honoured)
@@ -129,8 +133,8 @@ class Filter:
                 prompt = resp.read().decode("utf-8")
 
             # Cache the ready-to-use prompt (server baked everything)
-            self._prompt_cache[chat_id] = (now, prompt)
-            self._prompt_cache.move_to_end(chat_id)
+            self._prompt_cache[cache_key] = (now, prompt)
+            self._prompt_cache.move_to_end(cache_key)
 
             # Evict oldest entry when over capacity (O(1) with OrderedDict)
             while len(self._prompt_cache) > _PROMPT_CACHE_MAX_SIZE:
@@ -224,6 +228,10 @@ class Filter:
         archive_url = f"{base}/files/{chat_id}/archive"
 
         for message in body.get("messages", []):
+            # Docstring contract: archive button is appended to *assistant* messages only.
+            # Rewriting user/system/tool content would corrupt upstream input.
+            if message.get("role") != "assistant":
+                continue
             content = message.get("content")
             if not content or not isinstance(content, str):
                 continue

--- a/openwebui/functions/computer_link_filter.py
+++ b/openwebui/functions/computer_link_filter.py
@@ -224,7 +224,7 @@ class Filter:
 
         # Match orchestrator file links
         base = self.valves.FILE_SERVER_URL.rstrip("/")
-        file_url_pattern = re.escape(base) + r"/files/[^/]+/[^\s\)]+"
+        file_url_pattern = re.escape(base) + r"/files/" + re.escape(chat_id) + r"/[^\s\)]+"
         archive_url = f"{base}/files/{chat_id}/archive"
 
         for message in body.get("messages", []):

--- a/openwebui/functions/computer_link_filter.py
+++ b/openwebui/functions/computer_link_filter.py
@@ -2,584 +2,180 @@
 # Copyright (c) 2025 Open Computer Use Contributors
 """
 title: Computer Use Filter
-author: OpenWebUI Implementation
-version: 3.0.2
+author: Open Computer Use Contributors
+version: 3.1.0
 required_open_webui_version: 0.5.17
-description: Injects Computer Use system prompt with dynamic file URLs
+description: HTTP-fetches Computer Use system prompt from orchestrator /system-prompt endpoint, with LRU cache and stale-cache fallback.
 
 This filter works in conjunction with Computer Use Tools (computer_use_tools.py).
 
-ARCHITECTURE:
-- OpenWebUI runs as a web service
-- Docker containers are created for isolated code execution
-- File server provides file upload/download endpoints
-
-REQUIRED SETUP:
-1. Computer Use Tools must be installed with ID "ai_computer_use"
-2. This filter must be enabled globally or per-model
-3. File server must be accessible at FILE_SERVER_URL (default: http://localhost:8081)
-
 FUNCTIONALITY:
-- inlet(): Detects when tool_id "ai_computer_use" is active and injects system prompt
-  - Provides AI with file_base_url ({FILE_SERVER_URL}/files/{chat_id}/) so AI generates correct URLs directly
-  - Provides archive_url for downloading all files as archive
-- outlet(): Adds archive download button if file links are present
+- inlet(): When tool "ai_computer_use" is active and chat_id is present, fetches the
+  fully-baked system prompt from the orchestrator's /system-prompt endpoint (server
+  substitutes {file_base_url}, {archive_url}, {chat_id} and assembles <available_skills>)
+  and injects it into the system message. Cache: 5-minute TTL, max 100 entries,
+  O(1) LRU eviction. On fetch failure: serve stale cache if present; else skip injection.
+- outlet(): Appends an archive-download button to assistant messages containing file links.
 
-CHANGELOG (v3.0.0):
-- Major: AI now generates correct file URLs directly (no post-processing needed)
-- inlet() now provides file_base_url and archive_url to AI in system prompt
-- outlet() simplified - only adds archive button, no link replacement
-- Removed: _replace_links() method (no longer needed)
-- Removed: async outlet with event_emitter (not needed)
+CHANGELOG (v3.1.0):
+- Removed hardcoded ~460-line system prompt f-string; server is now the single source of truth.
+- HTTP fetch + OrderedDict LRU cache + stale-cache fallback (ported from internal fork v3.8.0).
+- Added SYSTEM_PROMPT_URL Valve (optional override); falls back to FILE_SERVER_URL/system-prompt.
+- Removed client-side URL substitution — server does it.
+- Dropped unused __files__ parameter from inlet().
 
-CHANGELOG (v2.4.0):
-- Removed: stream() method (links are tokenized across chunks, cannot replace on-the-fly)
-
-CHANGELOG (v2.3.0):
-- Added: outlet sends replace event to update UI immediately
+CHANGELOG (v3.0.2):
+- Previous version with hardcoded prompt; see git history for details.
 """
 
 import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import OrderedDict
 from typing import Optional
+
 from pydantic import BaseModel, Field
+
+
+# All known Open WebUI template variables
+# https://docs.openwebui.com/features/workspace/prompts/
+OPENWEBUI_TEMPLATE_VARS = [
+    "CURRENT_DATE", "CURRENT_DATETIME", "CURRENT_TIME",
+    "CURRENT_TIMEZONE", "CURRENT_WEEKDAY",
+    "USER_NAME", "USER_LANGUAGE", "USER_LOCATION",
+    "CLIPBOARD",
+]
+
+# Pattern: {{ VAR }} or {{VAR}} (with/without spaces, Jinja2-style)
+TEMPLATE_PATTERN = r"^.*\{\{\s*(?:" + "|".join(OPENWEBUI_TEMPLATE_VARS) + r")\s*\}\}.*$"
+
+# Cache TTL and size (module-level so tests can patch them)
+_PROMPT_TTL_SECONDS = 300
+_PROMPT_CACHE_MAX_SIZE = 100
+
+
+def _find_block_start(content: str, pos: int) -> int:
+    """
+    Find the start of the text block containing position `pos`.
+
+    A block is delimited by an empty line (double newline) or the start of content.
+    Used to inject the Computer Use system prompt BEFORE any Open WebUI template block.
+    """
+    boundary = content.rfind("\n\n", 0, pos)
+    return boundary + 2 if boundary != -1 else 0
 
 
 class Filter:
     class Valves(BaseModel):
         FILE_SERVER_URL: str = Field(
             default="http://localhost:8081",
-            description="File server base URL (without trailing slash)"
+            description="Orchestrator base URL (without trailing slash)",
+        )
+        SYSTEM_PROMPT_URL: str = Field(
+            default="",
+            description="Override URL for /system-prompt endpoint (empty = derive from FILE_SERVER_URL)",
         )
         ENABLE_ARCHIVE_BUTTON: bool = Field(
             default=True,
-            description="Add 'Download all as archive' button to messages with files"
+            description="Add 'Download all as archive' button to messages with files",
         )
         ARCHIVE_BUTTON_TEXT: str = Field(
             default="📦 Download all files as archive",
-            description="Text for the archive download button"
+            description="Text for the archive-download button",
         )
         INJECT_SYSTEM_PROMPT: bool = Field(
             default=True,
-            description="Inject Computer Use system prompt when tools are active"
+            description="Inject Computer Use system prompt when tools are active",
         )
 
     def __init__(self):
         self.valves = self.Valves()
+        # Per-chat LRU cache: chat_id -> (monotonic_fetched_at, prompt_text)
+        self._prompt_cache: OrderedDict[str, tuple[float, str]] = OrderedDict()
 
-    def _get_uploaded_filenames(self, __files__: Optional[list] = None) -> list:
-        """Extract filenames from uploaded files metadata"""
-        if not __files__:
-            return []
-
-        filenames = []
-        for file_obj in __files__:
-            if isinstance(file_obj, dict):
-                file_info = file_obj.get("file", {})
-                filename = file_info.get("filename")
-                if filename:
-                    filenames.append(filename)
-        return filenames
-
-    def inlet(self, body: dict, __user__: Optional[dict] = None, __files__: Optional[list] = None, __metadata__: Optional[dict] = None) -> dict:
+    def _fetch_system_prompt(self, chat_id: str, user_email: str = "") -> Optional[str]:
         """
-        Inject Computer Use system prompt BEFORE LLM processing.
+        Fetch system prompt from the orchestrator with per-chat caching.
+
+        Returns the prompt string on success, or on stale-cache fallback if the fetch
+        failed but a previous entry exists. Returns None when the cache is cold AND
+        the server is unreachable — caller must skip injection in that case.
         """
+        now = time.time()
+        cached = self._prompt_cache.get(chat_id)
+
+        # Cache hit within TTL
+        if cached and (now - cached[0]) < _PROMPT_TTL_SECONDS:
+            self._prompt_cache.move_to_end(chat_id)
+            return cached[1]
+
+        # Build URL (resolved at request time so Valves updates are honoured)
+        base_url = self.valves.SYSTEM_PROMPT_URL or (
+            self.valves.FILE_SERVER_URL.rstrip("/") + "/system-prompt"
+        )
+        params = {}
+        if chat_id:
+            params["chat_id"] = chat_id
+        if user_email:
+            params["user_email"] = user_email
+        url = base_url + ("?" + urllib.parse.urlencode(params) if params else "")
+
+        try:
+            req = urllib.request.Request(url, method="GET")
+            req.add_header("Accept", "text/plain")
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                prompt = resp.read().decode("utf-8")
+
+            # Cache the ready-to-use prompt (server baked everything)
+            self._prompt_cache[chat_id] = (now, prompt)
+            self._prompt_cache.move_to_end(chat_id)
+
+            # Evict oldest entry when over capacity (O(1) with OrderedDict)
+            while len(self._prompt_cache) > _PROMPT_CACHE_MAX_SIZE:
+                self._prompt_cache.popitem(last=False)
+
+            return prompt
+
+        except Exception as e:
+            print(f"[ComputerUseFilter] Failed to fetch system prompt: {e}")
+            # Stale-cache fallback (any age) when available
+            if cached:
+                return cached[1]
+            # Cold cache + server down -> caller skips injection
+            return None
+
+    def inlet(
+        self,
+        body: dict,
+        __user__: Optional[dict] = None,
+        __metadata__: Optional[dict] = None,
+    ) -> dict:
+        """Inject Computer Use system prompt BEFORE LLM processing."""
         if not self.valves.INJECT_SYSTEM_PROMPT:
             return body
 
-        # Check if Computer Use Tools are active
         tool_ids = body.get("tool_ids", [])
-
-        # Only inject if our specific tool is active
         if "ai_computer_use" not in tool_ids:
             return body
 
-
-        # Get chat_id for file URLs — skip injection entirely when absent,
-        # otherwise the prompt would ship with empty /files/ placeholders and the
-        # model would generate broken download links.
         chat_id = __metadata__.get("chat_id") if __metadata__ else None
         if not chat_id:
             return body
 
-        # Get files from metadata
-        metadata_files = __metadata__.get("files", []) if __metadata__ else []
+        user_email = __user__.get("email", "") if __user__ else ""
+
+        system_prompt = self._fetch_system_prompt(chat_id, user_email)
+        if not system_prompt:
+            # Cold cache + server down -> skip injection (same no-op path as missing chat_id)
+            return body
+
         messages = body.get("messages", [])
-
-        server_url = self.valves.FILE_SERVER_URL.rstrip("/")
-        file_base_url = f"{server_url}/files/{chat_id}"
-        archive_url = f"{file_base_url}/archive"
-
-        system_prompt = f"""
-<computer_use>
-<skills>
-A set of "skills" are available which are essentially folders that contain best practices for creating docs of different kinds. For instance, there is a docx skill which contains specific instructions for creating high-quality word documents, a PDF skill for creating and filling in PDFs, etc. These skill folders contain condensed wisdom from extensive testing to make really good, professional outputs. Sometimes multiple skills may be required to get the best results, so you should not limit yourself to just reading one.
-
-Your efforts are greatly aided by reading the documentation available in the skill BEFORE writing any code, creating any files, or using any computer tools. As such, when using the Linux computer to accomplish tasks, your first order of business should always be to think about the skills available in your <available_skills> and decide which skills, if any, are relevant to the task. Then, you can and should use the `view` tool to read the appropriate SKILL.md files and follow their instructions.
-
-For instance:
-
-User: Can you make me a powerpoint with a slide for each month of pregnancy showing how my body will be affected each month?
-Assistant: [immediately calls the view tool on /mnt/skills/public/pptx/SKILL.md]
-
-User: Please read this document and fix any grammatical errors.
-Assistant: [immediately calls the view tool on /mnt/skills/public/docx/SKILL.md]
-
-User: Please create an AI image based on the document I uploaded, then add it to the doc.
-Assistant: [immediately calls the view tool on /mnt/skills/public/docx/SKILL.md followed by reading the /mnt/skills/user/imagegen/SKILL.md file (this is an example user-uploaded skill and may not be present at all times, but you should attend very closely to user-provided skills since they're more than likely to be relevant)]
-
-User: Go to github.com/user/repo and summarize the README.
-Assistant: [immediately calls the view tool on /mnt/skills/public/playwright-cli/SKILL.md, then uses playwright-cli commands to navigate to the URL and extract content]
-
-Please invest the extra effort to read the appropriate SKILL.md file before jumping in -- it's worth it!
-</skills>
-
-<file_creation_advice>
-It is recommended that you use the following file creation triggers:
-- "write a document/report/post/article" → Create docx, .md, or .html file
-- "create a component/script/module" → Create code files
-- "fix/modify/edit my file" → Edit the actual uploaded file
-- "make a presentation" → Create .pptx file
-- ANY request with "save", "file", or "document" → Create files
-- writing more than 10 lines of code → Create files
-</file_creation_advice>
-
-<assistant_identity>
-You are an AI assistant with computer use capabilities. You can execute code, create files, and use various tools to help users accomplish their tasks. You are not tied to any specific AI model or product - you are a helpful assistant that works with the user's chosen AI model through this environment.
-</assistant_identity>
-
-<unnecessary_computer_use_avoidance>
-You should not use computer tools when:
-- Answering factual questions from your training knowledge
-- Summarizing content already provided in the conversation
-- Explaining concepts or providing information
-</unnecessary_computer_use_avoidance>
-
-<high_level_computer_use_explanation>
-You have access to a Linux computer (Ubuntu 24) to accomplish tasks by writing and executing code and bash commands.
-Available tools:
-* bash - Execute commands
-* str_replace - Edit existing files
-* file_create - Create new files
-* view - Read files and directories
-* sub_agent - Delegate complex tasks to autonomous sub-agent
-Working directory: `/home/assistant` (use for all temporary work)
-File system resets between tasks.
-Your ability to create files like docx, pptx, xlsx is marketed in the product to the user as 'create files' feature preview. You can create files like docx, pptx, xlsx and provide download links so the user can save them or upload them to google drive.
-</high_level_computer_use_explanation>
-
-<sub_agent_delegation>
-You have access to `sub_agent` tool that can handle complex, multi-step tasks autonomously.
-Use sub_agent when task requires:
-- Creating complex presentations (pptx) or documents
-- Research and information gathering from the web
-- Multiple coordinated file operations (multi-file refactoring)
-- Iterative work (run tests, fix, repeat until success)
-- Complex Git workflows (rebases, cherry-picks, conflict resolution)
-- Deep code analysis with automatic fixes
-
-Do NOT delegate simple tasks you can do directly in 1-2 tool calls.
-
-Sub-agent returns `session_id` which can be used with `resume_session_id` parameter to continue interrupted sessions.
-
-IMPORTANT: ALWAYS read /mnt/skills/public/sub-agent/SKILL.md BEFORE calling sub_agent. The skill contains critical task structure guidelines.
-</sub_agent_delegation>
-
-<file_handling_rules>
-CRITICAL - FILE LOCATIONS AND ACCESS:
-1. USER UPLOADS (files mentioned by user):
-   - Every file in your context window is also available in your computer
-   - Location: `/mnt/user-data/uploads`
-   - Use: `view /mnt/user-data/uploads` to see available files
-2. YOUR WORK:
-   - Location: `/home/assistant`
-   - Action: Create all new files here first
-   - Use: Normal workspace for all tasks
-   - Users are not able to see files in this directory - you should think of it as a temporary scratchpad
-3. FINAL OUTPUTS (files to share with user):
-   - Location: `/mnt/user-data/outputs`
-   - Web URL: Files here are accessible at {file_base_url}/
-   - Action: Copy completed files here and share as HTTP links
-   - Use: ONLY for final deliverables (including code files or that the user will want to see)
-   - It is very important to move final outputs to the /outputs directory. Without this step, users won't be able to see the work you have done.
-   - If task is simple (single file, <100 lines), write directly to /mnt/user-data/outputs/
-
-<notes_on_user_uploaded_files>
-There are some rules and nuance around how user-uploaded files work. Every file the user uploads is given a filepath in /mnt/user-data/uploads and can be accessed programmatically in the computer at this path. However, some files additionally have their contents present in the context window, either as text or as a base64 image that you can see natively.
-These are the file types that may be present in the context window:
-* md (as text)
-* txt (as text)
-* html (as text)
-* csv (as text)
-* png (as image)
-* pdf (as image)
-For files that do not have their contents present in the context window, you will need to interact with the computer to view these files (using view tool or bash).
-
-However, for the files whose contents are already present in the context window, it is up to you to determine if you actually need to access the computer to interact with the file, or if you can rely on the fact that you already have the contents of the file in the context window.
-
-Examples of when you should use the computer:
-* User uploads an image and asks you to convert it to grayscale
-
-Examples of when you should not use the computer:
-* User uploads an image of text and asks you to transcribe it (you can already see the image and can just transcribe it)
-</notes_on_user_uploaded_files>
-</file_handling_rules>
-
-<producing_outputs>
-FILE CREATION STRATEGY:
-For SHORT content (<100 lines):
-- Create the complete file in one tool call
-- Save directly to /mnt/user-data/outputs/
-For LONG content (>100 lines):
-- Use ITERATIVE EDITING - build the file across multiple tool calls
-- Start with outline/structure
-- Add content section by section
-- Review and refine
-- Copy final version to /mnt/user-data/outputs/
-- Typically, use of a skill will be indicated.
-REQUIRED: you must actually CREATE FILES when requested, not just show content. This is very important; otherwise the users will not be able to access the content properly.
-</producing_outputs>
-
-<sharing_files>
-When sharing files with users, you provide a link to the resource and a succinct summary of the contents or conclusion. You only provide direct links to files, not folders. You refrain from excessive or overly descriptive post-ambles after linking the contents. You finish your response with a succinct and concise explanation; you do NOT write extensive explanations of what is in the document, as the user is able to look at the document themselves if they want. The most important thing is that you give the user direct access to their documents - NOT that you explain the work you did.
-
-IMPORTANT: Files in `/mnt/user-data/outputs/` are accessible via URL: {file_base_url}/
-Example: file `/mnt/user-data/outputs/report.xlsx` → `{file_base_url}/report.xlsx`
-
-For IMAGE files (screenshots, charts, diagrams, photos), use markdown image syntax `![description](URL)` instead of regular links so images render inline. Image extensions: .png, .jpg, .jpeg, .gif, .webp, .svg, .bmp
-
-If user asks to download ALL files as archive, provide this link: {archive_url}
-
-<good_file_sharing_examples>
-[Assistant finishes running code to generate a report]
-[View your report]({file_base_url}/report.docx)
-[end of output]
-
-[Assistant finishes writing a script to compute the first 10 digits of pi]
-[View your script]({file_base_url}/pi.py)
-[end of output]
-
-[Assistant finishes creating a chart]
-![Sales Chart]({file_base_url}/chart.png)
-[end of output]
-
-[Assistant creates a report with visualization]
-[View your report]({file_base_url}/report.docx)
-
-![Data Visualization]({file_base_url}/viz.png)
-[end of output]
-
-These examples are good because they:
-1. are succinct (without unnecessary postamble)
-2. use "view" instead of "download"
-3. provide direct HTTP links to files
-4. use image syntax for .png/.jpg/.gif/.svg files
-</good_file_sharing_examples>
-
-It is imperative to give users the ability to view their files by putting them in the outputs directory and providing HTTP links. Without this step, users won't be able to see the work you have done or be able to access their files.
-</sharing_files>
-
-<artifacts>
-You can use your computer to create artifacts for substantial, high-quality code, analysis, and writing.
-
-You create single-file artifacts unless otherwise asked by the user. This means that when you create HTML and React artifacts, you do not create separate files for CSS and JS -- rather, you put everything in a single file.
-
-Although you are free to produce any file type, when making artifacts, a few specific file types have special rendering properties in the user interface. Specifically, these files and extension pairs will render in the user interface:
-
-- Markdown (extension .md)
-- HTML (extension .html)
-- React (extension .jsx)
-- Mermaid (extension .mermaid)
-- SVG (extension .svg)
-- PDF (extension .pdf)
-
-Here are some usage notes on these file types:
-
-### Markdown
-Markdown files should be created when providing the user with standalone, written content.
-Examples of when to use a markdown file:
-- Original creative writing
-- Content intended for eventual use outside the conversation (such as reports, emails, presentations, one-pagers, blog posts, articles, advertisement)
-- Comprehensive guides
-- Standalone text-heavy markdown or plain text documents (longer than 4 paragraphs or 20 lines)
-
-Examples of when to not use a markdown file:
-- Lists, rankings, or comparisons (regardless of length)
-- Plot summaries, story explanations, movie/show descriptions
-- Professional documents & analyses that should properly be docx files
-- As an accompanying README when the user did not request one
-
-If unsure whether to make a markdown Artifact, use the general principle of "will the user want to copy/paste this content outside the conversation". If yes, ALWAYS create the artifact.
-
-### HTML
-- HTML, JS, and CSS should be placed in a single file.
-- External scripts can be imported from https://cdnjs.cloudflare.com
-
-### React
-- Use this for displaying either: React elements, e.g. `<strong>Hello World!</strong>`, React pure functional components, e.g. `() => <strong>Hello World!</strong>`, React functional components with Hooks, or React component classes
-- When creating a React component, ensure it has no required props (or provide default values for all props) and use a default export.
-- Use only Tailwind's core utility classes for styling. THIS IS VERY IMPORTANT. We don't have access to a Tailwind compiler, so we're limited to the pre-defined classes in Tailwind's base stylesheet.
-- Base React is available to be imported. To use hooks, first import it at the top of the artifact, e.g. `import {{ useState }} from "react"`
-- Available libraries:
-   - lucide-react@0.263.1: `import {{ Camera }} from "lucide-react"`
-   - recharts: `import {{ LineChart, XAxis, ... }} from "recharts"`
-   - MathJS: `import * as math from 'mathjs'`
-   - lodash: `import _ from 'lodash'`
-   - d3: `import * as d3 from 'd3'`
-   - Plotly: `import * as Plotly from 'plotly'`
-   - Three.js (r128): `import * as THREE from 'three'`
-      - Remember that example imports like THREE.OrbitControls wont work as they aren't hosted on the Cloudflare CDN.
-      - The correct script URL is https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js
-      - IMPORTANT: Do NOT use THREE.CapsuleGeometry as it was introduced in r142. Use alternatives like CylinderGeometry, SphereGeometry, or create custom geometries instead.
-   - Papaparse: for processing CSVs
-   - SheetJS: for processing Excel files (XLSX, XLS)
-   - shadcn/ui: `import {{ Alert, AlertDescription, AlertTitle, AlertDialog, AlertDialogAction }} from '@/components/ui/alert'` (mention to user if used)
-   - Chart.js: `import * as Chart from 'chart.js'`
-   - Tone: `import * as Tone from 'tone'`
-   - mammoth: `import * as mammoth from 'mammoth'`
-   - tensorflow: `import * as tf from 'tensorflow'`
-
-# CRITICAL BROWSER STORAGE RESTRICTION
-**NEVER use localStorage, sessionStorage, or ANY browser storage APIs in artifacts.** These APIs are NOT supported and will cause artifacts to fail in the environment.
-Instead, you must:
-- Use React state (useState, useReducer) for React components
-- Use JavaScript variables or objects for HTML artifacts
-- Store all data in memory during the session
-
-**Exception**: If a user explicitly requests localStorage/sessionStorage usage, explain that these APIs are not supported in artifacts and will cause the artifact to fail. Offer to implement the functionality using in-memory storage instead, or suggest they copy the code to use in their own environment where browser storage is available.
-
-You should never include `<artifact>` or `<antartifact>` tags in its responses to users.
-</artifacts>
-
-<package_management>
-- npm: Works normally, global packages install to `/home/assistant/.npm-global`
-- pip: ALWAYS use `--break-system-packages` flag (e.g., `pip install pandas --break-system-packages`)
-- Virtual environments: Create if needed for complex Python projects
-- Always verify tool availability before use
-</package_management>
-
-<examples>
-EXAMPLE DECISIONS:
-Request: "Summarize this attached file"
-→ File is attached in conversation → Use provided content, do NOT use view tool
-Request: "Fix the bug in my Python file" + attachment
-→ File mentioned → Check /mnt/user-data/uploads → Copy to /home/assistant to iterate/lint/test → Provide to user back in /mnt/user-data/outputs
-Request: "What are the top video game companies by net worth?"
-→ Knowledge question → Answer directly, NO tools needed
-Request: "Write a blog post about AI trends"
-→ Content creation → CREATE actual .md file in /mnt/user-data/outputs, don't just output text
-Request: "Create a React component for user login"
-→ Code component → CREATE actual .jsx file(s) in /home/assistant then move to /mnt/user-data/outputs
-Request: "Go to github.com/user/repo and summarize the README"
-→ URL/website task → Read /mnt/skills/public/playwright-cli/SKILL.md FIRST, then use playwright-cli to navigate and extract content
-Request: "Go to github.com/user/repo, read the README and create a summary presentation"
-→ Multi-skill task → Read BOTH /mnt/skills/public/playwright-cli/SKILL.md AND /mnt/skills/public/pptx/SKILL.md, then use playwright-cli for content, then create pptx
-</examples>
-
-<additional_skills_reminder>
-Repeating again for emphasis: please begin the response to each and every request in which computer use is implicated by using the `view` tool to read the appropriate SKILL.md files (remember, multiple skill files may be relevant and essential) so that You can learn from the best practices that have been built up by trial and error to help You produce the highest-quality outputs. In particular:
-
-- When creating presentations, ALWAYS call `view` on /mnt/skills/public/pptx/SKILL.md before starting to make the presentation.
-- When creating spreadsheets, ALWAYS call `view` on /mnt/skills/public/xlsx/SKILL.md before starting to make the spreadsheet.
-- When creating word documents, ALWAYS call `view` on /mnt/skills/public/docx/SKILL.md before starting to make the document.
-- When creating PDFs? That's right, ALWAYS call `view` on /mnt/skills/public/pdf/SKILL.md before starting to make the PDF. (Don't use pypdf.)
-- When delegating tasks to sub_agent, ALWAYS call `view` on /mnt/skills/public/sub-agent/SKILL.md FIRST. The skill file contains critical information about task structure, session management, and resume capabilities. Never call sub_agent without reading this file first.
-- When navigating to websites, opening URLs, or interacting with web pages, ALWAYS call `view` on /mnt/skills/public/playwright-cli/SKILL.md before starting. This applies whenever the user asks to "go to", "open", "visit", or "navigate to" a website. For simple URL fetching (API calls, downloading raw files), use curl/wget instead.
-
-Please note that the above list of examples is *nonexhaustive* and in particular it does not cover either "user skills" (which are skills added by the user that are typically in `/mnt/skills/user`), or "example skills" (which are some other skills that may or may not be enabled that will be in `/mnt/skills/example`). These should also be attended to closely and used promiscuously when they seem at all relevant, and should usually be used in combination with the core document creation skills.
-
-This is extremely important, so thanks for paying attention to it.
-</additional_skills_reminder>
-</computer_use>
-
-<available_skills>
-<skill>
-<name>docx</name>
-<description>Document creation, editing, and analysis with tracked changes, comments, formatting. Use for .docx files.</description>
-<location>/mnt/skills/public/docx/SKILL.md</location>
-</skill>
-<skill>
-<name>pdf</name>
-<description>PDF manipulation: extract text/tables, create, merge/split, fill forms.</description>
-<location>/mnt/skills/public/pdf/SKILL.md</location>
-</skill>
-<skill>
-<name>pptx</name>
-<description>Presentation creation and editing for .pptx files with layouts, charts, speaker notes.</description>
-<location>/mnt/skills/public/pptx/SKILL.md</location>
-</skill>
-<skill>
-<name>xlsx</name>
-<description>Spreadsheet creation, editing, analysis with formulas, formatting, visualization.</description>
-<location>/mnt/skills/public/xlsx/SKILL.md</location>
-</skill>
-<skill>
-<name>skill-creator</name>
-<description>Guide for creating custom skills that extend AI capabilities.</description>
-<location>/mnt/skills/public/skill-creator/SKILL.md</location>
-</skill>
-<skill>
-<name>gitlab-explorer</name>
-<description>Explore GitLab repos: clone, search, view MRs, CI/CD, issues, git history.</description>
-<location>/mnt/skills/public/gitlab-explorer/SKILL.md</location>
-</skill>
-<skill>
-<name>sub-agent</name>
-<description>Delegate complex multi-step tasks to autonomous Claude Code agent.</description>
-<location>/mnt/skills/public/sub-agent/SKILL.md</location>
-</skill>
-<skill>
-<name>describe-image</name>
-<description>Describe images (charts, diagrams, tables, screenshots) using Vision AI.</description>
-<location>/mnt/skills/public/describe-image/SKILL.md</location>
-</skill>
-<skill>
-<name>playwright-cli</name>
-<description>Browser automation: navigate websites, fill forms, take screenshots, extract data. Use for any web interaction.</description>
-<location>/mnt/skills/public/playwright-cli/SKILL.md</location>
-</skill>
-<skill>
-<name>frontend-design</name>
-<description>Create production-grade frontend interfaces with high design quality. Web components, dashboards, React.</description>
-<location>/mnt/skills/public/frontend-design/SKILL.md</location>
-</skill>
-<skill>
-<name>doc-coauthoring</name>
-<description>Structured 3-stage workflow for co-authoring docs: context gathering, refinement, reader testing.</description>
-<location>/mnt/skills/public/doc-coauthoring/SKILL.md</location>
-</skill>
-<skill>
-<name>webapp-testing</name>
-<description>Test web applications using Playwright: verify UI, capture screenshots, view browser logs.</description>
-<location>/mnt/skills/public/webapp-testing/SKILL.md</location>
-</skill>
-<skill>
-<name>test-driven-development</name>
-<description>TDD workflow: write test first, watch it fail, write minimal code to pass.</description>
-<location>/mnt/skills/public/test-driven-development/SKILL.md</location>
-</skill>
-</available_skills>
-
-<filesystem_configuration>
-The following directories are mounted read-only:
-- /mnt/user-data/uploads
-- /mnt/transcripts
-- /mnt/skills/public
-- /mnt/skills/private
-- /mnt/skills/examples
-
-Do not attempt to edit, create, or delete files in these directories. If You needs to modify files from these locations, You should copy them to the working directory first.
-</filesystem_configuration>
-"""
-
-        # NOTE: File information is injected into user messages, NOT system prompt
-        # This prevents breaking prompt cache when new files are uploaded
-
         if not messages:
             return body
 
-        # Fix empty user messages with files attached
-        # Try both sources: body['files'] and metadata['files']
-        body_files = body.get("files", [])
-        all_files = metadata_files or body_files
-
-        if all_files:
-            # Extract filenames WITH timestamps
-            files_with_timestamps = []
-            for file_obj in all_files:
-                if isinstance(file_obj, dict):
-                    file_info = file_obj.get("file", {})
-                    filename = file_info.get("filename") or file_info.get("name")
-                    created_at = file_info.get("created_at", 0)
-                    if filename:
-                        files_with_timestamps.append({
-                            "filename": filename,
-                            "created_at": created_at
-                        })
-
-            # SMART FILTERING: Inject only NEWEST file(s) based on created_at timestamp
-            # Why: OpenWebUI doesn't save our content modifications, so we can't track mentions
-            # Solution: Assume user uploads files sequentially, inject only most recent ones
-
-            new_files = []
-
-            if len(messages) <= 2:
-                # First interaction - inject ALL files
-                new_files = [f["filename"] for f in files_with_timestamps]
-            else:
-                # Find the NEWEST file(s) uploaded (highest created_at timestamp)
-                if files_with_timestamps:
-                    # Sort by created_at descending
-                    sorted_files = sorted(files_with_timestamps, key=lambda x: x["created_at"], reverse=True)
-                    max_timestamp = sorted_files[0]["created_at"]
-
-                    # Get all files with the MAX timestamp (in case multiple uploaded at once)
-                    newest_files = [f for f in sorted_files if f["created_at"] == max_timestamp]
-
-                    # Calculate file age
-                    import time
-                    current_time = int(time.time())
-                    file_age_seconds = current_time - max_timestamp
-
-                    # HEURISTIC: Inject newest file ONLY if:
-                    # - This is message #3,4 (first few interactions) OR
-                    # - File was uploaded very recently (<60 seconds)
-                    if len(messages) <= 4:
-                        # Early in conversation - inject newest files
-                        new_files = [f["filename"] for f in newest_files]
-                    elif file_age_seconds < 60:
-                        # Recent upload - inject
-                        new_files = [f["filename"] for f in newest_files]
-                    else:
-                        pass
-
-            # IMPORTANT: If last user message is EMPTY and we have files, MUST inject something
-            # Otherwise we get "text content blocks must be non-empty" error
-            if not new_files and files_with_timestamps:
-                # Check if last user message is empty
-                last_user_idx = None
-                for idx in range(len(messages) - 1, -1, -1):
-                    if messages[idx].get("role") == "user":
-                        last_user_idx = idx
-                        break
-
-                if last_user_idx is not None:
-                    content = messages[last_user_idx].get("content", "")
-                    is_empty = isinstance(content, str) and (not content or content.strip() == "")
-
-                    if is_empty:
-                        # Last message is empty - inject NEWEST file to prevent error
-                        sorted_files = sorted(files_with_timestamps, key=lambda x: x["created_at"], reverse=True)
-                        new_files = [sorted_files[0]["filename"]]
-
-            # Add filenames to last user message
-            if new_files:
-                # Find the last user message
-                last_user_idx = None
-                for idx in range(len(messages) - 1, -1, -1):
-                    if messages[idx].get("role") == "user":
-                        last_user_idx = idx
-                        break
-
-                if last_user_idx is not None:
-                    msg = messages[last_user_idx]
-                    content = msg.get("content", "")
-
-                    if isinstance(content, str) and (not content or content.strip() == ""):
-                        # Empty user message - inject NEW filenames only
-                        files_text = "📎 " + ", ".join(new_files)
-                        msg["content"] = files_text
-                    elif isinstance(content, list):
-                        # Array content - find empty text blocks
-                        for item in content:
-                            if isinstance(item, dict) and item.get("type") == "text":
-                                text = item.get("text", "")
-                                if not text or text.strip() == "":
-                                    files_text = "📎 " + ", ".join(new_files)
-                                    item["text"] = files_text
-                                    break
-
-        # Find system message
+        # Locate existing system message
         system_msg_idx = None
         for idx, msg in enumerate(messages):
             if msg.get("role") == "system":
@@ -587,14 +183,23 @@ Do not attempt to edit, create, or delete files in these directories. If You nee
                 break
 
         if system_msg_idx is not None:
-            # Append to existing system message
-            messages[system_msg_idx]["content"] += "\n\n" + system_prompt
+            existing_content = messages[system_msg_idx].get("content", "")
+            match = re.search(TEMPLATE_PATTERN, existing_content, re.MULTILINE)
+            if match:
+                # Inject BEFORE the block containing the template variable
+                block_start = _find_block_start(existing_content, match.start())
+                messages[system_msg_idx]["content"] = (
+                    existing_content[:block_start].rstrip()
+                    + "\n\n"
+                    + system_prompt
+                    + "\n\n"
+                    + existing_content[block_start:]
+                )
+            else:
+                # No template vars -> append
+                messages[system_msg_idx]["content"] = existing_content + "\n\n" + system_prompt
         else:
-            # Insert new system message at the beginning
-            messages.insert(0, {
-                "role": "system",
-                "content": system_prompt
-            })
+            messages.insert(0, {"role": "system", "content": system_prompt})
 
         body["messages"] = messages
         return body
@@ -605,32 +210,26 @@ Do not attempt to edit, create, or delete files in these directories. If You nee
         __user__: Optional[dict] = None,
         __metadata__: Optional[dict] = None,
     ) -> dict:
-        """
-        Process messages after model generation.
-        Adds archive download button if file links are present.
-        """
-        if not self.valves.ENABLE_ARCHIVE_BUTTON:
-            return body
-
+        """Append an archive-download button to assistant messages with file links."""
         chat_id = __metadata__.get("chat_id") if __metadata__ else None
         if not chat_id:
             return body
 
-        server_url = self.valves.FILE_SERVER_URL.rstrip("/")
-        file_url_pattern = re.escape(server_url) + r'/files/[^/]+/[^\s\)]+'
+        if not self.valves.ENABLE_ARCHIVE_BUTTON:
+            return body
 
-        messages = body.get("messages", [])
+        # Match orchestrator file links
+        base = self.valves.FILE_SERVER_URL.rstrip("/")
+        file_url_pattern = re.escape(base) + r"/files/[^/]+/[^\s\)]+"
+        archive_url = f"{base}/files/{chat_id}/archive"
 
-        # Process messages array - add archive button if file links found
-        for message in messages:
+        for message in body.get("messages", []):
             content = message.get("content")
-            if content and isinstance(content, str):
-                # Check if content has file server links
-                if re.search(file_url_pattern, content):
-                    archive_url = f"{server_url}/files/{chat_id}/archive"
-                    # Add archive button if not already present
-                    if archive_url not in content:
-                        archive_button = f"\n\n---\n[{self.valves.ARCHIVE_BUTTON_TEXT}]({archive_url})"
-                        message["content"] = content + archive_button
+            if not content or not isinstance(content, str):
+                continue
+            if re.search(file_url_pattern, content) and archive_url not in content:
+                message["content"] = (
+                    content + f"\n\n[{self.valves.ARCHIVE_BUTTON_TEXT}]({archive_url})"
+                )
 
         return body

--- a/skills/public/sub-agent/SKILL.md
+++ b/skills/public/sub-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sub-agent
-description: "COSTLY: Spawns separate Claude CLI session. Use ONLY for complex CODE tasks requiring 10+ iterative tool calls (multi-file refactoring with tests, code review with fixes, test-fix cycles). Do NOT use for presentations, research, documentation, or tasks under 8 tool calls."
+description: "COSTLY: Spawns separate Claude CLI session. Use ONLY for complex CODE tasks requiring 10+ iterative tool calls (multi-file refactoring with tests, code review with fixes, test-fix cycles). Do NOT use for presentations, research, documentation, or any task completable in fewer than 10 tool calls."
 ---
 
 # Sub-Agent Skill
@@ -20,7 +20,7 @@ Only delegate non-code tasks (presentations, research) if the user EXPLICITLY as
 ## When NOT to Use
 
 Do **NOT** delegate if ANY of these apply:
-- Task can be done in 1-8 tool calls (even if it seems tedious)
+- Task can be done in fewer than 10 tool calls (even if it seems tedious)
 - Creating presentations, documents, spreadsheets (do it yourself)
 - Web research or information gathering (use search tools directly)
 - Simple code review or analysis (read files and respond)
@@ -58,37 +58,44 @@ Clear, specific instruction what to do.
 ### BAD
 ```
 sub_agent(
-    task="Create a presentation about AI trends",
-    description="User needs presentation"
+    task="Fix failing tests in the project",
+    description="Tests are red"
 )
 ```
+
+Too vague — no test command, no scope, no stop condition. The sub-agent will
+thrash over the whole codebase and likely exhaust `max_turns`.
 
 ### GOOD
 ```
 sub_agent(
     task="""
 ## ROLE
-You are a business presentation specialist.
+You are a Python debugging specialist fixing a broken test suite after a refactor.
 
 ## DIRECTIVE
-Create a 12-slide presentation on AI adoption trends for executives.
+Run `pytest tests/orchestrator/` and fix every failing test until the suite is green.
+The refactor renamed `SkillStore` → `SkillManager`; most failures are stale imports
+and fixture mocks that still reference the old name.
 
 ## CONSTRAINTS
-- Do NOT use technical jargon
-- Do NOT include more than 5 bullets per slide
-- Cite all sources
+- Do NOT modify the public test assertions (what they check, not how they set up).
+- Do NOT touch tests outside `tests/orchestrator/`.
+- Stop after 5 consecutive iterations with no new tests passing; report blockers.
 
 ## PROCESS
-1. Research current AI adoption statistics
-2. Create slide outline with key messages
-3. Build presentation with charts
-4. Add speaker notes
+1. Run the test command, capture the failing set.
+2. For each failure, identify root cause (import? mock? behaviour change?).
+3. Fix in production code when the refactor is incomplete; fix in fixtures when
+   the fixture is pinning the old name.
+4. Re-run the suite, repeat until all green or stop condition hit.
 
 ## OUTPUT
-- Save to /mnt/user-data/outputs/ai_trends.pptx
-- Create executive_summary.pdf
+- All `tests/orchestrator/` tests passing.
+- Summary of files changed with one-line rationale per file.
+- If any test remains red, explain why and what the blocker is.
 """,
-    description="AI presentation for board meeting",
+    description="Fix post-refactor test suite",
     max_turns=50
 )
 ```
@@ -137,8 +144,8 @@ The `session_id` is returned in sub_agent result JSON.
 ### How to resume via sub_agent tool:
 ```python
 sub_agent(
-    task="Continue the task. Previous progress: slide 8 of 15 completed.",
-    description="Resume interrupted presentation",
+    task="Continue the refactor. Previous progress: 12 of 18 modules migrated, test suite still red.",
+    description="Resume interrupted refactor",
     resume_session_id="abc123-session-id"
 )
 ```
@@ -147,8 +154,8 @@ sub_agent(
 
 **Read `references/usage.md`** if you need:
 
-- **Task template** for your specific task type (presentation, refactoring, code review, research, git, test-fix)
+- **Task template** for your specific task type (refactoring, code review, test-fix cycles)
 - **Anti-patterns** - common mistakes that cause sub-agent to fail
-- **Max turns guide** - how to choose the right value (10-20 for simple, 50+ for presentations)
+- **Max turns guide** - how to choose the right value (10-20 for simple, 50+ for large refactors)
 - **Model selection** - when to use `opus` instead of `sonnet`
 - **Environment details** - what paths and tools are available

--- a/skills/public/sub-agent/SKILL.md
+++ b/skills/public/sub-agent/SKILL.md
@@ -19,7 +19,12 @@ Only delegate non-code tasks (presentations, research) if the user EXPLICITLY as
 
 ## When NOT to Use
 
-Do **NOT** delegate if ANY of these apply:
+**Precedence:** if the user explicitly asks to delegate any of the items below
+(e.g. "please use sub_agent for this presentation"), the user's request wins
+and you may delegate. Otherwise treat the list as hard rules.
+
+Do **NOT** delegate if ANY of these apply (and the user has not explicitly
+overridden the rule for this specific task):
 - Task can be done in fewer than 10 tool calls (even if it seems tedious)
 - Creating presentations, documents, spreadsheets (do it yourself)
 - Web research or information gathering (use search tools directly)
@@ -67,7 +72,7 @@ Too vague — no test command, no scope, no stop condition. The sub-agent will
 thrash over the whole codebase and likely exhaust `max_turns`.
 
 ### GOOD
-```
+```python
 sub_agent(
     task="""
 ## ROLE

--- a/skills/public/sub-agent/SKILL.md
+++ b/skills/public/sub-agent/SKILL.md
@@ -1,27 +1,32 @@
 ---
 name: sub-agent
-description: "Delegate complex tasks to autonomous sub-agent. Use for: creating presentations, multi-file refactoring, code review, Git operations, research, documentation. Works like a powerful assistant within isolated environment."
+description: "COSTLY: Spawns separate Claude CLI session. Use ONLY for complex CODE tasks requiring 10+ iterative tool calls (multi-file refactoring with tests, code review with fixes, test-fix cycles). Do NOT use for presentations, research, documentation, or tasks under 8 tool calls."
 ---
 
 # Sub-Agent Skill
 
 Delegate complex, multi-step tasks to an autonomous sub-agent that can iterate until completion.
 
-## When to Use
+## When to Use (ONLY complex CODE tasks requiring 10+ iterative tool calls)
 
-- Creating presentations (10+ slides)
-- Multi-file refactoring
-- Iterative test-fix cycles
-- Research and reports
-- Code review with fixes
-- Complex Git operations
+WARNING: Each sub_agent call spawns a SEPARATE Claude CLI session consuming significant API resources. Use as a LAST RESORT.
+
+- Multi-file refactoring (5+ files) with test verification loops
+- Complex code review with automatic fixes across many files
+- Iterative test-fix cycles (run tests → analyze → fix → re-run until pass)
+
+Only delegate non-code tasks (presentations, research) if the user EXPLICITLY asks.
 
 ## When NOT to Use
 
-Do **NOT** delegate if you can do it directly in 1-2 tool calls:
-- Simple file reads/writes
-- Single bash command
-- Quick edits to one file
+Do **NOT** delegate if ANY of these apply:
+- Task can be done in 1-8 tool calls (even if it seems tedious)
+- Creating presentations, documents, spreadsheets (do it yourself)
+- Web research or information gathering (use search tools directly)
+- Simple code review or analysis (read files and respond)
+- Documentation or report writing (create files directly)
+- Git operations (commits, merges, rebases)
+- Single-file or few-file edits
 
 ## MANDATORY: Task Structure
 

--- a/skills/public/sub-agent/references/usage.md
+++ b/skills/public/sub-agent/references/usage.md
@@ -83,39 +83,6 @@ See `references/security-review.md` for detailed security review guidelines.
 
 ---
 
-### Git Operations
-
-```
-sub_agent(
-    task="""
-## ROLE
-You are a Git specialist managing repository operations.
-
-## DIRECTIVE
-[Git operation: analyze history, rebase, resolve conflicts]
-
-## CONSTRAINTS
-- Create backup branch before destructive operations
-- Do NOT force push to shared branches
-- Preserve commit authorship
-
-## PROCESS
-1. Analyze current state with git status/log
-2. Create backup if needed
-3. Perform operation
-4. Verify result
-
-## OUTPUT
-- Show git log of result
-- Create summary of operations
-""",
-    description="[Brief description]",
-    max_turns=20
-)
-```
-
----
-
 ### Test-Fix Cycle
 
 ```
@@ -213,11 +180,14 @@ task="Add docstrings to functions"
 
 ## Max Turns Guide
 
+Single-file or few-file work belongs in the main session — do not delegate
+those. The table starts at the smallest size that is still in-scope for
+`sub_agent` (multi-file refactors + test loops).
+
 | max_turns | Use Case |
 |-----------|----------|
-| 10-20 | Simple code tasks (single file fix) |
-| 25 | (default) Standard code tasks |
-| 30-40 | Medium refactoring (few files + tests) |
+| 25 | (default) Short multi-file refactor with test verification |
+| 30-40 | Medium multi-file refactoring (5-10 files + tests) |
 | 50-80 | Large multi-file refactoring with test loops, iterative test-fix cycles |
 | 100+ | Full codebase refactoring |
 

--- a/skills/public/sub-agent/references/usage.md
+++ b/skills/public/sub-agent/references/usage.md
@@ -2,43 +2,15 @@
 
 Detailed templates and reference for sub_agent tool. For basic usage, see SKILL.md.
 
+**Scope reminder:** `sub_agent` is for complex CODE tasks that require 10+ iterative
+tool calls (multi-file refactoring with test loops, code review with fixes across
+many files, iterative test-fix cycles). Do **not** delegate presentations, research,
+documentation writing, or anything completable in under 10 tool calls — handle those
+yourself. Only delegate non-code work if the user explicitly asks.
+
 ---
 
 ## Task Templates
-
-### Presentation
-
-```
-sub_agent(
-    task="""
-## ROLE
-You are a business presentation specialist creating [TYPE] slides.
-
-## DIRECTIVE
-Create a [NUMBER]-slide presentation about [TOPIC] for [AUDIENCE].
-
-## CONSTRAINTS
-- Do NOT use more than [N] bullets per slide
-- Do NOT use technical jargon if audience is non-technical
-- Cite all sources for data claims
-
-## PROCESS
-1. Review source materials in /mnt/user-data/uploads/
-2. Create slide outline with key messages
-3. Build presentation with charts and visuals
-4. Add speaker notes for each slide
-
-## OUTPUT
-- Save to /mnt/user-data/outputs/[filename].pptx
-- Include speaker notes
-- Create PDF version
-""",
-    description="[Brief description]",
-    max_turns=50
-)
-```
-
----
 
 ### Refactoring
 
@@ -69,41 +41,6 @@ You are a [LANGUAGE] refactoring specialist.
 """,
     description="[Brief description]",
     max_turns=30
-)
-```
-
----
-
-### Research
-
-```
-sub_agent(
-    task="""
-## ROLE
-You are a research analyst specializing in [DOMAIN].
-
-## DIRECTIVE
-Research [TOPIC] and create [DELIVERABLE].
-
-## CONSTRAINTS
-- Use only publicly available sources
-- Focus on [YEAR]+ data
-- Cite all sources with URLs
-
-## PROCESS
-1. Search for relevant information
-2. Compile and analyze findings
-3. Create structured report
-4. Add source citations
-
-## OUTPUT
-- Save to /mnt/user-data/outputs/[filename].md
-- Include sources section
-- Add executive summary
-""",
-    description="[Brief description]",
-    model="opus",
-    max_turns=40
 )
 ```
 
@@ -218,7 +155,6 @@ Run tests, analyze failures, fix issues until all pass.
 ### Vague Tasks
 ```
 # BAD
-task="Create a presentation"
 task="Fix the tests"
 task="Refactor the code"
 ```
@@ -270,7 +206,7 @@ task="Add docstrings to functions"
 
 | Model | Use When |
 |-------|----------|
-| `sonnet` | Default. Fast. Presentations, refactoring, file processing |
+| `sonnet` | Default. Fast. Refactoring, file processing, test-fix cycles |
 | `opus` | Complex reasoning: debugging, architecture, security analysis |
 
 ---
@@ -282,7 +218,7 @@ task="Add docstrings to functions"
 | 10-20 | Simple code tasks (single file fix) |
 | 25 | (default) Standard code tasks |
 | 30-40 | Medium refactoring (few files + tests) |
-| 50-80 | Large multi-file refactoring with test loops |
+| 50-80 | Large multi-file refactoring with test loops, iterative test-fix cycles |
 | 100+ | Full codebase refactoring |
 
 ---

--- a/skills/public/sub-agent/references/usage.md
+++ b/skills/public/sub-agent/references/usage.md
@@ -279,10 +279,10 @@ task="Add docstrings to functions"
 
 | max_turns | Use Case |
 |-----------|----------|
-| 10-20 | Simple tasks (single file) |
-| 30-40 | Medium (few files) |
-| 50 | (default) Presentations 10-15 slides |
-| 60-80 | Large presentations 20+ slides, multi-file refactoring |
+| 10-20 | Simple code tasks (single file fix) |
+| 25 | (default) Standard code tasks |
+| 30-40 | Medium refactoring (few files + tests) |
+| 50-80 | Large multi-file refactoring with test loops |
 | 100+ | Full codebase refactoring |
 
 ---

--- a/tests/corporate-patterns.txt
+++ b/tests/corporate-patterns.txt
@@ -8,3 +8,6 @@ sk-A82_\|sk--Mo5\|mcp-internal-\|dockerai-mcp-|Hardcoded API keys
 gitlab\.alfaleasing\.\|nexus\.yc\.alfaleasing|Internal container registry
 cdp\.alfaleasing\.\|alfaleasing-rca|Internal CA certificates
 svc-alfaai\|dockerai\.inner|Internal service accounts
+files-claude\|files_claude|Internal fork slug (private repo reference)
+openwebui-computer-use-community-1|Author's private workstation project directory
+/Users/ngyambroskin/\|/home/ngyambroskin/|Author's private workstation home path

--- a/tests/orchestrator/test_system_prompt_endpoint.py
+++ b/tests/orchestrator/test_system_prompt_endpoint.py
@@ -12,6 +12,7 @@ Run: python -m pytest tests/orchestrator/test_system_prompt_endpoint.py -v
 import sys
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(ROOT / "computer-use-server"))
@@ -19,6 +20,7 @@ sys.path.insert(0, str(ROOT / "computer-use-server"))
 from fastapi.testclient import TestClient  # noqa: E402
 
 import app as app_module  # noqa: E402
+import skill_manager as skill_manager_module  # noqa: E402
 
 
 class SystemPromptEndpointContract(unittest.TestCase):
@@ -28,6 +30,13 @@ class SystemPromptEndpointContract(unittest.TestCase):
     def setUpClass(cls):
         cls.client = TestClient(app_module.app)
         cls.file_server_url = app_module.FILE_SERVER_URL
+
+    def setUp(self):
+        # Ensure tests are hermetic: reset skill_manager memory cache so that
+        # a prior test run (or another test in this file) cannot leak a cached
+        # skill list for the same email. Tests that need an external provider
+        # stub it explicitly below.
+        skill_manager_module._memory_cache.clear()
 
     def test_chat_id_substitutes_urls_and_literal(self):
         resp = self.client.get("/system-prompt", params={"chat_id": "abc123"})
@@ -41,14 +50,22 @@ class SystemPromptEndpointContract(unittest.TestCase):
         self.assertNotIn("{chat_id}", body)
 
     def test_user_email_returns_default_skills_when_provider_unconfigured(self):
-        # With MCP_TOKENS_URL / MCP_TOKENS_API_KEY unset, get_user_skills() falls back
-        # to DEFAULT_PUBLIC_SKILLS per skill_manager._fetch_user_config returning None.
-        resp = self.client.get(
-            "/system-prompt",
-            params={"chat_id": "abc", "user_email": "test@example.com"},
-        )
+        # Hermetic: force _fetch_user_config -> None and _load_user_config_cache -> None
+        # so get_user_skills() takes the DEFAULT_PUBLIC_SKILLS fallback path
+        # regardless of MCP_TOKENS_URL / MCP_TOKENS_API_KEY env state on the host.
+        async def _no_provider(_email):
+            return None
+
+        with patch.object(skill_manager_module, "_fetch_user_config", side_effect=_no_provider), \
+             patch.object(skill_manager_module, "_load_user_config_cache", return_value=None):
+            resp = self.client.get(
+                "/system-prompt",
+                params={"chat_id": "abc", "user_email": "test@example.com"},
+            )
         self.assertEqual(resp.status_code, 200)
         self.assertIn("<available_skills>", resp.text)
+        # DEFAULT_PUBLIC_SKILLS must appear — pin a representative one
+        self.assertIn("<name>\ndocx\n</name>", resp.text)
 
     def test_legacy_file_base_url_and_archive_url_substitute(self):
         resp = self.client.get(

--- a/tests/orchestrator/test_system_prompt_endpoint.py
+++ b/tests/orchestrator/test_system_prompt_endpoint.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
+"""Pinning tests for /system-prompt endpoint.
+
+The endpoint at computer-use-server/app.py:1154-1205 is already a correct port
+of the internal fork v3.7/v3.8. These tests pin the current contract so future
+refactors cannot regress it. All tests should PASS on current HEAD.
+
+Run: python -m pytest tests/orchestrator/test_system_prompt_endpoint.py -v
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(ROOT / "computer-use-server"))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+import app as app_module  # noqa: E402
+
+
+class SystemPromptEndpointContract(unittest.TestCase):
+    """Pin /system-prompt endpoint behaviour — DO NOT modify the endpoint to make these pass."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.client = TestClient(app_module.app)
+        cls.file_server_url = app_module.FILE_SERVER_URL
+
+    def test_chat_id_substitutes_urls_and_literal(self):
+        resp = self.client.get("/system-prompt", params={"chat_id": "abc123"})
+        self.assertEqual(resp.status_code, 200)
+        body = resp.text
+        self.assertIn(f"{self.file_server_url}/files/abc123", body)
+        self.assertIn(f"{self.file_server_url}/files/abc123/archive", body)
+        self.assertIn("abc123", body)
+        self.assertNotIn("{file_base_url}", body)
+        self.assertNotIn("{archive_url}", body)
+        self.assertNotIn("{chat_id}", body)
+
+    def test_user_email_returns_default_skills_when_provider_unconfigured(self):
+        # With MCP_TOKENS_URL / MCP_TOKENS_API_KEY unset, get_user_skills() falls back
+        # to DEFAULT_PUBLIC_SKILLS per skill_manager._fetch_user_config returning None.
+        resp = self.client.get(
+            "/system-prompt",
+            params={"chat_id": "abc", "user_email": "test@example.com"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("<available_skills>", resp.text)
+
+    def test_legacy_file_base_url_and_archive_url_substitute(self):
+        resp = self.client.get(
+            "/system-prompt",
+            params={
+                "file_base_url": "https://example.com/files/xyz",
+                "archive_url": "https://example.com/files/xyz/arch",
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        body = resp.text
+        self.assertIn("https://example.com/files/xyz", body)
+        self.assertIn("https://example.com/files/xyz/arch", body)
+        self.assertIn("xyz", body)
+        self.assertNotIn("{file_base_url}", body)
+        self.assertNotIn("{archive_url}", body)
+        self.assertNotIn("{chat_id}", body)
+
+    def test_no_params_returns_unsubstituted_template(self):
+        resp = self.client.get("/system-prompt")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.text
+        # Degraded diagnostic path — at least one placeholder still present
+        self.assertTrue(
+            any(ph in body for ph in ("{file_base_url}", "{archive_url}", "{chat_id}")),
+            "Expected un-substituted placeholders in no-params response",
+        )
+
+    def test_content_type_is_text_plain(self):
+        resp = self.client.get("/system-prompt", params={"chat_id": "abc"})
+        self.assertTrue(
+            resp.headers.get("content-type", "").startswith("text/plain"),
+            f"Expected text/plain, got {resp.headers.get('content-type')}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test-no-corporate.sh
+++ b/tests/test-no-corporate.sh
@@ -78,6 +78,66 @@ else
     pass "No branding asset directories"
 fi
 
+# Git-history guards: only run when ROOT is a git work tree (skip silently on
+# sparse checkouts / tarballs). Both checks scope to the PR range
+# (origin/main..HEAD) so they don't flag already-merged history on main.
+echo ""
+echo "[+3] No cyrillic characters in PR commit messages"
+if git -C "$ROOT" rev-parse --git-dir > /dev/null 2>&1; then
+    if git -C "$ROOT" rev-parse --verify --quiet origin/main > /dev/null 2>&1; then
+        CYR_HITS=$(git -C "$ROOT" log origin/main..HEAD --pretty=format:'%H%n%B%n===END===' 2>/dev/null | \
+            awk -v RS='===END===\n' '
+                /[А-Яа-яЁё]/ {
+                    split($0, lines, "\n");
+                    sha = lines[1];
+                    subj = "";
+                    for (i = 2; i <= length(lines); i++) {
+                        if (lines[i] != "") { subj = lines[i]; break }
+                    }
+                    if (sha != "") { print substr(sha, 1, 12) "  " subj }
+                }
+            ' || true)
+        if [ -z "$CYR_HITS" ]; then
+            pass "No cyrillic in PR commit messages"
+        else
+            fail "Cyrillic found in commit messages: $CYR_HITS"
+        fi
+    else
+        pass "Skipped (no origin/main ref — detached checkout)"
+    fi
+else
+    pass "Skipped (not a git work tree)"
+fi
+
+echo ""
+echo "[+4] No private-fork details in PR commit messages"
+if git -C "$ROOT" rev-parse --git-dir > /dev/null 2>&1; then
+    if git -C "$ROOT" rev-parse --verify --quiet origin/main > /dev/null 2>&1; then
+        PRIVATE_RE='files-claude|files_claude|ngyambroskin|openwebui-computer-use-community-1'
+        PRIV_HITS=$(git -C "$ROOT" log origin/main..HEAD --pretty=format:'%H%n%B%n===END===' 2>/dev/null | \
+            awk -v re="$PRIVATE_RE" -v RS='===END===\n' '
+                $0 ~ re {
+                    split($0, lines, "\n");
+                    sha = lines[1];
+                    subj = "";
+                    for (i = 2; i <= length(lines); i++) {
+                        if (lines[i] != "") { subj = lines[i]; break }
+                    }
+                    if (sha != "") { print substr(sha, 1, 12) "  " subj }
+                }
+            ' || true)
+        if [ -z "$PRIV_HITS" ]; then
+            pass "No private-fork details in PR commit messages"
+        else
+            fail "Private-fork reference in commit messages: $PRIV_HITS"
+        fi
+    else
+        pass "Skipped (no origin/main ref — detached checkout)"
+    fi
+else
+    pass "Skipped (not a git work tree)"
+fi
+
 # Summary
 echo ""
 echo "==============================="

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
+"""Tests for computer_link_filter (Open WebUI Function).
+
+Run: python -m pytest tests/test_filter.py -v
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "openwebui" / "functions"))
+
+import computer_link_filter  # noqa: E402
+
+
+def _make_filter(file_server_url: str = "http://localhost:8081") -> "computer_link_filter.Filter":
+    f = computer_link_filter.Filter()
+    f.valves.FILE_SERVER_URL = file_server_url
+    return f
+
+
+def _active_body() -> dict:
+    return {
+        "tool_ids": ["ai_computer_use"],
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+
+def _system_content(body: dict) -> str:
+    for m in body["messages"]:
+        if m.get("role") == "system":
+            return m.get("content", "")
+    return ""
+
+
+class TrailingSlashNormalisation(unittest.TestCase):
+    """FILE_SERVER_URL may arrive with a trailing slash; URLs must never end up with `//files/`."""
+
+    def test_inlet_does_not_emit_double_slash(self):
+        f = _make_filter("http://localhost:8081/")
+        body = f.inlet(_active_body(), __metadata__={"chat_id": "abc"})
+        self.assertNotIn("//files/", _system_content(body))
+
+    def test_outlet_archive_button_has_no_double_slash(self):
+        f = _make_filter("http://localhost:8081/")
+        link = "http://localhost:8081/files/abc/report.pdf"
+        body = {"messages": [{"role": "assistant", "content": f"see {link}"}]}
+        out = f.outlet(body, __metadata__={"chat_id": "abc"})
+        content = out["messages"][0]["content"]
+        self.assertNotIn("//files/", content)
+        self.assertIn("http://localhost:8081/files/abc/archive", content)
+
+
+class EmptyChatIdHandling(unittest.TestCase):
+    """When chat_id is missing, the injected prompt must not reference broken /files/ URLs."""
+
+    def test_inlet_skips_injection_when_chat_id_is_none(self):
+        f = _make_filter()
+        body = f.inlet(_active_body(), __metadata__={})
+        self.assertEqual("", _system_content(body),
+                         "System prompt should not be injected when chat_id is missing")
+
+    def test_inlet_skips_injection_when_metadata_missing(self):
+        f = _make_filter()
+        body = f.inlet(_active_body(), __metadata__=None)
+        self.assertEqual("", _system_content(body))
+
+
+class BaselineBehaviour(unittest.TestCase):
+    """Regression guards: normal happy path must keep working."""
+
+    def test_inlet_injects_when_tool_active_and_chat_id_present(self):
+        f = _make_filter()
+        body = f.inlet(_active_body(), __metadata__={"chat_id": "abc"})
+        self.assertIn("http://localhost:8081/files/abc", _system_content(body))
+
+    def test_inlet_no_injection_when_tool_inactive(self):
+        f = _make_filter()
+        body = f.inlet(
+            {"tool_ids": [], "messages": [{"role": "user", "content": "hi"}]},
+            __metadata__={"chat_id": "abc"},
+        )
+        self.assertEqual("", _system_content(body))
+
+    def test_outlet_appends_archive_button_once(self):
+        f = _make_filter()
+        link = "http://localhost:8081/files/abc/report.pdf"
+        body = {"messages": [{"role": "assistant", "content": f"see {link}"}]}
+        out1 = f.outlet(body, __metadata__={"chat_id": "abc"})
+        out2 = f.outlet(out1, __metadata__={"chat_id": "abc"})
+        self.assertEqual(
+            out1["messages"][0]["content"],
+            out2["messages"][0]["content"],
+            "Archive button must be idempotent (not duplicated on repeat outlet calls)",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -126,6 +126,24 @@ class BaselineBehaviour(unittest.TestCase):
             "Archive button must be idempotent (not duplicated on repeat outlet calls)",
         )
 
+    def test_outlet_does_not_modify_non_assistant_messages(self):
+        """User/system/tool messages must be left untouched even if they contain a file URL."""
+        f = _make_filter()
+        link = "http://localhost:8081/files/abc/report.pdf"
+        original_user = f"check {link}"
+        original_system = f"context with {link}"
+        body = {
+            "messages": [
+                {"role": "user", "content": original_user},
+                {"role": "system", "content": original_system},
+                {"role": "tool", "content": f"tool output {link}"},
+            ]
+        }
+        out = f.outlet(body, __metadata__={"chat_id": "abc"})
+        self.assertEqual(out["messages"][0]["content"], original_user)
+        self.assertEqual(out["messages"][1]["content"], original_system)
+        self.assertNotIn("archive", out["messages"][2]["content"].lower())
+
 
 class SystemPromptFetchCache(unittest.TestCase):
     """New in v3.1.0: HTTP-fetch + LRU cache + stale-cache fallback."""
@@ -135,12 +153,12 @@ class SystemPromptFetchCache(unittest.TestCase):
         with patch("urllib.request.urlopen", return_value=_urlopen_mock("PROMPT_V1")):
             result = f._fetch_system_prompt("chat-a", "")
         self.assertEqual(result, "PROMPT_V1")
-        self.assertIn("chat-a", f._prompt_cache)
-        self.assertEqual(f._prompt_cache["chat-a"][1], "PROMPT_V1")
+        self.assertIn(("chat-a", ""), f._prompt_cache)
+        self.assertEqual(f._prompt_cache[("chat-a", "")][1], "PROMPT_V1")
 
     def test_cache_hit_within_ttl_skips_http(self):
         f = _make_filter()
-        f._prompt_cache["chat-a"] = (time.time(), "CACHED")
+        f._prompt_cache[("chat-a", "")] = (time.time(), "CACHED")
         with patch("urllib.request.urlopen", side_effect=AssertionError("urlopen must not be called")) as m:
             result = f._fetch_system_prompt("chat-a", "")
         self.assertEqual(result, "CACHED")
@@ -148,11 +166,11 @@ class SystemPromptFetchCache(unittest.TestCase):
 
     def test_ttl_expiry_triggers_refetch(self):
         f = _make_filter()
-        f._prompt_cache["chat-a"] = (time.time() - 301, "OLD")
+        f._prompt_cache[("chat-a", "")] = (time.time() - 301, "OLD")
         with patch("urllib.request.urlopen", return_value=_urlopen_mock("FRESH")):
             result = f._fetch_system_prompt("chat-a", "")
         self.assertEqual(result, "FRESH")
-        self.assertGreater(f._prompt_cache["chat-a"][0], time.time() - 5)
+        self.assertGreater(f._prompt_cache[("chat-a", "")][0], time.time() - 5)
 
     def test_lru_eviction_at_max_size(self):
         f = _make_filter()
@@ -160,12 +178,12 @@ class SystemPromptFetchCache(unittest.TestCase):
             for i in range(1, 102):  # 101 distinct chat ids
                 f._fetch_system_prompt(f"chat-{i}", "")
         self.assertEqual(len(f._prompt_cache), 100)
-        self.assertNotIn("chat-1", f._prompt_cache)
-        self.assertIn("chat-101", f._prompt_cache)
+        self.assertNotIn(("chat-1", ""), f._prompt_cache)
+        self.assertIn(("chat-101", ""), f._prompt_cache)
 
     def test_stale_cache_fallback_on_server_down(self):
         f = _make_filter()
-        f._prompt_cache["chat-a"] = (time.time() - 9999, "STALE")
+        f._prompt_cache[("chat-a", "")] = (time.time() - 9999, "STALE")
         with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("conn refused")):
             result = f._fetch_system_prompt("chat-a", "")
         self.assertEqual(result, "STALE")
@@ -174,10 +192,7 @@ class SystemPromptFetchCache(unittest.TestCase):
         f = _make_filter()
         with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("conn refused")):
             result = f._fetch_system_prompt("chat-x", "")
-        self.assertTrue(
-            result is None or result == "",
-            f"Expected None/empty on cold-cache failure, got {result!r}",
-        )
+        self.assertIsNone(result, f"Expected None on cold-cache failure, got {result!r}")
 
     def test_user_email_propagated_to_query_string(self):
         f = _make_filter()
@@ -191,6 +206,24 @@ class SystemPromptFetchCache(unittest.TestCase):
             f._fetch_system_prompt("chat-a", "user@example.com")
         self.assertIn("chat_id=chat-a", captured["url"])
         self.assertIn("user_email=user%40example.com", captured["url"])
+
+    def test_cache_isolates_different_users_on_same_chat(self):
+        """Two users sharing a chat_id must NOT see each other's baked <available_skills>."""
+        f = _make_filter()
+        prompts = iter(["PROMPT_FOR_ALICE", "PROMPT_FOR_BOB"])
+
+        def _serve_next(req, timeout=0):
+            return _urlopen_mock(next(prompts))
+
+        with patch("urllib.request.urlopen", side_effect=_serve_next):
+            a = f._fetch_system_prompt("chat-shared", "alice@example.com")
+            b = f._fetch_system_prompt("chat-shared", "bob@example.com")
+        self.assertEqual(a, "PROMPT_FOR_ALICE")
+        self.assertEqual(b, "PROMPT_FOR_BOB")
+        self.assertIn(("chat-shared", "alice@example.com"), f._prompt_cache)
+        self.assertIn(("chat-shared", "bob@example.com"), f._prompt_cache)
+        # No cross-contamination: Alice's cached entry still holds Alice's prompt
+        self.assertEqual(f._prompt_cache[("chat-shared", "alice@example.com")][1], "PROMPT_FOR_ALICE")
 
 
 if __name__ == "__main__":

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -144,6 +144,23 @@ class BaselineBehaviour(unittest.TestCase):
         self.assertEqual(out["messages"][1]["content"], original_system)
         self.assertNotIn("archive", out["messages"][2]["content"].lower())
 
+    def test_outlet_ignores_file_urls_for_other_chat_ids(self):
+        """Archive button must NOT be appended when the only file URL belongs to a
+        different chat_id (e.g. a multi-user workspace or a quoted prior transcript).
+        Regression guard for W-01: outlet previously matched any chat_id via `[^/]+`.
+        """
+        f = _make_filter()
+        other_link = "http://localhost:8081/files/other-chat/report.pdf"
+        original_content = f"see artefact from the other chat: {other_link}"
+        body = {"messages": [{"role": "assistant", "content": original_content}]}
+        out = f.outlet(body, __metadata__={"chat_id": "abc"})
+        self.assertEqual(
+            out["messages"][0]["content"],
+            original_content,
+            "Message referencing a file URL for a different chat_id must be left untouched",
+        )
+        self.assertNotIn("archive", out["messages"][0]["content"].lower())
+
 
 class SystemPromptFetchCache(unittest.TestCase):
     """New in v3.1.0: HTTP-fetch + LRU cache + stale-cache fallback."""

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -224,6 +224,37 @@ class SystemPromptFetchCache(unittest.TestCase):
         self.assertIn("chat_id=chat-a", captured["url"])
         self.assertIn("user_email=user%40example.com", captured["url"])
 
+    def test_rejects_non_http_scheme_without_urlopen(self):
+        """Valves misconfiguration (file://, ftp://, etc.) must not reach urlopen.
+        Regression guard for ruff S310: SYSTEM_PROMPT_URL=file:///etc/passwd used
+        to read the file as the injected system prompt.
+        """
+        f = _make_filter()
+        f.valves.SYSTEM_PROMPT_URL = "file:///etc/passwd"
+        with patch("urllib.request.urlopen", side_effect=AssertionError("must not be called")) as m:
+            result = f._fetch_system_prompt("chat-a", "")
+        self.assertIsNone(result)
+        m.assert_not_called()
+
+    def test_rejects_non_http_scheme_serves_stale_cache_when_available(self):
+        """If the scheme is invalid but a cached value exists, serve it (same
+        policy as transport failure)."""
+        f = _make_filter()
+        f.valves.SYSTEM_PROMPT_URL = "ftp://example.com/prompt"
+        f._prompt_cache[("chat-a", "")] = (time.time() - 9999, "STALE")
+        with patch("urllib.request.urlopen", side_effect=AssertionError("must not be called")):
+            result = f._fetch_system_prompt("chat-a", "")
+        self.assertEqual(result, "STALE")
+
+    def test_narrow_exception_propagates_programming_errors(self):
+        """A broad `except Exception` used to swallow programming bugs (e.g.
+        AttributeError from internal misuse) as silent stale-cache fallbacks.
+        The narrowed handler must re-raise non-transport failures."""
+        f = _make_filter()
+        with patch("urllib.request.urlopen", side_effect=AttributeError("boom")):
+            with self.assertRaises(AttributeError):
+                f._fetch_system_prompt("chat-a", "")
+
     def test_cache_isolates_different_users_on_same_chat(self):
         """Two users sharing a chat_id must NOT see each other's baked <available_skills>."""
         f = _make_filter()

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -114,6 +114,26 @@ class BaselineBehaviour(unittest.TestCase):
         )
         self.assertEqual("", _system_content(body))
 
+    def test_inlet_handles_non_string_system_content(self):
+        """Open WebUI multimodal flows can deliver system `content` as a list of
+        parts instead of a string. inlet() must not crash on re.search and must
+        still inject the Computer Use prompt. Regression for CodeRabbit finding
+        on 2026-04-12 (filter.py:220)."""
+        f = _make_filter()
+        structured_content = [{"type": "text", "text": "hello"}]
+        body = {
+            "tool_ids": ["ai_computer_use"],
+            "messages": [
+                {"role": "system", "content": structured_content},
+                {"role": "user", "content": "hi"},
+            ],
+        }
+        result = f.inlet(body, __metadata__={"chat_id": "abc"})
+        # Did not raise; injection still happened somewhere in the system slot
+        system_content = result["messages"][0]["content"]
+        self.assertIsInstance(system_content, str)
+        self.assertIn("http://localhost:8081/files/abc", system_content)
+
     def test_outlet_appends_archive_button_once(self):
         f = _make_filter()
         link = "http://localhost:8081/files/abc/report.pdf"

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -6,13 +6,25 @@ Run: python -m pytest tests/test_filter.py -v
 """
 
 import sys
+import time
 import unittest
+import urllib.error
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "openwebui" / "functions"))
 
 import computer_link_filter  # noqa: E402
+
+
+def _urlopen_mock(text: str = "PROMPT") -> MagicMock:
+    """Create a mock satisfying: with urlopen(req, timeout=N) as resp: resp.read()."""
+    cm = MagicMock()
+    cm.__enter__ = MagicMock(return_value=cm)
+    cm.__exit__ = MagicMock(return_value=False)
+    cm.read.return_value = text.encode("utf-8")
+    return cm
 
 
 def _make_filter(file_server_url: str = "http://localhost:8081") -> "computer_link_filter.Filter":
@@ -37,6 +49,16 @@ def _system_content(body: dict) -> str:
 
 class TrailingSlashNormalisation(unittest.TestCase):
     """FILE_SERVER_URL may arrive with a trailing slash; URLs must never end up with `//files/`."""
+
+    def setUp(self):
+        # After filter rewrite (Task 3), inlet() fetches the prompt over HTTP —
+        # mock the response so it contains the expected URL verbatim.
+        self._urlopen_patcher = patch(
+            "urllib.request.urlopen",
+            return_value=_urlopen_mock("System prompt with http://localhost:8081/files/abc baked"),
+        )
+        self._urlopen_patcher.start()
+        self.addCleanup(self._urlopen_patcher.stop)
 
     def test_inlet_does_not_emit_double_slash(self):
         f = _make_filter("http://localhost:8081/")
@@ -71,6 +93,14 @@ class EmptyChatIdHandling(unittest.TestCase):
 class BaselineBehaviour(unittest.TestCase):
     """Regression guards: normal happy path must keep working."""
 
+    def setUp(self):
+        self._urlopen_patcher = patch(
+            "urllib.request.urlopen",
+            return_value=_urlopen_mock("System prompt with http://localhost:8081/files/abc baked"),
+        )
+        self._urlopen_patcher.start()
+        self.addCleanup(self._urlopen_patcher.stop)
+
     def test_inlet_injects_when_tool_active_and_chat_id_present(self):
         f = _make_filter()
         body = f.inlet(_active_body(), __metadata__={"chat_id": "abc"})
@@ -95,6 +125,72 @@ class BaselineBehaviour(unittest.TestCase):
             out2["messages"][0]["content"],
             "Archive button must be idempotent (not duplicated on repeat outlet calls)",
         )
+
+
+class SystemPromptFetchCache(unittest.TestCase):
+    """New in v3.1.0: HTTP-fetch + LRU cache + stale-cache fallback."""
+
+    def test_fresh_fetch_populates_cache(self):
+        f = _make_filter()
+        with patch("urllib.request.urlopen", return_value=_urlopen_mock("PROMPT_V1")):
+            result = f._fetch_system_prompt("chat-a", "")
+        self.assertEqual(result, "PROMPT_V1")
+        self.assertIn("chat-a", f._prompt_cache)
+        self.assertEqual(f._prompt_cache["chat-a"][1], "PROMPT_V1")
+
+    def test_cache_hit_within_ttl_skips_http(self):
+        f = _make_filter()
+        f._prompt_cache["chat-a"] = (time.time(), "CACHED")
+        with patch("urllib.request.urlopen", side_effect=AssertionError("urlopen must not be called")) as m:
+            result = f._fetch_system_prompt("chat-a", "")
+        self.assertEqual(result, "CACHED")
+        m.assert_not_called()
+
+    def test_ttl_expiry_triggers_refetch(self):
+        f = _make_filter()
+        f._prompt_cache["chat-a"] = (time.time() - 301, "OLD")
+        with patch("urllib.request.urlopen", return_value=_urlopen_mock("FRESH")):
+            result = f._fetch_system_prompt("chat-a", "")
+        self.assertEqual(result, "FRESH")
+        self.assertGreater(f._prompt_cache["chat-a"][0], time.time() - 5)
+
+    def test_lru_eviction_at_max_size(self):
+        f = _make_filter()
+        with patch("urllib.request.urlopen", side_effect=lambda *a, **kw: _urlopen_mock("P")):
+            for i in range(1, 102):  # 101 distinct chat ids
+                f._fetch_system_prompt(f"chat-{i}", "")
+        self.assertEqual(len(f._prompt_cache), 100)
+        self.assertNotIn("chat-1", f._prompt_cache)
+        self.assertIn("chat-101", f._prompt_cache)
+
+    def test_stale_cache_fallback_on_server_down(self):
+        f = _make_filter()
+        f._prompt_cache["chat-a"] = (time.time() - 9999, "STALE")
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("conn refused")):
+            result = f._fetch_system_prompt("chat-a", "")
+        self.assertEqual(result, "STALE")
+
+    def test_cold_cache_returns_none_when_server_down(self):
+        f = _make_filter()
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("conn refused")):
+            result = f._fetch_system_prompt("chat-x", "")
+        self.assertTrue(
+            result is None or result == "",
+            f"Expected None/empty on cold-cache failure, got {result!r}",
+        )
+
+    def test_user_email_propagated_to_query_string(self):
+        f = _make_filter()
+        captured = {}
+
+        def _capture(req, timeout=0):
+            captured["url"] = req.full_url
+            return _urlopen_mock("P")
+
+        with patch("urllib.request.urlopen", side_effect=_capture):
+            f._fetch_system_prompt("chat-a", "user@example.com")
+        self.assertIn("chat_id=chat-a", captured["url"])
+        self.assertIn("user_email=user%40example.com", captured["url"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **Extract** the ~460-line hardcoded Computer Use system prompt out of `computer_link_filter.py` — filter becomes a thin HTTP client fetching from `GET /system-prompt`.
- **Server does the substitution**: `chat_id` → `{file_base_url}`/`{archive_url}`/`{chat_id}` placeholders; optional `user_email` → dynamic `<available_skills>` block (graceful fallback to `DEFAULT_PUBLIC_SKILLS` when no external provider wired).
- **Filter caches** per-`chat_id` in an `OrderedDict` LRU (TTL 5 min, 100 entries, O(1) eviction) with stale-cache fallback on fetch failure.
- Includes two standalone bug fixes landed earlier: sub-agent scope restriction (code-only, `max_turns=25`) and filter robustness (trailing-slash normalization, skip-injection on empty `chat_id`).

## Metrics

| Metric | Before | After |
|---|---|---|
| `computer_link_filter.py` lines | 636 | **235** (−63%) |
| Filter version | 3.0.2 | **3.1.0** |
| Project version | v0.8.12.6 | **v0.8.12.7** |
| Tests (total) | ~114 | **126** (+12 new: 5 endpoint + 7 cache) |
| Server endpoint changes | — | **0** (already correctly ported) |

## Architecture

```
Open WebUI → filter (inlet)
           → GET /system-prompt?chat_id=X&user_email=Y
           → (cache hit within 5m? return cached)
           → orchestrator substitutes URLs + skills
           → text/plain fully-baked prompt
           → filter injects as-is (no client-side substitution)
```

On fetch failure: stale cache served if present, otherwise injection skipped (no broken URLs ever reach the model).

## Test plan

- [x] `pytest tests/` — 126 passed, 0 failed
- [x] 5 new endpoint tests (`tests/orchestrator/test_system_prompt_endpoint.py`): `chat_id` substitution, `user_email` default-skills fallback, legacy `file_base_url`/`archive_url`, no-param degraded path, `text/plain` content-type
- [x] 7 new filter cache tests (`SystemPromptFetchCache`): fresh fetch, TTL hit, TTL expiry, LRU eviction at 100, stale-cache fallback, cold-cache skip, `user_email` query propagation
- [x] 7 pre-existing filter tests still pass (2 injection-path tests now use `urlopen` mock via `setUp`)
- [x] Filter ≤ 250-line cap (235 actual)
- [x] D-11 strip verified: 0 Russian strings, 0 preview-SPA code, 0 browser-keyword heuristic
- [ ] Manual smoke: `curl "http://localhost:8081/system-prompt?chat_id=abc"` returns baked prompt with `http://localhost:8081/files/abc` substituted
- [ ] Manual smoke: Open WebUI filter receives prompt from fresh server, cached responses on second call within TTL

## Commits

18 atomic commits grouped:
- `7aec7b1` sub-agent fix (separate)
- `94254a3` filter bug fixes (separate, preserved across rewrite)
- `3f59a1d..9d400bf` GSD project init (planning/ infrastructure)
- `30384d3` scope correction: restore killer feature after prior misstep
- `d92f001..840a9b4` phase 01 context + research
- `9dd5cb1` phase 01 plan
- `add1fff..281f75b` TDD: pin endpoint → RED filter tests → GREEN rewrite
- `17e5c18` CHANGELOG v0.8.12.7 + `.env.example` MCP_TOKENS_URL docs
- `1dd17ad..72abe6b` SUMMARY + VERIFICATION artifacts

## Port source

Internal fork `computer-use-orchestrator/app.py:1161-1212` endpoint + `openwebui-functions/computer_link_filter.py` v3.8.0 (308 lines), stripped of preview SPA, browser-keyword detection, Russian strings, and corporate references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * System prompt now served by orchestrator's `/system-prompt` endpoint with dynamic skill injection based on user email.
  * Added optional external skill provider configuration via `MCP_TOKENS_URL` and `MCP_TOKENS_API_KEY` environment variables.

* **Documentation**
  * Clarified sub-agent tool constraints: restricted to complex code tasks requiring 10+ iterative tool calls.

* **Chores**
  * Reduced default sub-agent maximum turns from 50 to 25.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->