### PR TITLE
ci: smoke-test sandbox image and Chromium in build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,8 +66,14 @@ jobs:
       - name: Pick image tag for smoke tests
         id: img
         run: |
-          # docker/metadata-action emits newline-separated tags; grab the first one.
-          tag=$(echo "${{ steps.meta.outputs.tags }}" | head -n1)
+          # docker/metadata-action emits newline-separated tags; grab the first
+          # non-blank line. Fail loudly if nothing came through so downstream
+          # `docker run` doesn't hit an empty image name with a cryptic error.
+          tag=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | sed '/^[[:space:]]*$/d' | head -n1)
+          if [ -z "$tag" ]; then
+            echo "No image tag produced by docker/metadata-action" >&2
+            exit 1
+          fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Smoke test — image packages and CLI tools
@@ -77,6 +83,9 @@ jobs:
 
       - name: Smoke test — Chromium launches in container
         run: |
+          # Use page.set_content with a local HTML string instead of going
+          # over the network: this test should only validate that chromium
+          # binary + wire protocol work, not internet reachability.
           docker run --rm --platform linux/amd64 \
             --entrypoint=python3 "${{ steps.img.outputs.tag }}" \
             -c "
@@ -84,10 +93,10 @@ jobs:
           with sync_playwright() as p:
               browser = p.chromium.launch(headless=True)
               page = browser.new_page()
-              page.goto('https://example.com', timeout=30000)
+              page.set_content('<html><head><title>Example Domain</title></head><body></body></html>')
               title = page.title()
               browser.close()
-              assert 'Example Domain' in title, f'unexpected title: {title}'
+              assert title == 'Example Domain', f'unexpected title: {title}'
               print(f'OK: title={title}')
           "
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,8 +77,9 @@ jobs:
 
       - name: Smoke test — Chromium launches in container
         run: |
-          docker run --rm --platform linux/amd64 "${{ steps.img.outputs.tag }}" \
-            python3 -c "
+          docker run --rm --platform linux/amd64 \
+            --entrypoint=python3 "${{ steps.img.outputs.tag }}" \
+            -c "
           from playwright.sync_api import sync_playwright
           with sync_playwright() as p:
               browser = p.chromium.launch(headless=True)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Free disk space for 8GB+ image + local load
+        run: |
+          # Sandbox image is ~8GB; `load: true` stores an extra copy in the
+          # docker daemon. Ubuntu runners start with ~14GB free; prune unused
+          # preinstalled toolchains to avoid running out during smoke tests.
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /opt/hostedtoolcache/CodeQL || true
+          df -h /
+
       - uses: docker/setup-buildx-action@v4
 
       - uses: docker/login-action@v3
@@ -43,14 +52,43 @@ jobs:
             type=sha
 
       - uses: docker/build-push-action@v7
+        id: build
         with:
           context: .
           platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Pick image tag for smoke tests
+        id: img
+        run: |
+          # docker/metadata-action emits newline-separated tags; grab the first one.
+          tag=$(echo "${{ steps.meta.outputs.tags }}" | head -n1)
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke test — image packages and CLI tools
+        run: |
+          chmod +x tests/test-docker-image.sh
+          ./tests/test-docker-image.sh "${{ steps.img.outputs.tag }}"
+
+      - name: Smoke test — Chromium launches in container
+        run: |
+          docker run --rm --platform linux/amd64 "${{ steps.img.outputs.tag }}" \
+            python3 -c "
+          from playwright.sync_api import sync_playwright
+          with sync_playwright() as p:
+              browser = p.chromium.launch(headless=True)
+              page = browser.new_page()
+              page.goto('https://example.com', timeout=30000)
+              title = page.title()
+              browser.close()
+              assert 'Example Domain' in title, f'unexpected title: {title}'
+              print(f'OK: title={title}')
+          "
 
   build-server:
     name: Build Server Image

--- a/tests/test-docker-image.sh
+++ b/tests/test-docker-image.sh
@@ -26,7 +26,10 @@ fail() {
 }
 
 run_in_container() {
-    docker run --rm --platform linux/amd64 "$IMAGE" bash -c "$1" 2>/dev/null
+    # --entrypoint=bash bypasses /home/assistant/.entrypoint.sh, which prints
+    # GITLAB_TOKEN / ANTHROPIC_AUTH_TOKEN status banners and corrupts captured
+    # stdout when those env vars are unset (CI default).
+    docker run --rm --platform linux/amd64 --entrypoint=bash "$IMAGE" -c "$1" 2>/dev/null
 }
 
 echo "=== Testing Docker image: $IMAGE ==="

