### PR TITLE
fix(sandbox): pin claude-code to 2.1.112 (last pre-exe repackage)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,13 @@ LABEL maintainer="OpenWebUI Implementation"
 LABEL description="AI Computer Use Environment"
 LABEL version="1.0.0"
 
-# Claude Code version (use "latest" for newest, or pin specific version)
-ARG CLAUDE_CODE_VERSION=2.1.114
+# Claude Code version. Pinned to 2.1.112 — the last release that ships the
+# package as plain JS (cli.js in the tarball). Starting with 2.1.113 the pkg
+# repackaged to a postinstall loader (install.cjs) that downloads a native
+# claude.exe binary and drops cli.js entirely, which breaks our bun-wrapper
+# shim below ("Module not found .../cli.js"). Do NOT bump to 2.1.113+ without
+# also removing the wrapper and verifying the native binary works under Bun.
+ARG CLAUDE_CODE_VERSION=2.1.112
 
 # Prevent interactive prompts
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Summary

Pin `@anthropic-ai/claude-code` to **2.1.112** to unblock sandbox CI.

Starting with 2.1.113, Anthropic repackaged the npm tarball:
- Removed `cli.js` (plain JS entry point).
- Added `install.cjs` (postinstall loader that downloads a native `claude.exe` binary).

Our Dockerfile uses a `bun /usr/local/lib/.../cli.js` wrapper to run Claude Code under the Bun runtime (originally a workaround for a `Bun is not defined` error). With no `cli.js` in the tarball, every sandbox build post-2.1.113 fails:

```
error: Module not found "/usr/local/lib/node_modules_global/lib/node_modules/@anthropic-ai/claude-code/cli.js"
```

## What this PR does

- `ARG CLAUDE_CODE_VERSION=2.1.114` → `2.1.112`
- Adds a multi-line comment explaining the constraint so future bumps don't silently break again. Explicit warning: do NOT bump to ≥2.1.113 without also removing the bun wrapper and verifying the native binary works under Bun.

## What this PR does NOT do

- Does not remove the bun wrapper. That's the proper long-term fix (embrace the native binary shipped by `install.cjs`) but needs separate investigation + testing — worth its own PR.

## Test plan

- [x] `npm pack @anthropic-ai/claude-code@2.1.112` → tarball contains `package/cli.js` (confirmed)
- [x] `npm pack @anthropic-ai/claude-code@2.1.113` → tarball has `install.cjs` + `bin/claude.exe`, no `cli.js` (confirmed — this is the regression)
- [ ] CI sandbox build turns green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependency version pin to ensure compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->