### PR TITLE
fix(init): filter global + tool public-read + correct model-params endpoint

### DIFF
--- a/openwebui/init.sh
+++ b/openwebui/init.sh
@@ -97,15 +97,21 @@ echo "[init] Valves set: FILE_SERVER_URL=$MCP_SERVER_URL"
 
 # Make tool public-read so non-admin users can see & call it.
 # Open WebUI's UI "Public" toggle writes BOTH group:* and user:* wildcards — we mirror
-# that exactly. Without these grants, only the admin who created the tool sees it.
-curl -sf -X POST "$WEBUI_URL/api/v1/tools/id/ai_computer_use/access/update" \
+# that exactly. Without these grants, only the admin who created the tool sees it, so
+# a failure here must block the marker file — otherwise the next restart skips init
+# and the tool stays admin-only forever.
+INIT_FAILED=0
+if curl -sf -X POST "$WEBUI_URL/api/v1/tools/id/ai_computer_use/access/update" \
     -H "$AUTH" -H "Content-Type: application/json" \
     -d '{"access_grants":[
            {"principal_type":"group","principal_id":"*","permission":"read"},
            {"principal_type":"user","principal_id":"*","permission":"read"}
-         ]}' >/dev/null 2>&1 \
-    && echo "[init] Tool marked public (all users + all groups, read)." \
-    || echo "[init] WARNING: Could not set tool public access."
+         ]}' >/dev/null 2>&1; then
+    echo "[init] Tool marked public (all users + all groups, read)."
+else
+    echo "[init] ERROR: Could not set tool public access — tool will remain admin-only. Init will retry on next restart."
+    INIT_FAILED=1
+fi
 
 # Install function: computer_link_filter.py
 echo "[init] Installing Computer Use filter..."