--- a/tests/test-docker-image.sh
+++ b/tests/test-docker-image.sh
@@ -38,9 +38,15 @@ run_in_container() {
 echo "=== Testing Docker image: $IMAGE ==="
 echo ""
 
+# Note on `|| VAR=""` after every `VAR=$(run_in_container ...)`:
+# Without it, `set -euo pipefail` aborts the whole script the moment docker
+# returns non-zero — before fail() can record the failure or print summary.
+# Forcing the assignment to succeed (with empty content on docker error) lets
+# the existing grep-based pass/fail accounting handle the failure naturally.
+
 # 1. Node.js and Python versions
 echo "[1/11] Runtime versions"
-VERSIONS=$(run_in_container 'node --version && python3 --version')
+VERSIONS=$(run_in_container 'node --version && python3 --version') || VERSIONS=""
 echo "$VERSIONS" | grep -q "v22" && pass "Node.js v22" || fail "Node.js version"
 echo "$VERSIONS" | grep -q "Python 3" && pass "Python 3" || fail "Python version"
 
@@ -48,7 +54,7 @@ echo "$VERSIONS" | grep -q "Python 3" && pass "Python 3" || fail "Python version
 echo ""
 echo "[2/11] CommonJS require()"
 for pkg in react pptxgenjs pdf-lib docx sharp react-dom/server react-icons/fa; do
-    RESULT=$(run_in_container "node -e \"try { require('$pkg'); console.log('OK') } catch(e) { console.log('FAIL: ' + e.code) }\"")
+    RESULT=$(run_in_container "node -e \"try { require('$pkg'); console.log('OK') } catch(e) { console.log('FAIL: ' + e.code) }\"") || RESULT=""
     echo "$RESULT" | grep -q "OK" && pass "require('$pkg')" || fail "require('$pkg'): $RESULT"
 done
 
@@ -56,7 +62,7 @@ done
 echo ""
 echo "[3/11] ES Modules import"
 for pkg in react pptxgenjs pdf-lib; do
-    RESULT=$(run_in_container "node --input-type=module -e \"import '$pkg'; console.log('OK')\"")
+    RESULT=$(run_in_container "node --input-type=module -e \"import '$pkg'; console.log('OK')\"") || RESULT=""
     echo "$RESULT" | grep -q "OK" && pass "import '$pkg'" || fail "import '$pkg'"
 done
 
@@ -76,7 +82,7 @@ fi
 echo ""
 echo "[5/11] CLI tools"
 for tool in mmdc tsc tsx claude; do
-    RESULT=$(run_in_container "which $tool >/dev/null 2>&1 && echo OK || echo MISSING")
+    RESULT=$(run_in_container "which $tool >/dev/null 2>&1 && echo OK || echo MISSING") || RESULT=""
     echo "$RESULT" | grep -q "OK" && pass "$tool in PATH" || fail "$tool not found in PATH"
 done
 
@@ -84,16 +90,16 @@ done
 echo ""
 echo "[6/11] Python packages"
 for pkg in docx pptx openpyxl; do
-    RESULT=$(run_in_container "python3 -c \"import $pkg; print('OK')\"")
+    RESULT=$(run_in_container "python3 -c \"import $pkg; print('OK')\"") || RESULT=""
     echo "$RESULT" | grep -q "OK" && pass "python import $pkg" || fail "python import $pkg"
 done
-RESULT=$(run_in_container "python3 -c \"from playwright.sync_api import sync_playwright; print('OK')\"")
+RESULT=$(run_in_container "python3 -c \"from playwright.sync_api import sync_playwright; print('OK')\"") || RESULT=""
 echo "$RESULT" | grep -q "OK" && pass "python playwright" || fail "python playwright"
 
 # 7. User npm install (lodash)
 echo ""
 echo "[7/11] User npm install"
-RESULT=$(run_in_container 'cd /home/assistant && npm install lodash >/dev/null 2>&1 && if [ -d /home/assistant/node_modules/lodash ]; then echo "user=YES"; else echo "user=NO"; fi && SYS_COUNT=$(ls /home/node_modules/ 2>/dev/null | wc -l) && echo "system=$SYS_COUNT"')
+RESULT=$(run_in_container 'cd /home/assistant && npm install lodash >/dev/null 2>&1 && if [ -d /home/assistant/node_modules/lodash ]; then echo "user=YES"; else echo "user=NO"; fi && SYS_COUNT=$(ls /home/node_modules/ 2>/dev/null | wc -l) && echo "system=$SYS_COUNT"') || RESULT=""
 echo "$RESULT" | grep -q "user=YES" && pass "lodash in /home/assistant/node_modules" || fail "lodash not in user dir"
 SYS=$(echo "$RESULT" | awk -F= '/^system=/{print $2}')
 [ "${SYS:-0}" -gt 100 ] && pass "system packages intact ($SYS)" || fail "system packages count: $SYS (expected > 100)"
@@ -101,21 +107,29 @@ SYS=$(echo "$RESULT" | awk -F= '/^system=/{print $2}')
 # 8. npm prefix check
 echo ""
 echo "[8/11] npm configuration"
-RESULT=$(run_in_container 'npm config get prefix 2>/dev/null || echo "undefined"')
-# Acceptable: prefix deleted from user .npmrc (npm falls back to default
-# /usr/local), or explicitly pinned to the shared global path.
-# The original "undefined" branch is kept for legacy npm versions that
-# returned an empty string when prefix was unset.
-if echo "$RESULT" | grep -qE "(undefined|/usr/local|node_modules_global)"; then
-    pass "npm prefix configured correctly ($RESULT)"
+RESULT=$(run_in_container 'npm config get prefix 2>/dev/null || echo "undefined"') || RESULT=""
+# Trim trailing whitespace/newlines so the anchored regex below can match
+# against a clean single-line value.
+RESULT_TRIMMED=$(echo "$RESULT" | head -n1 | tr -d '[:space:]')
+# Acceptable, anchored values:
+#   - "undefined"                           — legacy npm with prefix unset
+#   - "/usr/local"                          — Dockerfile runs `npm config
+#                                             delete prefix` as last step, so
+#                                             npm falls back to its default
+#   - "/usr/local/lib/node_modules_global"  — explicit pin (older image layout)
+# The anchored regex rejects silently permissive substring matches like
+# "/usr/local/something/weird" or "node_modules_global" appearing in
+# arbitrary paths.
+if echo "$RESULT_TRIMMED" | grep -qE "^(undefined|/usr/local|/usr/local/lib/node_modules_global)$"; then
+    pass "npm prefix configured correctly ($RESULT_TRIMMED)"
 else
-    fail "npm prefix: $RESULT"
+    fail "npm prefix: $RESULT_TRIMMED"
 fi
 
 # 9. Volume size
 echo ""
 echo "[9/11] Volume size"
-SIZE_KB=$(run_in_container "du -sk /home/assistant/ | cut -f1")
+SIZE_KB=$(run_in_container "du -sk /home/assistant/ | cut -f1") || SIZE_KB=""
 if [ "${SIZE_KB:-999999}" -lt 1024 ]; then
     pass "/home/assistant < 1MB (${SIZE_KB}KB)"
 else
@@ -131,7 +145,7 @@ RESULT=$(run_in_container '
 [ -f /home/assistant/package.json ] && echo "packagejson=OK" || echo "packagejson=FAIL"
 OWNER=$(stat -c %U /home/assistant/.entrypoint.sh)
 echo "owner=$OWNER"
-')
+') || RESULT=""
 echo "$RESULT" | grep -q "entrypoint=OK" && pass ".entrypoint.sh executable" || fail ".entrypoint.sh not executable"
 echo "$RESULT" | grep -q "gitconfig=OK" && pass ".gitconfig exists" || fail ".gitconfig missing"
 echo "$RESULT" | grep -q "packagejson=OK" && pass "package.json guard exists" || fail "package.json guard missing"

--- a/tests/test-docker-image.sh
+++ b/tests/test-docker-image.sh
@@ -39,14 +39,14 @@ echo "=== Testing Docker image: $IMAGE ==="
 echo ""
 
 # 1. Node.js and Python versions
-echo "[1/10] Runtime versions"
+echo "[1/11] Runtime versions"
 VERSIONS=$(run_in_container 'node --version && python3 --version')
 echo "$VERSIONS" | grep -q "v22" && pass "Node.js v22" || fail "Node.js version"
 echo "$VERSIONS" | grep -q "Python 3" && pass "Python 3" || fail "Python version"
 
 # 2. CommonJS require()
 echo ""
-echo "[2/10] CommonJS require()"
+echo "[2/11] CommonJS require()"
 for pkg in react pptxgenjs pdf-lib docx sharp react-dom/server react-icons/fa; do
     RESULT=$(run_in_container "node -e \"try { require('$pkg'); console.log('OK') } catch(e) { console.log('FAIL: ' + e.code) }\"")
     echo "$RESULT" | grep -q "OK" && pass "require('$pkg')" || fail "require('$pkg'): $RESULT"
@@ -54,7 +54,7 @@ done
 
 # 3. ES Modules import
 echo ""
-echo "[3/10] ES Modules import"
+echo "[3/11] ES Modules import"
 for pkg in react pptxgenjs pdf-lib; do
     RESULT=$(run_in_container "node --input-type=module -e \"import '$pkg'; console.log('OK')\"")
     echo "$RESULT" | grep -q "OK" && pass "import '$pkg'" || fail "import '$pkg'"
@@ -62,7 +62,7 @@ done
 
 # 4. html2pptx import (full path)
 echo ""
-echo "[4/10] html2pptx import"
+echo "[4/11] html2pptx import"
 RESULT=$(run_in_container "node --input-type=module -e \"import { html2pptx } from '/usr/local/lib/node_modules_global/lib/node_modules/@anthropic-ai/html2pptx/dist/html2pptx.mjs'; console.log('OK')\"" 2>/dev/null || echo "SKIP")
 if echo "$RESULT" | grep -q "OK"; then
     pass "html2pptx ESM import"
@@ -74,7 +74,7 @@ fi
 
 # 5. CLI tools
 echo ""
-echo "[5/10] CLI tools"
+echo "[5/11] CLI tools"
 for tool in mmdc tsc tsx claude; do
     RESULT=$(run_in_container "which $tool >/dev/null 2>&1 && echo OK || echo MISSING")
     echo "$RESULT" | grep -q "OK" && pass "$tool in PATH" || fail "$tool not found in PATH"
@@ -82,7 +82,7 @@ done
 
 # 6. Python packages
 echo ""
-echo "[6/10] Python packages"
+echo "[6/11] Python packages"
 for pkg in docx pptx openpyxl; do
     RESULT=$(run_in_container "python3 -c \"import $pkg; print('OK')\"")
     echo "$RESULT" | grep -q "OK" && pass "python import $pkg" || fail "python import $pkg"
@@ -92,7 +92,7 @@ echo "$RESULT" | grep -q "OK" && pass "python playwright" || fail "python playwr
 
 # 7. User npm install (lodash)
 echo ""
-echo "[7/10] User npm install"
+echo "[7/11] User npm install"
 RESULT=$(run_in_container 'cd /home/assistant && npm install lodash >/dev/null 2>&1 && if [ -d /home/assistant/node_modules/lodash ]; then echo "user=YES"; else echo "user=NO"; fi && SYS_COUNT=$(ls /home/node_modules/ 2>/dev/null | wc -l) && echo "system=$SYS_COUNT"')
 echo "$RESULT" | grep -q "user=YES" && pass "lodash in /home/assistant/node_modules" || fail "lodash not in user dir"
 SYS=$(echo "$RESULT" | awk -F= '/^system=/{print $2}')
@@ -100,7 +100,7 @@ SYS=$(echo "$RESULT" | awk -F= '/^system=/{print $2}')
 
 # 8. npm prefix check
 echo ""
-echo "[8/10] npm configuration"
+echo "[8/11] npm configuration"
 RESULT=$(run_in_container 'npm config get prefix 2>/dev/null || echo "undefined"')
 # Acceptable: prefix deleted from user .npmrc (npm falls back to default
 # /usr/local), or explicitly pinned to the shared global path.
@@ -114,7 +114,7 @@ fi
 
 # 9. Volume size
 echo ""
-echo "[9/10] Volume size"
+echo "[9/11] Volume size"
 SIZE_KB=$(run_in_container "du -sk /home/assistant/ | cut -f1")
 if [ "${SIZE_KB:-999999}" -lt 1024 ]; then
     pass "/home/assistant < 1MB (${SIZE_KB}KB)"
@@ -124,7 +124,7 @@ fi
 
 # 10. Permissions and guard files
 echo ""
-echo "[10/10] Permissions and guard files"
+echo "[10/11] Permissions and guard files"
 RESULT=$(run_in_container '
 [ -x /home/assistant/.entrypoint.sh ] && echo "entrypoint=OK" || echo "entrypoint=FAIL"
 [ -f /home/assistant/.gitconfig ] && echo "gitconfig=OK" || echo "gitconfig=FAIL"
@@ -136,6 +136,29 @@ echo "$RESULT" | grep -q "entrypoint=OK" && pass ".entrypoint.sh executable" || 
 echo "$RESULT" | grep -q "gitconfig=OK" && pass ".gitconfig exists" || fail ".gitconfig missing"
 echo "$RESULT" | grep -q "packagejson=OK" && pass "package.json guard exists" || fail "package.json guard missing"
 echo "$RESULT" | grep -q "owner=assistant" && pass "files owned by assistant" || fail "files not owned by assistant"
+
+# 11. Entrypoint executes cleanly with the real ENTRYPOINT path.
+# All other tests bypass /home/assistant/.entrypoint.sh via --entrypoint=bash
+# so stdout parsing works. That leaves no coverage for the entrypoint script
+# itself — a shell syntax error there would ship unnoticed. This step runs
+# the image with its declared entrypoint and checks that (a) the process
+# exits 0, and (b) the expected status banner is printed.
+echo ""
+echo "[11/11] Entrypoint execution"
+ENTRYPOINT_OUT=$(docker run --rm --platform linux/amd64 --user=assistant "$IMAGE" true 2>&1)
+ENTRYPOINT_EXIT=$?
+if [ "$ENTRYPOINT_EXIT" -eq 0 ]; then
+    pass "entrypoint exits 0 with default command"
+else
+    fail "entrypoint exited $ENTRYPOINT_EXIT (output: $ENTRYPOINT_OUT)"
+fi
+# The banner text changes based on token presence; at least one of these
+# lines must appear, proving the entrypoint ran through its env-check block.
+if echo "$ENTRYPOINT_OUT" | grep -qE "(GITLAB_TOKEN|ANTHROPIC_AUTH_TOKEN|Claude Code configured)"; then
+    pass "entrypoint printed expected status banner"
+else
+    fail "entrypoint ran but produced no recognisable banner: $ENTRYPOINT_OUT"
+fi
 
 # Summary
 echo ""

--- a/tests/test-docker-image.sh
+++ b/tests/test-docker-image.sh
@@ -145,11 +145,13 @@ echo "$RESULT" | grep -q "owner=assistant" && pass "files owned by assistant" ||
 # exits 0, and (b) the expected status banner is printed.
 echo ""
 echo "[11/11] Entrypoint execution"
-ENTRYPOINT_OUT=$(docker run --rm --platform linux/amd64 --user=assistant "$IMAGE" true 2>&1)
-ENTRYPOINT_EXIT=$?
-if [ "$ENTRYPOINT_EXIT" -eq 0 ]; then
+# Wrap the command substitution in `if` so `set -e` does not abort the
+# whole test script on a non-zero docker exit — we need to reach fail()
+# with the captured output for structured reporting.
+if ENTRYPOINT_OUT=$(docker run --rm --platform linux/amd64 --user=assistant "$IMAGE" true 2>&1); then
     pass "entrypoint exits 0 with default command"
 else
+    ENTRYPOINT_EXIT=$?
     fail "entrypoint exited $ENTRYPOINT_EXIT (output: $ENTRYPOINT_OUT)"
 fi
 # The banner text changes based on token presence; at least one of these

--- a/tests/test-docker-image.sh
+++ b/tests/test-docker-image.sh
@@ -29,7 +29,10 @@ run_in_container() {
     # --entrypoint=bash bypasses /home/assistant/.entrypoint.sh, which prints
     # GITLAB_TOKEN / ANTHROPIC_AUTH_TOKEN status banners and corrupts captured
     # stdout when those env vars are unset (CI default).
-    docker run --rm --platform linux/amd64 --entrypoint=bash "$IMAGE" -c "$1" 2>/dev/null
+    # --user=assistant matches production (docker-compose runs as assistant)
+    # so user-scoped npm config (prefix delete, etc.) is the configuration
+    # actually under test.
+    docker run --rm --platform linux/amd64 --entrypoint=bash --user=assistant "$IMAGE" -c "$1" 2>/dev/null
 }
 
 echo "=== Testing Docker image: $IMAGE ==="
@@ -92,16 +95,19 @@ echo ""
 echo "[7/10] User npm install"
 RESULT=$(run_in_container 'cd /home/assistant && npm install lodash >/dev/null 2>&1 && if [ -d /home/assistant/node_modules/lodash ]; then echo "user=YES"; else echo "user=NO"; fi && SYS_COUNT=$(ls /home/node_modules/ 2>/dev/null | wc -l) && echo "system=$SYS_COUNT"')
 echo "$RESULT" | grep -q "user=YES" && pass "lodash in /home/assistant/node_modules" || fail "lodash not in user dir"
-SYS=$(echo "$RESULT" | grep -oP 'system=\K\d+' || echo "0")
+SYS=$(echo "$RESULT" | awk -F= '/^system=/{print $2}')
 [ "${SYS:-0}" -gt 100 ] && pass "system packages intact ($SYS)" || fail "system packages count: $SYS (expected > 100)"
 
 # 8. npm prefix check
 echo ""
 echo "[8/10] npm configuration"
 RESULT=$(run_in_container 'npm config get prefix 2>/dev/null || echo "undefined"')
-# prefix should be undefined (deleted) or /usr/local/lib/node_modules_global
-if echo "$RESULT" | grep -qE "(undefined|node_modules_global)"; then
-    pass "npm prefix configured correctly"
+# Acceptable: prefix deleted from user .npmrc (npm falls back to default
+# /usr/local), or explicitly pinned to the shared global path.
+# The original "undefined" branch is kept for legacy npm versions that
+# returned an empty string when prefix was unset.
+if echo "$RESULT" | grep -qE "(undefined|/usr/local|node_modules_global)"; then
+    pass "npm prefix configured correctly ($RESULT)"
 else
     fail "npm prefix: $RESULT"
 fi


### PR DESCRIPTION
## Summary

Wires two runtime smoke tests into the existing `Build Sandbox Image` CI job:

1. **Image smoke test** — runs `tests/test-docker-image.sh` against the freshly-built sandbox image (npm packages, CLI tools, Python imports, Playwright install, volume size, ownership).
2. **Browser smoke test** — `playwright.chromium.launch()` → `goto example.com` → assert title `"Example Domain"`. Catches wire-protocol mismatches and missing/broken browser binaries that pure `docker build` cannot detect.

Both run inside the same job (no inter-job artifact transfer of the 8GB image). The runner is pre-pruned (~10GB freed) so the loaded image fits alongside the buildx cache.

## Why now

PR #47 (playwright pin sync) was a near miss: Dependabot bumped the npm half to 1.59.1 while the matching PyPI release wasn't published yet. Pure `docker build` CI didn't catch it — the failure surfaced only when I rebuilt locally. These smoke tests would have caught the same class of bug at PR time.

## Test plan
- [ ] CI on this PR runs `Build Sandbox Image` and the new smoke-test steps land green
- [ ] `Smoke test — image packages and CLI tools` step shows `RESULT: ALL TESTS PASSED`
- [ ] `Smoke test — Chromium launches in container` step prints `OK: title=Example Domain`

## Risks and notes

- `load: true` is now unconditional. On `push` to `main` this still pushes to ghcr.io as before, plus loads locally for the smoke tests — small extra time, no behavior change for downstream consumers.
- Disk-prune step removes preinstalled toolchains the build doesn't use (.NET, Android SDK, GHC, CodeQL bundle). If a future job inside the same workflow needs them, restore selectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added smoke tests that run the built container, verify CLI/entrypoint behavior, and launch a browser to confirm page title for end-to-end validation.
  * Improved robustness of runtime and package checks; added an explicit entrypoint execution check, clearer test reporting, and use of the image tag produced by the build for tests.

* **Chores**
  * Frees disk space and reports filesystem usage before sandbox builds.
  * Ensures built sandbox images are loaded locally for immediate testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->