### PR TITLE
feat(filter): expose /preview/{chat_id} via new Valves (v3.2.0)

### DIFF
--- a/docs/openwebui-filter.md
+++ b/docs/openwebui-filter.md
@@ -1,0 +1,76 @@
+# Open WebUI Computer Use Filter
+
+## Purpose
+
+The Computer Use Filter (`openwebui/functions/computer_link_filter.py`) is the only integration point between Open WebUI and the Computer Use Server. Its `inlet()` fetches the server-baked system prompt over HTTP and injects it into the conversation when the `ai_computer_use` tool is active. Its `outlet()` decorates assistant messages that contain sandbox file URLs with a preview iframe artifact, an opt-in preview link, and an archive-download link — giving stock Open WebUI deployments full access to the sandbox preview SPA without any frontend patches.
+
+The filter is the single source of truth for the client-side URL shape; the server owns prompt content and preview rendering. Read the file itself for the authoritative Valve defaults and behaviour.
+
+## Installation
+
+- Open WebUI → **Admin Panel** → **Functions** → **New Function**.
+- Paste the entire contents of `openwebui/functions/computer_link_filter.py` into the editor.
+- Save, then toggle the function on for the target model(s).
+- Optionally override any Valve from the function's settings panel. Defaults are chosen so a fresh deployment works end-to-end as soon as the Computer Use Server is reachable at `http://localhost:8081`.
+- Upstream reference: [Open WebUI Functions documentation](https://docs.openwebui.com/features/plugin/functions/).
+
+## Valves reference
+
+| Name | Type | Default | Purpose |
+|------|------|---------|---------|
+| `FILE_SERVER_URL` | str | `"http://localhost:8081"` | Orchestrator base URL. Derives `/system-prompt`, `/files/{chat_id}/…`, `/files/{chat_id}/archive`, and `/preview/{chat_id}`. Trailing slash is tolerated (stripped internally). |
+| `SYSTEM_PROMPT_URL` | str | `""` | Override URL for the `/system-prompt` endpoint. Empty means derive from `FILE_SERVER_URL`. Non-http(s) schemes are rejected. |
+| `INJECT_SYSTEM_PROMPT` | bool | `True` | If `False`, `inlet()` skips system-prompt injection entirely — useful when another filter owns the prompt. |
+| `ENABLE_ARCHIVE_BUTTON` | bool | `True` | If `True`, `outlet()` appends `[{ARCHIVE_BUTTON_TEXT}]({base}/files/{chat_id}/archive)` to assistant messages containing file URLs for the current chat. Idempotent. |
+| `ARCHIVE_BUTTON_TEXT` | str | `"📦 Download all files as archive"` | Label for the archive-download markdown link. |
+| `ENABLE_PREVIEW_ARTIFACT` | bool | `True` | If `True`, `outlet()` appends a fenced ```html block with an `<iframe src="{base}/preview/{chat_id}" …>` snippet. Default UX for deployments that render fenced html blocks as interactive artifacts. |
+| `ENABLE_PREVIEW_BUTTON` | bool | `False` | If `True`, `outlet()` appends `[{PREVIEW_BUTTON_TEXT}]({base}/preview/{chat_id})`. Opt-in fallback for stock Open WebUI where artifact rendering is unavailable. |
+| `PREVIEW_BUTTON_TEXT` | str | `"🖥️ Open preview"` | Label for the opt-in preview-button markdown link. |
+
+## Preview UX: artifact vs button — which one fits you?
+
+The filter ships two preview modes. They are independent and can be enabled together.
+
+- **Artifact mode** (default, `ENABLE_PREVIEW_ARTIFACT=True`). Every assistant message containing a sandbox file URL is decorated with a fenced ```html block wrapping an `<iframe>` whose `src` points at `/preview/{chat_id}`. Deployments that render fenced html as artifacts show the Computer Use preview SPA inline, no click required. This is the project's opinionated UX.
+- **Button mode** (`ENABLE_PREVIEW_BUTTON=True`). The same trigger appends a markdown link `[🖥️ Open preview](…)` that opens the preview SPA in a new tab. One click, but works on stock Open WebUI without any artifact-rendering support.
+- **Both on**. Safe — both are idempotent substring-guarded. Useful while comparing rendering behaviour across deployments or during migrations.
+
+Rule of thumb:
+
+- Operators who know their UI renders html artifacts → keep defaults (artifact only).
+- Stock Open WebUI deployments → set `ENABLE_PREVIEW_ARTIFACT=False` and `ENABLE_PREVIEW_BUTTON=True` for the click-through experience.
+- During evaluation → leave both on and compare.
+
+## Archive button
+
+`ENABLE_ARCHIVE_BUTTON` (default `True`) preserves the v3.0.x behaviour: when an assistant message contains at least one file URL under `{FILE_SERVER_URL}/files/{chat_id}/…`, `outlet()` appends a markdown link to the archive endpoint `/files/{chat_id}/archive`. The endpoint streams a zip of every file the sandbox has written for the chat. The append is idempotent (substring check against the fully-rendered URL) — safe to re-run `outlet()` on the same body as many times as the framework chooses.
+
+## System prompt injection
+
+`INJECT_SYSTEM_PROMPT` (default `True`) and `SYSTEM_PROMPT_URL` (default empty) control the `inlet()` path. When the `ai_computer_use` tool is active and `chat_id` is present, the filter HTTP-fetches the baked prompt from the server and injects it into the system message, with a 5-minute LRU cache and a stale-cache fallback on transport failure. Non-http(s) schemes are rejected to avoid `file://` / `ftp://` information-disclosure paths. See `docs/system-prompt.md` for the server-side contract, including how `user_email` drives the `<available_skills>` block.
+
+## Troubleshooting
+
+### Preview shows "connection refused" or a blank frame
+
+- Check that `FILE_SERVER_URL` is reachable *from the user's browser* — Open WebUI may reach the server via `host.docker.internal` while the browser needs a routable hostname.
+- Confirm the Computer Use Server is running: `docker compose ps` should list the `computer-use-server` container as healthy.
+- Copy the `src=` value out of the iframe and `curl` it directly — the SPA HTML should come back with HTTP 200.
+
+### Button/iframe never appears
+
+- The assistant message must contain at least one URL matching `{FILE_SERVER_URL}/files/{chat_id}/…`. No file URL, no decoration.
+- `chat_id` must reach `outlet()` via `__metadata__`. Restart Open WebUI after toggling Valves if the model didn't re-init.
+- At least one of `ENABLE_PREVIEW_ARTIFACT`, `ENABLE_PREVIEW_BUTTON`, or `ENABLE_ARCHIVE_BUTTON` must be `True` — when all three are off, `outlet()` returns the body unchanged.
+
+### "Non-http scheme" error in logs
+
+Caused by setting `SYSTEM_PROMPT_URL` to a `file://`, `ftp://`, or similarly non-http(s) URL. The filter rejects it and serves the stale cache if available, otherwise skips injection. Fix by pointing the Valve at an `http://` or `https://` endpoint, or leave it empty so it derives from `FILE_SERVER_URL`.
+
+## Version history
+
+- **v3.2.0** — Added `ENABLE_PREVIEW_ARTIFACT` (default `True`), `ENABLE_PREVIEW_BUTTON` (default `False`), and `PREVIEW_BUTTON_TEXT` Valves. `outlet()` now emits an inline iframe artifact and/or a markdown preview link alongside the archive button. All v3.1.0 invariants preserved.
+- **v3.1.0** — Removed the hardcoded ~460-line system prompt f-string; server became the single source of truth. HTTP fetch + LRU cache + stale-cache fallback. `SYSTEM_PROMPT_URL` Valve added; non-http(s) schemes rejected.
+- **v3.0.2** — Last hardcoded-prompt revision. See git history for details.
+
+For deeper context, consult the CHANGELOG blocks in the module docstring of `openwebui/functions/computer_link_filter.py` and the per-commit history on `main`.

--- a/openwebui/functions/computer_link_filter.py
+++ b/openwebui/functions/computer_link_filter.py
@@ -305,30 +305,59 @@ class Filter:
         __user__: Optional[dict] = None,
         __metadata__: Optional[dict] = None,
     ) -> dict:
-        """Append an archive-download button to assistant messages with file links."""
+        """Append preview iframe artifact, preview button, and/or archive button to assistant messages with file links.
+
+        - ENABLE_PREVIEW_ARTIFACT (default True): inline ```html <iframe src="…/preview/{chat_id}"> artifact.
+        - ENABLE_PREVIEW_BUTTON (default False): markdown link to the preview page — opt-in for stock Open WebUI.
+        - ENABLE_ARCHIVE_BUTTON (default True): markdown link to the archive endpoint.
+
+        Invariants (preserved from v3.1.0):
+        1. Only role=="assistant" messages are touched.
+        2. Non-string content is skipped.
+        3. file_url_pattern is scoped to the current chat_id (no cross-chat decoration).
+        4. FILE_SERVER_URL is rstripped before URL construction (no //preview/ or //files/).
+        5. Substring-based idempotency — repeated outlet() calls do not duplicate.
+        """
+        if not (self.valves.ENABLE_ARCHIVE_BUTTON
+                or self.valves.ENABLE_PREVIEW_BUTTON
+                or self.valves.ENABLE_PREVIEW_ARTIFACT):
+            return body
+
         chat_id = __metadata__.get("chat_id") if __metadata__ else None
         if not chat_id:
             return body
 
-        if not self.valves.ENABLE_ARCHIVE_BUTTON:
-            return body
-
-        # Match orchestrator file links
         base = self.valves.FILE_SERVER_URL.rstrip("/")
         file_url_pattern = re.escape(base) + r"/files/" + re.escape(chat_id) + r"/[^\s\)]+"
