### PR TITLE
docs: simplify landing page to only what actually works

### DIFF
--- a/computer-use-server/static/docs.html
+++ b/computer-use-server/static/docs.html
@@ -5,7 +5,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Computer Use File Server + MCP</title>
+    <title>Computer Use Server</title>
     <style>
         * { box-sizing: border-box; }
         body {
@@ -81,10 +81,13 @@
         }
         .tool-list strong { color: #1976d2; }
         .section { margin-bottom: 30px; }
+        .links { list-style: none; padding: 0; }
+        .links li { margin: 6px 0; }
     </style>
 </head>
 <body>
-    <h1>Computer Use File Server + MCP</h1>
+    <h1>Computer Use Server</h1>
+    <p>MCP (Model Context Protocol) endpoint and file server for Computer Use sandbox containers.</p>
 
     <div class="nav">
         <a href="/docs">Swagger UI</a>
@@ -92,12 +95,13 @@
         <a href="/mcp">MCP Info</a>
         <a href="/health">Health</a>
         <a href="/system-prompt">System Prompt</a>
+        <a href="https://github.com/Yambr/open-computer-use">GitHub</a>
     </div>
 
     <div class="section" style="background: #e8f5e9; padding: 20px; border-radius: 8px; border: 2px solid #4CAF50;">
-        <h2>Recommended: LiteLLM MCP Proxy</h2>
-        <p><strong>Endpoint:</strong> <code>http://localhost:8081/mcp/docker_ai</code></p>
-        <p>Use your regular LiteLLM API key (NOT the docker-ai internal key).</p>
+        <h2>MCP Endpoint</h2>
+        <p><strong>URL:</strong> <code>POST http://localhost:8081/mcp</code></p>
+        <p><strong>Auth:</strong> <code>Authorization: Bearer &lt;MCP_API_KEY&gt;</code> (the value of the <code>MCP_API_KEY</code> env var on the server).</p>
 
         <h3>Available Tools</h3>
         <ul class="tool-list">
@@ -105,108 +109,45 @@
             <li><strong>view</strong> — view files and directories</li>
             <li><strong>create_file</strong> — create new files</li>
             <li><strong>str_replace</strong> — edit files (text replacement)</li>
-            <li><strong>sub_agent</strong> — delegate tasks to an autonomous agent (Claude)</li>
+            <li><strong>sub_agent</strong> — delegate tasks to an autonomous Claude Code agent</li>
         </ul>
 
-        <h3>Usage Examples</h3>
-
-        <h4>Step 1: Initialize (obtain session ID)</h4>
-        <pre>curl -sD - -X POST "http://localhost:8081/mcp/docker_ai" \
-  -H "Authorization: Bearer &lt;LITELLM_API_KEY&gt;" \
+        <h3>Step 1: Initialize (get session ID)</h3>
+        <pre>curl -sD - -X POST "http://localhost:8081/mcp" \
+  -H "Authorization: Bearer &lt;MCP_API_KEY&gt;" \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
-  -H "X-Chat-Id: my-unique-session" \
+  -H "X-Chat-Id: my-session" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 
 # Response contains header: mcp-session-id: &lt;SESSION_ID&gt;</pre>
 
-        <h4>Step 2: Call a tool</h4>
-        <pre>curl -s -X POST "http://localhost:8081/mcp/docker_ai" \
-  -H "Authorization: Bearer &lt;LITELLM_API_KEY&gt;" \
+        <h3>Step 2: Call a tool</h3>
+        <pre>curl -s -X POST "http://localhost:8081/mcp" \
+  -H "Authorization: Bearer &lt;MCP_API_KEY&gt;" \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
   -H "Mcp-Session-Id: &lt;SESSION_ID&gt;" \
-  -H "X-Chat-Id: my-unique-session" \
+  -H "X-Chat-Id: my-session" \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"bash_tool","arguments":{"command":"echo Hello","description":"test"}}}'</pre>
 
         <h3>Required Headers</h3>
         <table>
             <tr><th>Header</th><th>Description</th></tr>
-            <tr><td><code>Authorization</code></td><td>Bearer token from LiteLLM: <code>Bearer &lt;LITELLM_API_KEY&gt;</code></td></tr>
+            <tr><td><code>Authorization</code></td><td><code>Bearer &lt;MCP_API_KEY&gt;</code></td></tr>
             <tr><td><code>Accept</code></td><td><code>application/json, text/event-stream</code></td></tr>
