### PR TITLE
chore(deps): sync playwright pin to 1.57.0

### DIFF
--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -40,10 +40,10 @@ The Dockerfile uses a multi-stage build approach for optimal layer caching:
 
 **Key Packages** (107 total):
 - Document: python-docx 1.2.0, python-pptx 1.0.2, openpyxl 3.1.5
-- PDF: pypdf 5.9.0, pdfplumber 0.11.7, reportlab 4.4.4
+- PDF: pypdf 5.9.0, pdfplumber 0.11.7, reportlab 4.4.10
 - Image: Pillow 11.3.0, opencv-python 4.11.0
 - Data: pandas 2.3.3, numpy 2.3.3
-- Web: playwright 1.55.0, requests 2.32.5
+- Web: playwright 1.57.0, requests 2.32.5
 
 ### Node.js Environment
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "marked": "^16.4.0",
     "pdf-lib": "^1.17.1",
     "pdfjs-dist": "^5.4.296",
-    "playwright": "1.59.1",
+    "playwright": "1.57.0",
     "pptxgenjs": "^4.0.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",


### PR DESCRIPTION
## Summary
- Revert npm `playwright` 1.59.1 → 1.57.0 so it matches `requirements.txt` (`playwright==1.57.0`). Dependabot #37 bumped npm ahead of PyPI — 1.59.1 isn't on PyPI yet (max available is 1.58.0), and the two halves share `/opt/pw-browsers` in the sandbox, so mismatched versions break the browser wire protocol.
- Refresh stale version labels in `docs/DOCKER.md`: reportlab 4.4.4 → 4.4.10 (matches #35), playwright 1.55.0 → 1.57.0.

When PyPI publishes 1.59.x, Dependabot will propose a coordinated bump in both `package.json` and `requirements.txt`.

## Test plan
- [x] `docker build --platform linux/amd64 -t open-computer-use:latest .` succeeds
- [x] Inside image: `pip show playwright` → 1.57.0, `npm ls playwright` → 1.57.0
- [x] Chromium smoke test: `playwright.chromium.launch()` + goto example.com + read title → "Example Domain"
- [ ] CI: Build Sandbox Image, Test, CodeQL all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated reportlab to version 4.4.10
  * Updated playwright to version 1.57.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->