+        preview_url = f"{base}/preview/{chat_id}"
         archive_url = f"{base}/files/{chat_id}/archive"
 
         for message in body.get("messages", []):
-            # Docstring contract: archive button is appended to *assistant* messages only.
-            # Rewriting user/system/tool content would corrupt upstream input.
             if message.get("role") != "assistant":
                 continue
             content = message.get("content")
             if not content or not isinstance(content, str):
                 continue
-            if re.search(file_url_pattern, content) and archive_url not in content:
-                message["content"] = (
-                    content + f"\n\n[{self.valves.ARCHIVE_BUTTON_TEXT}]({archive_url})"
+            if not re.search(file_url_pattern, content):
+                continue
+
+            links: list[str] = []
+            if self.valves.ENABLE_PREVIEW_BUTTON and preview_url not in content:
+                links.append(f"[{self.valves.PREVIEW_BUTTON_TEXT}]({preview_url})")
+            if self.valves.ENABLE_ARCHIVE_BUTTON and archive_url not in content:
+                links.append(f"[{self.valves.ARCHIVE_BUTTON_TEXT}]({archive_url})")
+            if links:
+                content += "\n\n" + "\n".join(links)
+
+            if self.valves.ENABLE_PREVIEW_ARTIFACT:
+                iframe = (
+                    f'<iframe src="{preview_url}" '
+                    f'style="width:100%;height:100%;border:none" '
+                    f'allow="clipboard-write; keyboard-map"></iframe>'
                 )
+                if iframe not in content:
+                    content += "\n\n```html\n" + iframe + "\n```"
+
+            message["content"] = content
 
         return body

--- a/openwebui/functions/computer_link_filter.py
+++ b/openwebui/functions/computer_link_filter.py
@@ -3,9 +3,9 @@
 """
 title: Computer Use Filter
 author: Open Computer Use Contributors
-version: 3.1.0
+version: 3.2.0
 required_open_webui_version: 0.5.17
-description: HTTP-fetches Computer Use system prompt from orchestrator /system-prompt endpoint, with LRU cache and stale-cache fallback.
+description: HTTP-fetches Computer Use system prompt from orchestrator, with LRU cache and stale-cache fallback. outlet() appends a preview iframe artifact (default) or a markdown preview button (opt-in) to assistant messages containing Computer Use file links.
 
 This filter works in conjunction with Computer Use Tools (computer_use_tools.py).
 
@@ -15,7 +15,26 @@ FUNCTIONALITY:
   substitutes {file_base_url}, {archive_url}, {chat_id} and assembles <available_skills>)
   and injects it into the system message. Cache: 5-minute TTL, max 100 entries,
   O(1) LRU eviction. On fetch failure: serve stale cache if present; else skip injection.
-- outlet(): Appends an archive-download button to assistant messages containing file links.
+- outlet(): Appends a preview iframe artifact (ENABLE_PREVIEW_ARTIFACT=True by default)
+  and/or a markdown preview button (ENABLE_PREVIEW_BUTTON=False by default) and/or an
+  archive-download button (ENABLE_ARCHIVE_BUTTON=True by default) to assistant messages
+  containing file URLs for the current chat_id. All three are idempotent (substring
+  guarded) and scoped to the current chat_id.
+
+CHANGELOG (v3.2.0):
+- Added ENABLE_PREVIEW_ARTIFACT Valve (default True) — outlet() now emits an inline
+  <iframe src="{base}/preview/{chat_id}"> wrapped in a fenced ```html block when the
+  assistant message contains a file URL for the current chat_id. Intended UX for
+  deployments that render HTML artifacts.
+- Added ENABLE_PREVIEW_BUTTON Valve (default False) — opt-in markdown link fallback
+  for stock Open WebUI installations that do not render artifact blocks.
+- Added PREVIEW_BUTTON_TEXT Valve (default "🖥️ Open preview") — button label for
+  the opt-in preview link.
+- outlet() correctness invariants preserved: role=="assistant" guard,
+  isinstance(content, str) guard, chat_id-scoped file_url_pattern,
+  FILE_SERVER_URL.rstrip("/") guard against //preview/, substring-based idempotency.
+- Archive button behaviour unchanged; preview and archive links share the
+  single-blank-line separator style.
 
 CHANGELOG (v3.1.0):
 - Removed hardcoded ~460-line system prompt f-string; server is now the single source of truth.
@@ -26,6 +45,35 @@ CHANGELOG (v3.1.0):
 
 CHANGELOG (v3.0.2):
 - Previous version with hardcoded prompt; see git history for details.
+
+    VALVES:
+        FILE_SERVER_URL (str, default "http://localhost:8081"):
+            Orchestrator base URL. The filter derives /system-prompt,
+            /files/{chat_id}/…, /files/{chat_id}/archive, and /preview/{chat_id}
+            from this. Trailing slash is tolerated (stripped internally).
+        SYSTEM_PROMPT_URL (str, default ""):
+            Override URL for the /system-prompt endpoint. Empty means derive from
+            FILE_SERVER_URL. Non-http(s) schemes are rejected.
+        INJECT_SYSTEM_PROMPT (bool, default True):
+            If False, inlet() skips system-prompt injection entirely (useful when
+            another filter owns the prompt).
+        ENABLE_ARCHIVE_BUTTON (bool, default True):
+            If True, outlet() appends `[{ARCHIVE_BUTTON_TEXT}]({base}/files/{chat_id}/archive)`
+            to assistant messages containing file URLs for the current chat_id. Idempotent.
+        ARCHIVE_BUTTON_TEXT (str, default "📦 Download all files as archive"):
+            Label for the archive-download markdown link.
+        ENABLE_PREVIEW_ARTIFACT (bool, default True):
+            If True, outlet() appends a fenced ```html block containing an
+            `<iframe src="{base}/preview/{chat_id}" style="width:100%;height:100%;border:none"
+            allow="clipboard-write; keyboard-map"></iframe>` snippet to assistant messages
+            containing file URLs for the current chat_id. Intended default UX for
+            deployments that render fenced html blocks as artifacts.
+        ENABLE_PREVIEW_BUTTON (bool, default False):
+            If True, outlet() appends `[{PREVIEW_BUTTON_TEXT}]({base}/preview/{chat_id})`
+            to the same qualifying messages. Opt-in escape hatch for stock Open WebUI
+            where artifact rendering is unavailable.
+        PREVIEW_BUTTON_TEXT (str, default "🖥️ Open preview"):
+            Label for the opt-in preview-button markdown link.
 """
 
 import re
@@ -84,6 +132,18 @@ class Filter:
         ARCHIVE_BUTTON_TEXT: str = Field(
             default="📦 Download all files as archive",
             description="Text for the archive-download button",
+        )
+        ENABLE_PREVIEW_ARTIFACT: bool = Field(
+            default=True,
+            description="Append an inline <iframe> artifact rendering /preview/{chat_id} to assistant messages with file links",
+        )
+        ENABLE_PREVIEW_BUTTON: bool = Field(
+            default=False,
+            description="Append a markdown [preview](…) link to assistant messages with file links (opt-in fallback when artifact rendering is unavailable)",
+        )
+        PREVIEW_BUTTON_TEXT: str = Field(
+            default="🖥️ Open preview",
+            description="Text for the preview-button markdown link",
         )
         INJECT_SYSTEM_PROMPT: bool = Field(
             default=True,

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -294,5 +294,129 @@ class SystemPromptFetchCache(unittest.TestCase):
         self.assertEqual(f._prompt_cache[("chat-shared", "alice@example.com")][1], "PROMPT_FOR_ALICE")
 
 
+class PreviewArtifact(unittest.TestCase):
+    """Covers PREVIEW-01 (default iframe artifact), PREVIEW-03 (invariants for iframe), PREVIEW-04 (iframe idempotency)."""
+
+    def _assistant_body_with_file(self, chat_id: str = "abc") -> dict:
+        link = f"http://localhost:8081/files/{chat_id}/report.pdf"
+        return {"messages": [{"role": "assistant", "content": f"see {link}"}]}
+
+    def test_outlet_appends_iframe_artifact_by_default(self):
+        f = _make_filter()
+        body = f.outlet(self._assistant_body_with_file(), __metadata__={"chat_id": "abc"})
+        content = body["messages"][0]["content"]
+        self.assertIn('<iframe src="http://localhost:8081/preview/abc"', content)
+        self.assertIn("```html", content)
+        self.assertIn('allow="clipboard-write; keyboard-map"', content)
+
+    def test_outlet_iframe_artifact_is_idempotent(self):
+        f = _make_filter()
+        body = self._assistant_body_with_file()
+        out1 = f.outlet(body, __metadata__={"chat_id": "abc"})
+        out2 = f.outlet(out1, __metadata__={"chat_id": "abc"})
+        self.assertEqual(out1["messages"][0]["content"], out2["messages"][0]["content"])
+        self.assertEqual(out2["messages"][0]["content"].count("<iframe src="), 1)
+
+    def test_outlet_iframe_artifact_disabled_when_valve_false(self):
+        f = _make_filter()
+        f.valves.ENABLE_PREVIEW_ARTIFACT = False
+        body = f.outlet(self._assistant_body_with_file(), __metadata__={"chat_id": "abc"})
+        content = body["messages"][0]["content"]
+        self.assertNotIn("<iframe", content)
+        self.assertNotIn("```html", content)
+
+    def test_outlet_iframe_artifact_respects_other_chat_ids(self):
+        f = _make_filter()
+        other_link = "http://localhost:8081/files/other-chat/report.pdf"
+        original = f"see artefact from another chat: {other_link}"
+        body = {"messages": [{"role": "assistant", "content": original}]}
+        out = f.outlet(body, __metadata__={"chat_id": "abc"})
+        self.assertEqual(out["messages"][0]["content"], original)
+
+    def test_outlet_iframe_not_added_to_non_assistant_roles(self):
+        f = _make_filter()
+        link = "http://localhost:8081/files/abc/report.pdf"
+        body = {
+            "messages": [
+                {"role": "user", "content": f"u {link}"},
+                {"role": "system", "content": f"s {link}"},
+                {"role": "tool", "content": f"t {link}"},
+            ]
+        }
+        out = f.outlet(body, __metadata__={"chat_id": "abc"})
+        for msg in out["messages"]:
+            self.assertNotIn("<iframe", msg["content"])
+            self.assertNotIn("```html", msg["content"])
+
+    def test_outlet_iframe_url_has_no_double_slash_when_trailing_slash(self):
+        f = _make_filter("http://localhost:8081/")
+        body = f.outlet(self._assistant_body_with_file(), __metadata__={"chat_id": "abc"})
+        content = body["messages"][0]["content"]
+        self.assertNotIn("//preview/", content)
+        self.assertIn('<iframe src="http://localhost:8081/preview/abc"', content)
+
+
+class PreviewButton(unittest.TestCase):
+    """Covers PREVIEW-02 (opt-in markdown button), PREVIEW-04 (button idempotency)."""
+
+    def _assistant_body_with_file(self, chat_id: str = "abc") -> dict:
+        link = f"http://localhost:8081/files/{chat_id}/report.pdf"
+        return {"messages": [{"role": "assistant", "content": f"see {link}"}]}
+
+    def test_outlet_preview_button_off_by_default(self):
+        f = _make_filter()
+        body = f.outlet(self._assistant_body_with_file(), __metadata__={"chat_id": "abc"})
+        self.assertNotIn("[🖥️ Open preview]", body["messages"][0]["content"])
+
+    def test_outlet_preview_button_appended_when_enabled(self):
+        f = _make_filter()
+        f.valves.ENABLE_PREVIEW_BUTTON = True
+        body = f.outlet(self._assistant_body_with_file(), __metadata__={"chat_id": "abc"})
+        self.assertIn(
+            "[🖥️ Open preview](http://localhost:8081/preview/abc)",
+            body["messages"][0]["content"],
+        )
+
+    def test_outlet_preview_button_is_idempotent(self):
+        f = _make_filter()
+        f.valves.ENABLE_PREVIEW_BUTTON = True
+        body = self._assistant_body_with_file()
+        out1 = f.outlet(body, __metadata__={"chat_id": "abc"})
+        out2 = f.outlet(out1, __metadata__={"chat_id": "abc"})
+        self.assertEqual(out1["messages"][0]["content"], out2["messages"][0]["content"])
+        self.assertEqual(
+            out2["messages"][0]["content"].count("[🖥️ Open preview]"),
+            1,
+        )
+
+    def test_outlet_preview_button_respects_other_chat_ids(self):
+        f = _make_filter()
+        f.valves.ENABLE_PREVIEW_BUTTON = True
+        other_link = "http://localhost:8081/files/other-chat/report.pdf"
+        original = f"see {other_link}"
+        body = {"messages": [{"role": "assistant", "content": original}]}
+        out = f.outlet(body, __metadata__={"chat_id": "abc"})
+        self.assertEqual(out["messages"][0]["content"], original)
+
+
+class DocstringDriftGuard(unittest.TestCase):
+    """Covers DOCS-03 — every Field on Filter.Valves is listed in the module VALVES: docstring."""
+
+    def test_every_valve_is_documented_in_docstring(self):
+        doc = computer_link_filter.__doc__ or ""
+        self.assertIn("VALVES:", doc, "Module docstring must contain a VALVES: block")
+        # Extract everything under VALVES: to the next blank-line-separated section
+        # (or end of docstring). Simple split is sufficient — drift guard only.
+        after_marker = doc.split("VALVES:", 1)[1]
+        for field_name in computer_link_filter.Filter.Valves.model_fields:
+            self.assertIn(
+                field_name,
+                after_marker,
+                f"Valve {field_name!r} is defined on Filter.Valves but missing "
+                f"from the VALVES: docstring block — update the docstring "
+                f"in computer_link_filter.py to list it.",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -47,6 +47,11 @@ def _system_content(body: dict) -> str:
     return ""
 
 
+def _assistant_body_with_file(chat_id: str = "abc") -> dict:
+    link = f"http://localhost:8081/files/{chat_id}/report.pdf"
+    return {"messages": [{"role": "assistant", "content": f"see {link}"}]}
+
+
 class TrailingSlashNormalisation(unittest.TestCase):
     """FILE_SERVER_URL may arrive with a trailing slash; URLs must never end up with `//files/`."""
 
@@ -297,13 +302,9 @@ class SystemPromptFetchCache(unittest.TestCase):
 class PreviewArtifact(unittest.TestCase):
     """Covers PREVIEW-01 (default iframe artifact), PREVIEW-03 (invariants for iframe), PREVIEW-04 (iframe idempotency)."""
 
-    def _assistant_body_with_file(self, chat_id: str = "abc") -> dict:
-        link = f"http://localhost:8081/files/{chat_id}/report.pdf"
-        return {"messages": [{"role": "assistant", "content": f"see {link}"}]}
-
     def test_outlet_appends_iframe_artifact_by_default(self):
         f = _make_filter()
-        body = f.outlet(self._assistant_body_with_file(), __metadata__={"chat_id": "abc"})
+        body = f.outlet(_assistant_body_with_file(), __metadata__={"chat_id": "abc"})
         content = body["messages"][0]["content"]
         self.assertIn('<iframe src="http://localhost:8081/preview/abc"', content)
         self.assertIn("```html", content)
@@ -311,7 +312,7 @@ class PreviewArtifact(unittest.TestCase):
 
     def test_outlet_iframe_artifact_is_idempotent(self):
         f = _make_filter()
-        body = self._assistant_body_with_file()
+        body = _assistant_body_with_file()
         out1 = f.outlet(body, __metadata__={"chat_id": "abc"})
         out2 = f.outlet(out1, __metadata__={"chat_id": "abc"})
         self.assertEqual(out1["messages"][0]["content"], out2["messages"][0]["content"])
@@ -320,7 +321,7 @@ class PreviewArtifact(unittest.TestCase):
     def test_outlet_iframe_artifact_disabled_when_valve_false(self):
         f = _make_filter()
         f.valves.ENABLE_PREVIEW_ARTIFACT = False
-        body = f.outlet(self._assistant_body_with_file(), __metadata__={"chat_id": "abc"})
+        body = f.outlet(_assistant_body_with_file(), __metadata__={"chat_id": "abc"})
         content = body["messages"][0]["content"]
         self.assertNotIn("<iframe", content)
         self.assertNotIn("```html", content)
@@ -350,7 +351,7 @@ class PreviewArtifact(unittest.TestCase):
 
     def test_outlet_iframe_url_has_no_double_slash_when_trailing_slash(self):
         f = _make_filter("http://localhost:8081/")
-        body = f.outlet(self._assistant_body_with_file(), __metadata__={"chat_id": "abc"})
+        body = f.outlet(_assistant_body_with_file(), __metadata__={"chat_id": "abc"})
         content = body["messages"][0]["content"]
         self.assertNotIn("//preview/", content)
         self.assertIn('<iframe src="http://localhost:8081/preview/abc"', content)
@@ -359,19 +360,15 @@ class PreviewArtifact(unittest.TestCase):
 class PreviewButton(unittest.TestCase):
     """Covers PREVIEW-02 (opt-in markdown button), PREVIEW-04 (button idempotency)."""
 
-    def _assistant_body_with_file(self, chat_id: str = "abc") -> dict:
-        link = f"http://localhost:8081/files/{chat_id}/report.pdf"
-        return {"messages": [{"role": "assistant", "content": f"see {link}"}]}
-
     def test_outlet_preview_button_off_by_default(self):
         f = _make_filter()
-        body = f.outlet(self._assistant_body_with_file(), __metadata__={"chat_id": "abc"})
+        body = f.outlet(_assistant_body_with_file(), __metadata__={"chat_id": "abc"})
         self.assertNotIn("[🖥️ Open preview]", body["messages"][0]["content"])
 
     def test_outlet_preview_button_appended_when_enabled(self):
         f = _make_filter()
         f.valves.ENABLE_PREVIEW_BUTTON = True
-        body = f.outlet(self._assistant_body_with_file(), __metadata__={"chat_id": "abc"})
+        body = f.outlet(_assistant_body_with_file(), __metadata__={"chat_id": "abc"})
         self.assertIn(
             "[🖥️ Open preview](http://localhost:8081/preview/abc)",
             body["messages"][0]["content"],
@@ -380,7 +377,7 @@ class PreviewButton(unittest.TestCase):
     def test_outlet_preview_button_is_idempotent(self):
         f = _make_filter()
         f.valves.ENABLE_PREVIEW_BUTTON = True
-        body = self._assistant_body_with_file()
+        body = _assistant_body_with_file()
         out1 = f.outlet(body, __metadata__={"chat_id": "abc"})
         out2 = f.outlet(out1, __metadata__={"chat_id": "abc"})
         self.assertEqual(out1["messages"][0]["content"], out2["messages"][0]["content"])


### PR DESCRIPTION
## Summary

Expose the orchestrator's existing file-preview SPA (`GET /preview/{chat_id}`) to users of stock Open WebUI (without frontend patches) by teaching the filter's `outlet()` to emit an inline iframe artifact by default and, opt-in, a markdown preview button. Every v3.1.0 correctness invariant in the filter stays intact; every Valve (old and new) is documented in one authoritative place.

**Credit:** this PR is a re-implementation of the idea from @rahxam's #42, rebased onto v3.1.0. The original PR couldn't be merged cleanly — it targets v3.0.2 and would revert the hardening that landed in #44 (`role=="assistant"` guard, `isinstance(content, str)` guard, `chat_id`-scoped `file_url_pattern`, `rstrip("/")` base normalisation).

Closes the UX gap raised by #42 while keeping all of those guards.

## Changes

- **Filter `v3.1.0` → `v3.2.0`** — three new Valves:
  - `ENABLE_PREVIEW_ARTIFACT: bool = True` (**new default**) — inline `<iframe>` preview artifact in assistant messages with files.
  - `ENABLE_PREVIEW_BUTTON: bool = False` (opt-in) — markdown link for stock Open WebUI where artifact rendering is unavailable.
  - `PREVIEW_BUTTON_TEXT: str = "🖥️ Open preview"` — customisable label.
- **Preserved invariants** — `role == "assistant"`, `isinstance(content, str)`, `re.escape(chat_id)` scoping, `FILE_SERVER_URL.rstrip("/")`, substring idempotency.
- **New authoritative Valve reference** — `VALVES:` block in module docstring + `docs/openwebui-filter.md` (decision guide + troubleshooting) + a drift test asserting every `Field(...)` is documented.
- **No server changes** — `/preview/{chat_id}` already exists in `computer-use-server/app.py:1102`.

## Files

| File | Change |
|---|---|
| `openwebui/functions/computer_link_filter.py` | +102 / -13 (Valves, `outlet()` extension, `VALVES:` docstring, `CHANGELOG (v3.2.0)`, version bump) |
| `tests/test_filter.py` | +124 (11 new tests: 6 `PreviewArtifact`, 4 `PreviewButton`, 1 docstring drift guard) |
| `docs/openwebui-filter.md` | +76 (new) |

## Test plan

- [x] `pytest tests/test_filter.py -v` in `python:3.13-slim` — **32 passed** (21 pre-existing + 11 new)
- [x] `pytest tests/orchestrator tests/security tests/patches -v` in `python:3.13-slim` — **105 passed**, 1 pre-existing warning (unrelated)
- [x] v3.1.0 regression suites (`BaselineBehaviour`, `TrailingSlashNormalisation`, `EmptyChatIdHandling`, `SystemPromptFetchCache`) unchanged, all green
- [ ] `docker build --platform linux/amd64` + `./tests/test-docker-image.sh` + `./tests/test-no-corporate.sh` + `./tests/test-project-structure.sh` — **deferred to CI** (local build stalled under QEMU on arm64 with pip `ReadTimeoutError` from PyPI; no Dockerfile/requirements/npm/skills changes in this PR, so this gate is infrastructure-orthogonal and handled by GitHub Actions on native amd64)

## Default behaviour

On stock Open WebUI with no config changes: every assistant message with a file URL now gets an inline iframe preview artifact. Operators who prefer a click-through link flip `ENABLE_PREVIEW_BUTTON=True` and optionally `ENABLE_PREVIEW_ARTIFACT=False`. See `docs/openwebui-filter.md` for the decision guide.

## Supersedes

#42 (will be closed with credit after this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable preview options for assistant messages: default iframe preview artifact (on), optional preview button (off), and customizable button text; archive download link remains available.

* **Documentation**
  * Added a comprehensive guide covering installation, configuration valves, preview UX modes, troubleshooting, and version history.

* **Tests**
  * Added tests for preview artifact/button injection, idempotency, role/chat scoping, and docstring/config drift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->