-            <tr><td><code>X-Chat-Id</code></td><td>Unique session ID (creates a separate Docker container)</td></tr>
-            <tr><td><code>Mcp-Session-Id</code></td><td>Session ID from the initialize response</td></tr>
-            <tr><td><code>X-MCP-Servers</code></td><td><em>(optional)</em> Comma-separated list of MCP servers for sub_agent (see below)</td></tr>
+            <tr><td><code>X-Chat-Id</code></td><td>Unique session ID (one sandbox container per chat ID)</td></tr>
+            <tr><td><code>Mcp-Session-Id</code></td><td>Session ID from the <em>initialize</em> response (required on subsequent calls)</td></tr>
+            <tr><td><code>X-MCP-Servers</code></td><td><em>(optional)</em> Comma-separated external MCP servers for <code>sub_agent</code> — see below</td></tr>
         </table>
-
-        <h3>Usage via chat/completions</h3>
-        <pre>curl -X POST http://localhost:8081/v1/chat/completions \
-  -H "Authorization: Bearer &lt;LITELLM_API_KEY&gt;" \
-  -H "X-OpenWebUI-Chat-Id: my-chat-123" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "claude/claude-sonnet-4-5",
-    "messages": [{"role": "user", "content": "Run ls -la"}],
-    "tools": [{"type": "mcp", "server_label": "docker_ai"}]
-  }'</pre>
-
-        <h3>MCP Servers for sub_agent</h3>
-        <p>To allow sub_agent to use external MCP servers (Confluence, Jira, Grafana, etc.),
-        pass their names via the <code>X-MCP-Servers</code> header.</p>
-
-        <p><strong>How it works:</strong></p>
-        <ul>
-            <li>Each server URL is constructed from the template: <code>{ANTHROPIC_BASE_URL}/mcp/{server_name}</code> (LiteLLM MCP proxy)</li>
-            <li>Authorization: <code>ANTHROPIC_AUTH_TOKEN</code> from the container env — no need to pass keys separately</li>
-            <li>User email from <code>X-User-Email</code> is forwarded to each MCP server</li>
-        </ul>
-
-        <p><strong>Available servers:</strong> check your LiteLLM instance for the list of registered MCP servers.</p>
-
-        <p><strong>Format:</strong> comma-separated server names (as registered in LiteLLM):</p>
-        <pre>X-MCP-Servers: confluence,jira</pre>
-
-        <p><strong>Example:</strong> sub_agent with Confluence and Jira MCP servers:</p>
-        <pre>curl -s -X POST "http://localhost:8081/mcp/docker_ai" \
-  -H "Authorization: Bearer &lt;LITELLM_API_KEY&gt;" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "Mcp-Session-Id: &lt;SESSION_ID&gt;" \
-  -H "X-Chat-Id: my-session" \
-  -H "X-MCP-Servers: confluence,jira" \
-  -H "X-User-Email: user@example.com" \
-  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"sub_agent","arguments":{"task":"Find the onboarding page in Confluence","description":"search confluence"}}}'</pre>
-
-        <p><strong>Result:</strong> before launching Claude Code inside the container, a <code>~/.mcp.json</code> file is created:</p>
-        <pre>{
-  "mcpServers": {
-    "confluence": {
-      "type": "http",
-      "url": "http://localhost:8081/mcp/confluence",
-      "headers": {
-        "Authorization": "Bearer &lt;ANTHROPIC_AUTH_TOKEN from env&gt;",
-        "x-openwebui-user-email": "user@example.com"
-      }
-    },
-    "jira": { ... }
-  }
-}</pre>
-        <p>If the <code>X-MCP-Servers</code> header is not provided, sub_agent works without MCP servers (as before).</p>
     </div>
 