@@ -150,17 +156,25 @@ IS_ACTIVE=$(echo "$FILTER_STATE" | python3 -c "import sys,json;print(json.load(s
 IS_GLOBAL=$(echo "$FILTER_STATE" | python3 -c "import sys,json;print(json.load(sys.stdin).get('is_global',False))" 2>/dev/null || echo "False")
 
 if [ "$IS_ACTIVE" != "True" ]; then
-    curl -sf -X POST "$WEBUI_URL/api/v1/functions/id/computer_use_filter/toggle" \
-        -H "$AUTH" >/dev/null 2>&1 || true
-    echo "[init] Filter activated."
+    if curl -sf -X POST "$WEBUI_URL/api/v1/functions/id/computer_use_filter/toggle" \
+        -H "$AUTH" >/dev/null 2>&1; then
+        echo "[init] Filter activated."
+    else
+        echo "[init] ERROR: Could not activate filter — it will stay disabled until the next successful init. Init will retry on next restart."
+        INIT_FAILED=1
+    fi
 else
     echo "[init] Filter already active."
 fi
 
 if [ "$IS_GLOBAL" != "True" ]; then
-    curl -sf -X POST "$WEBUI_URL/api/v1/functions/id/computer_use_filter/toggle/global" \
-        -H "$AUTH" >/dev/null 2>&1 || true
-    echo "[init] Filter marked global (applies to all chats)."
+    if curl -sf -X POST "$WEBUI_URL/api/v1/functions/id/computer_use_filter/toggle/global" \
+        -H "$AUTH" >/dev/null 2>&1; then
+        echo "[init] Filter marked global (applies to all chats)."
+    else
+        echo "[init] ERROR: Could not mark filter global — it is active but won't apply to chats. Init will retry on next restart."
+        INIT_FAILED=1
+    fi
 else
     echo "[init] Filter already global."
 fi
@@ -171,26 +185,37 @@ fi
 # which takes the full ModelsConfigForm and merges DEFAULT_MODEL_PARAMS. We preserve
 # existing fields so we don't clobber DEFAULT_MODELS / DEFAULT_MODEL_METADATA.
 echo "[init] Ensuring DEFAULT_MODEL_PARAMS has native function calling + streaming..."
+# Fetch current config; pipe its body into Python via stdin so arbitrary content
+# (quotes, newlines, triple-quote sequences) cannot break the interpolation.
+# Use direct assignment, not setdefault — any prior value for these two fields
+# must be overwritten so our "params enforced" log is truthful.
 MODELS_CFG=$(curl -sf "$WEBUI_URL/api/v1/configs/models" -H "$AUTH" 2>/dev/null || echo "{}")
-MERGED_CFG=$(python3 -c "
+MERGED_CFG=$(printf '%s' "$MODELS_CFG" | python3 -c "
 import json, sys
-cfg = json.loads('''$MODELS_CFG''' or '{}')
+raw = sys.stdin.read() or '{}'
+cfg = json.loads(raw)
 params = cfg.get('DEFAULT_MODEL_PARAMS') or {}
-params.setdefault('function_calling', 'native')
-params.setdefault('stream_response', True)
+params['function_calling'] = 'native'
+params['stream_response'] = True
 cfg['DEFAULT_MODEL_PARAMS'] = params
 cfg.setdefault('DEFAULT_MODELS', cfg.get('DEFAULT_MODELS') or '')
 cfg.setdefault('DEFAULT_PINNED_MODELS', cfg.get('DEFAULT_PINNED_MODELS') or '')
 cfg.setdefault('MODEL_ORDER_LIST', cfg.get('MODEL_ORDER_LIST') or [])
 cfg.setdefault('DEFAULT_MODEL_METADATA', cfg.get('DEFAULT_MODEL_METADATA') or {})
 print(json.dumps(cfg))
-" 2>/dev/null)
-if [ -n "$MERGED_CFG" ]; then
-    curl -sf -X POST "$WEBUI_URL/api/v1/configs/models" \
-        -H "$AUTH" -H "Content-Type: application/json" \
-        -d "$MERGED_CFG" >/dev/null 2>&1 \
-        && echo "[init] DEFAULT_MODEL_PARAMS set (function_calling=native, stream_response=true)." \
-        || echo "[init] WARNING: Could not update DEFAULT_MODEL_PARAMS (endpoint may differ on this Open WebUI version)."
+" 2>&1) || MERGED_CFG=""
+
+if [ -z "$MERGED_CFG" ] || printf '%s' "$MERGED_CFG" | grep -q '^Traceback'; then
+    echo "[init] WARNING: Could not merge DEFAULT_MODEL_PARAMS (Python parse failed)."
+    if [ -n "$MERGED_CFG" ]; then
+        printf '[init]   %s\n' "$MERGED_CFG" | head -5
+    fi
+elif curl -sf -X POST "$WEBUI_URL/api/v1/configs/models" \
+    -H "$AUTH" -H "Content-Type: application/json" \
+    -d "$MERGED_CFG" >/dev/null 2>&1; then
+    echo "[init] DEFAULT_MODEL_PARAMS set (function_calling=native, stream_response=true)."
+else
+    echo "[init] WARNING: Could not POST DEFAULT_MODEL_PARAMS (endpoint may differ on this Open WebUI version)."
 fi
 
 # Also try setting via workspace model (fallback for v0.8.11–0.8.12)
@@ -232,7 +257,14 @@ print(json.dumps({
         echo "[init] Workspace model creation skipped (may already exist)"
 fi
 
-# Mark as initialized
-touch "$MARKER_FILE"
-echo "[init] Done! Open WebUI is ready with Computer Use."
+# Mark as initialized — only if every required step succeeded. If INIT_FAILED=1,
+# leave the marker off so the next container start retries the failed steps
+# (public-access grant, filter toggle, filter global). Without this guard a
+# transient failure would be baked in forever.
+if [ "$INIT_FAILED" = "0" ]; then
+    touch "$MARKER_FILE"
+    echo "[init] Done! Open WebUI is ready with Computer Use."
+else
+    echo "[init] Done with errors — marker NOT written, init will re-run on next restart to retry the failed steps."
+fi
 echo "[init] Login: $ADMIN_EMAIL / $ADMIN_PASSWORD"

--- a/openwebui/init.sh
+++ b/openwebui/init.sh
@@ -95,6 +95,18 @@ curl -sf -X POST "$WEBUI_URL/api/v1/tools/id/ai_computer_use/valves/update" \
     -d "{\"FILE_SERVER_URL\": \"$MCP_SERVER_URL\", \"MCP_API_KEY\": \"$MCP_API_KEY\", \"DEBUG_LOGGING\": false}" >/dev/null
 echo "[init] Valves set: FILE_SERVER_URL=$MCP_SERVER_URL"
 
+# Make tool public-read so non-admin users can see & call it.
+# Open WebUI's UI "Public" toggle writes BOTH group:* and user:* wildcards — we mirror
+# that exactly. Without these grants, only the admin who created the tool sees it.
+curl -sf -X POST "$WEBUI_URL/api/v1/tools/id/ai_computer_use/access/update" \
+    -H "$AUTH" -H "Content-Type: application/json" \
+    -d '{"access_grants":[
+           {"principal_type":"group","principal_id":"*","permission":"read"},
+           {"principal_type":"user","principal_id":"*","permission":"read"}
+         ]}' >/dev/null 2>&1 \
+    && echo "[init] Tool marked public (all users + all groups, read)." \
+    || echo "[init] WARNING: Could not set tool public access."
+
 # Install function: computer_link_filter.py
 echo "[init] Installing Computer Use filter..."
 FUNC_PAYLOAD=$(python3 -c "
@@ -128,16 +140,58 @@ curl -sf -X POST "$WEBUI_URL/api/v1/functions/id/computer_use_filter/valves/upda
     -d "{\"FILE_SERVER_URL\": \"$MCP_SERVER_EXTERNAL_URL\", \"ARCHIVE_BUTTON\": \"on\", \"INJECT_SYSTEM_PROMPT\": true}" >/dev/null 2>&1 || true
 echo "[init] Filter valves set: FILE_SERVER_URL=$MCP_SERVER_EXTERNAL_URL (external/browser URL)"
 
-# Enable filter globally
-curl -sf -X POST "$WEBUI_URL/api/v1/functions/id/computer_use_filter/toggle" \
-    -H "$AUTH" >/dev/null 2>&1 || true
-echo "[init] Filter enabled globally."
+# Enable filter (is_active=True) and mark it global (is_global=True).
+# Open WebUI v0.8.12 has TWO separate endpoints: /toggle flips is_active,
+# /toggle/global flips is_global. Active-but-not-global is silently inert —
+# the filter loads but is never applied to chats. Query state first and only
+# flip when needed so the script stays idempotent on re-runs.
+FILTER_STATE=$(curl -sf "$WEBUI_URL/api/v1/functions/id/computer_use_filter" -H "$AUTH" 2>/dev/null || echo "{}")
+IS_ACTIVE=$(echo "$FILTER_STATE" | python3 -c "import sys,json;print(json.load(sys.stdin).get('is_active',False))" 2>/dev/null || echo "False")
+IS_GLOBAL=$(echo "$FILTER_STATE" | python3 -c "import sys,json;print(json.load(sys.stdin).get('is_global',False))" 2>/dev/null || echo "False")
 
-# Enable tool for all models globally (default tool)
-echo "[init] Enabling tool globally for all models..."
-curl -sf -X POST "$WEBUI_URL/api/v1/configs/models/default/update" \
-    -H "$AUTH" -H "Content-Type: application/json" \
-    -d '{"toolIds": ["ai_computer_use"], "filterIds": ["computer_use_filter"], "params": {"function_calling": "native", "stream_response": true}}' >/dev/null 2>&1 || true
+if [ "$IS_ACTIVE" != "True" ]; then
+    curl -sf -X POST "$WEBUI_URL/api/v1/functions/id/computer_use_filter/toggle" \
+        -H "$AUTH" >/dev/null 2>&1 || true
+    echo "[init] Filter activated."
+else
+    echo "[init] Filter already active."
+fi
+
+if [ "$IS_GLOBAL" != "True" ]; then
+    curl -sf -X POST "$WEBUI_URL/api/v1/functions/id/computer_use_filter/toggle/global" \
+        -H "$AUTH" >/dev/null 2>&1 || true
+    echo "[init] Filter marked global (applies to all chats)."
+else
+    echo "[init] Filter already global."
+fi
+
+# Set global DEFAULT_MODEL_PARAMS so every model uses Native Function Calling + streaming
+# without per-model Advanced Params clicks. The old /api/v1/configs/models/default/update
+# endpoint does not exist in Open WebUI v0.8.12 (returns 405) — use POST /api/v1/configs/models
+# which takes the full ModelsConfigForm and merges DEFAULT_MODEL_PARAMS. We preserve
+# existing fields so we don't clobber DEFAULT_MODELS / DEFAULT_MODEL_METADATA.
+echo "[init] Ensuring DEFAULT_MODEL_PARAMS has native function calling + streaming..."
+MODELS_CFG=$(curl -sf "$WEBUI_URL/api/v1/configs/models" -H "$AUTH" 2>/dev/null || echo "{}")
+MERGED_CFG=$(python3 -c "
+import json, sys
+cfg = json.loads('''$MODELS_CFG''' or '{}')
+params = cfg.get('DEFAULT_MODEL_PARAMS') or {}
+params.setdefault('function_calling', 'native')
+params.setdefault('stream_response', True)
+cfg['DEFAULT_MODEL_PARAMS'] = params
+cfg.setdefault('DEFAULT_MODELS', cfg.get('DEFAULT_MODELS') or '')
+cfg.setdefault('DEFAULT_PINNED_MODELS', cfg.get('DEFAULT_PINNED_MODELS') or '')
+cfg.setdefault('MODEL_ORDER_LIST', cfg.get('MODEL_ORDER_LIST') or [])
+cfg.setdefault('DEFAULT_MODEL_METADATA', cfg.get('DEFAULT_MODEL_METADATA') or {})
+print(json.dumps(cfg))
+" 2>/dev/null)
+if [ -n "$MERGED_CFG" ]; then
+    curl -sf -X POST "$WEBUI_URL/api/v1/configs/models" \
+        -H "$AUTH" -H "Content-Type: application/json" \
+        -d "$MERGED_CFG" >/dev/null 2>&1 \
+        && echo "[init] DEFAULT_MODEL_PARAMS set (function_calling=native, stream_response=true)." \
+        || echo "[init] WARNING: Could not update DEFAULT_MODEL_PARAMS (endpoint may differ on this Open WebUI version)."
+fi
 
 # Also try setting via workspace model (fallback for v0.8.11–0.8.12)
 # Get first available model and create a workspace model with native FC


### PR DESCRIPTION
## Summary

Three silent bugs in `openwebui/init.sh` that caused `docker-compose.webui.yml` auto-init to look successful in logs while leaving the installation partially broken. All three were discovered during a production incident (see PR #60 for the docs side of this story).

1. **Filter was activated but not marked global.** Open WebUI v0.8.12 has two separate endpoints — `/toggle` flips `is_active`, `/toggle/global` flips `is_global`. init.sh dialed only the first yet logged "Filter enabled globally". A filter that's active but not global loads without applying to any chat (no error, no log line). Fix: read current state, toggle each flag independently only when needed — idempotent on re-runs.

2. **Tool `ai_computer_use` had no access_grants** — only the admin account that created it saw the tool. Non-admin users got an empty tool list with no error. Open WebUI's UI "Share → Public" writes both `group:*` and `user:*` wildcards with `permission=read`; init.sh now POSTs the same payload to `/api/v1/tools/id/ai_computer_use/access/update`.

3. **`POST /api/v1/configs/models/default/update` does not exist on v0.8.12** (returns 405 Method Not Allowed) — the call was silently swallowed via `|| true`. The correct endpoint is `POST /api/v1/configs/models` with the full `ModelsConfigForm`. init.sh now GETs the current config, merges `{function_calling: "native", stream_response: true}` into `DEFAULT_MODEL_PARAMS`, preserves other fields (`DEFAULT_MODELS`, `DEFAULT_MODEL_METADATA`, etc.), and POSTs it back. Users no longer need to flip Advanced Params on every model by hand.

Matching docs update in #60.

## Test plan

- [x] Fresh `docker compose -f docker-compose.webui.yml up --build`. Init log shows:
  - `[init] Tool marked public (all users + all groups, read).`
  - `[init] Filter activated.`
  - `[init] Filter marked global (applies to all chats).`
  - `[init] DEFAULT_MODEL_PARAMS set (function_calling=native, stream_response=true).`
- [x] Verify in Postgres (`docker-compose.webui.yml` uses Postgres):
  - `SELECT is_active, is_global FROM function WHERE id='computer_use_filter'` → `t, t`.
  - `SELECT principal_type, principal_id, permission FROM access_grant WHERE resource_id='ai_computer_use'` → 2 rows, `(group, *, read)` and `(user, *, read)`.
  - `SELECT data::jsonb->'models' FROM config` → contains `"default_params": {"function_calling": "native", "stream_response": true}`.
- [x] Re-run on the same volume — all steps log "already active / already global" instead of double-toggling (idempotency).
- [x] `./tests/test-no-corporate.sh` and `./tests/test-project-structure.sh` — PASSED.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tool access initialization to ensure consistent public visibility configuration across the system.
  * Improved filter state management with conditional activation checks to prevent unnecessary toggles and enhance stability.
  * Corrected default model configuration workflow to use proper API endpoints while preserving existing settings during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->