-    <div class="section" style="background: #e3f2fd; padding: 20px; border-radius: 8px; border: 2px solid #1976d2;">
-        <h2>System Prompt for Integrations</h2>
-        <p>A ready-made system prompt that teaches the AI how to work with the Computer Use VM (files, skills, tools). Use it in n8n, your own agents, or any integrations.</p>
-
-        <h3>Get the Prompt</h3>
-        <pre># Template with placeholders {file_base_url} and {archive_url}
-curl http://localhost:8081/system-prompt
-
-# With substituted URLs (for a specific chat)
-curl "http://localhost:8081/system-prompt?file_base_url=http://localhost:8081/files/MY_CHAT_ID&amp;archive_url=http://localhost:8081/files/MY_CHAT_ID/archive"</pre>
-
-        <h3>Usage in n8n</h3>
-        <p>Add an HTTP Request node with <code>GET /system-prompt</code> and insert the result into the system message of your AI agent. Substitute <code>file_base_url</code> and <code>archive_url</code> via query params or replace the placeholders in n8n.</p>
+    <div class="section">
+        <h2>External MCP servers for <code>sub_agent</code></h2>
+        <p>Pass a comma-separated list of MCP server names via the <code>X-MCP-Servers</code> header; the server writes <code>~/.mcp.json</code> inside the sandbox before launching Claude Code. Server URLs are built from <code>ANTHROPIC_BASE_URL</code>; auth reuses <code>ANTHROPIC_AUTH_TOKEN</code>.</p>
+        <pre>-H "X-MCP-Servers: confluence,jira" \
+-H "X-User-Email: user@example.com"</pre>
+        <p>Full recipe: <a href="https://github.com/Yambr/open-computer-use/blob/main/docs/MCP.md">docs/MCP.md</a>.</p>
     </div>
 
     <div class="section">
@@ -221,7 +162,7 @@ curl "http://localhost:8081/system-prompt?file_base_url=http://localhost:8081/fi
         <div class="endpoint">
             <span class="method get">GET</span>
             <code>/files/{chat_id}/archive</code>
-            <p>Download all files as a ZIP archive</p>
+            <p>Download all output files as a ZIP archive</p>
         </div>
 
         <div class="endpoint">
@@ -233,53 +174,30 @@ curl "http://localhost:8081/system-prompt?file_base_url=http://localhost:8081/fi
         <div class="endpoint">
             <span class="method get">GET</span>
             <code>/api/uploads/{chat_id}/manifest</code>
-            <p>Get the manifest of uploaded files (filename to MD5 mapping)</p>
+            <p>Manifest of uploaded files (filename → MD5)</p>
         </div>
     </div>
 
-    <div class="section" style="background: #fff3e0; border: 1px solid #ff9800; border-radius: 8px; padding: 20px;">
-        <h2>Direct Access to /mcp (for developers)</h2>
-        <p style="color: #e65100;"><strong>Warning:</strong> Direct access to <code>localhost:8081/mcp</code> requires a special API key. For normal usage, use the LiteLLM endpoint above.</p>
-
-        <h3>Example (internal use only)</h3>
-        <pre>curl -X POST http://localhost:8081/mcp \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer &lt;INTERNAL_MCP_API_KEY&gt;" \
-  -H "X-Chat-Id: my-session-123" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"bash_tool","arguments":{"command":"echo Hello","description":"test"}}}'</pre>
+    <div class="section" style="background: #e3f2fd; padding: 20px; border-radius: 8px; border: 2px solid #1976d2;">
+        <h2>System Prompt</h2>
+        <p>Ready-made system prompt that teaches an AI how to use this server (files, skills, tools). Use it in n8n, custom agents, or any integration.</p>
+        <pre>curl http://localhost:8081/system-prompt</pre>
+        <p>The server owns the public URL (<code>PUBLIC_BASE_URL</code> env var) and bakes it into the returned prompt; callers no longer need to pass <code>file_base_url</code>/<code>archive_url</code> query params (legacy, still accepted for backward compatibility).</p>
     </div>
 
     <div class="section">
-        <h2>Architecture</h2>
-        <pre>
-┌─────────────────────────────────────────────────────────────────┐
-│                        Docker Host                              │
-│                                                                 │
-│  ┌──────────────────┐      ┌─────────────────────────────────┐ │
-│  │  File Server     │      │  Docker Containers              │ │
-│  │  (this service)  │      │                                 │ │
-│  │                  │      │  ┌─────────────────────────┐   │ │
-│  │  POST /mcp ──────┼──────┼──│ owui-chat-{chat_id}     │   │ │
-│  │                  │      │  │  - bash_tool            │   │ │
-│  │  GET /files/* ───┼──────┼──│  - view                 │   │ │
-│  │                  │      │  │  - create_file          │   │ │
-│  │                  │      │  │  - str_replace          │   │ │
-│  └──────────────────┘      │  └─────────────────────────┘   │ │
-│           │                │                                 │ │
-│           │                │  ┌─────────────────────────┐   │ │
-│           ▼                │  │ owui-chat-{other_id}    │   │ │
-│  /var/run/docker.sock      │  └─────────────────────────┘   │ │
-│                            └─────────────────────────────────┘ │
-│                                                                 │
-│  /data/{chat_id}/                                              │
-│    ├── uploads/   (files from user)                            │
-│    └── outputs/   (files created by AI)                        │
-└─────────────────────────────────────────────────────────────────┘
-        </pre>
+        <h2>Documentation &amp; source</h2>
+        <ul class="links">
+            <li>📖 <a href="https://github.com/Yambr/open-computer-use">Repository</a> — README, setup, architecture</li>
+            <li>🔌 <a href="https://github.com/Yambr/open-computer-use/blob/main/docs/MCP.md">docs/MCP.md</a> — MCP tools reference, external MCP servers</li>
+            <li>🔑 <a href="https://github.com/Yambr/open-computer-use/blob/main/docs/claude-code-gateway.md">docs/claude-code-gateway.md</a> — Claude Code auth inside the sandbox (Anthropic / LiteLLM / Bedrock)</li>
+            <li>🧩 <a href="https://github.com/Yambr/open-computer-use/blob/main/docs/openwebui-filter.md">docs/openwebui-filter.md</a> — Open WebUI filter &amp; tool integration</li>
+            <li>🐛 <a href="https://github.com/Yambr/open-computer-use/issues">Issues</a></li>
+        </ul>
     </div>
 
     <footer style="margin-top: 40px; padding-top: 20px; border-top: 1px solid #ddd; color: #666; font-size: 14px;">
-        Computer Use File Server + MCP v2.0.0
+        Computer Use Server — <a href="https://github.com/Yambr/open-computer-use" style="color: #1976d2;">github.com/Yambr/open-computer-use</a>
     </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Rewrite `computer-use-server/static/docs.html` to document only endpoints that actually exist on this server.
- Remove references to `/mcp/docker_ai`, `/v1/chat/completions`, and `INTERNAL_MCP_API_KEY` — these described LiteLLM-proxy features as if they were the server's own contract and sent users down dead ends.
- Collapse the fake "recommended" vs "internal" split into the single real `POST /mcp` endpoint with `MCP_API_KEY` bearer auth.
- Keep verified content: tool list, init/tools-call curls, `X-MCP-Servers` header (short, with a link), File API, `/system-prompt`.
- Add links to the GitHub repo and `docs/` pages (README, MCP.md, claude-code-gateway.md, openwebui-filter.md) for anything longer.

## What was actually broken

Verified against `app.py`, `mcp_tools.py`, `docker_manager.py`:

| Old claim | Reality |
|---|---|
| `POST /mcp/docker_ai` | No such route. `docker_ai` is even in `BLOCKED_SERVERS` in `docker_manager.py`. |
| `POST /v1/chat/completions` with `tools:[{type:mcp,...}]` | Not implemented here (LiteLLM feature). |
| `INTERNAL_MCP_API_KEY` | The real env var is `MCP_API_KEY`; there is no separate "internal" key. |
| `/system-prompt?file_base_url=…&archive_url=…` | Params are legacy; server now owns `PUBLIC_BASE_URL`. Clarified on the page. |

## Test plan

- [ ] Open the updated page in a browser; confirm layout renders with the existing CSS untouched.
- [ ] `grep -E 'docker_ai|v1/chat/completions|INTERNAL_MCP_API_KEY' computer-use-server/static/docs.html` returns empty (verified locally).
- [ ] Every curl on the page runs clean against a running server with a valid `MCP_API_KEY`.
- [ ] `./tests/test-project-structure.sh` passes (verified locally: 22/22).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rebranded service to "Computer Use Server"
  * Updated MCP setup instructions with new endpoint and authentication method
  * Clarified Claude Code agent integration for sub-agent delegation
  * Simplified system prompt endpoint documentation
  * Reorganized and consolidated documentation for improved readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->