### PR TITLE
docs: surface Yambr cloud options in README and add docs/CLOUD.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ MCP server that gives any LLM its own computer — managed Docker workspaces wit
 | Path | URL | What you need | Best for |
 |------|-----|---------------|----------|
 | **Free demo** — Open WebUI + Computer Use, models included | **[chat.yambr.com](https://chat.yambr.com)** | Sign in with GitHub or Google | Trying it end-to-end in 30 seconds, zero setup |
-| **Hosted MCP endpoint** — tools only, bring your own LLM | Key at **[app.yambr.com](https://app.yambr.com)** → connect to `https://api.yambr.com/mcp/computer_use` | GitHub or Google sign-in, short manual approval, your own OpenAI / Anthropic / OpenRouter key | Adding Computer Use tools to an existing agent, Claude Desktop, n8n, OpenAI Agents SDK |
+| **Hosted MCP endpoint** — tools only, bring your own LLM | Key at **[app.yambr.com](https://app.yambr.com)** → connect to `https://api.yambr.com/mcp/computer_use` | GitHub or Google sign-in; your own OpenAI / Anthropic / OpenRouter key for inference | Adding Computer Use tools to an existing agent, Claude Desktop, n8n, OpenAI Agents SDK |
 | **Self-host** | [Quick Start](#quick-start) below | Docker, ~15 min first build, your own LLM key | Full control, air-gapped, heavy use |
 
-Sign-in is GitHub or Google OAuth — no email/password, no SMS. On the hosted API, Yambr provides the tools; your LLM inference stays on your provider (OpenAI, Anthropic, OpenRouter, …). On `chat.yambr.com` the hosted Open WebUI instance includes models too, as a free convenience. See [docs/CLOUD.md](docs/CLOUD.md) for the full hosted-vs-self-host picture; [docs.yambr.com](https://docs.yambr.com) holds the canonical cloud docs.
+Sign-in is GitHub or Google OAuth — no email/password, no SMS. `chat.yambr.com` includes models as a free convenience; the hosted API is tools-only. Canonical cloud docs: [docs.yambr.com](https://docs.yambr.com). Short orientation: [docs/CLOUD.md](docs/CLOUD.md).
 
 ![Demo: AI reads GitHub README and creates a landing page](docs/demo-landing-page.gif)
 
@@ -145,33 +145,19 @@ See [docs/SKILLS.md](docs/SKILLS.md) for details.
 
 ## MCP Integration
 
-The server speaks standard MCP over Streamable HTTP. Connect it to anything — run the server yourself, or use the managed endpoint at `api.yambr.com`.
+The server speaks standard MCP over Streamable HTTP. Point any MCP client at it — hosted or self-hosted.
 
-### Hosted (managed)
+- **Hosted**: `https://api.yambr.com/mcp/computer_use` with `Authorization: Bearer <key from app.yambr.com>`. Client configs and full reference live on [docs.yambr.com](https://docs.yambr.com).
+- **Self-hosted**: `http://localhost:8081/mcp`. Quick sanity check:
 
-```bash
-# Request a key at app.yambr.com first, then:
-curl -X POST https://api.yambr.com/mcp/computer_use \
-  -H "Authorization: Bearer sk-yambr-..." \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "X-Chat-Id: my-session" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
-```
+  ```bash
+  curl -X POST http://localhost:8081/mcp \
+    -H "Content-Type: application/json" \
+    -H "X-Chat-Id: test" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+  ```
 
-You bring your own model provider — Yambr doesn't resell inference. See [docs/CLOUD.md](docs/CLOUD.md) for Claude Desktop / OpenAI Agents SDK / n8n configs and [docs.yambr.com](https://docs.yambr.com) for the canonical cloud reference.
-
-### Self-hosted
-
-```bash
-# Test with curl
-curl -X POST http://localhost:8081/mcp \
-  -H "Content-Type: application/json" \
-  -H "X-Chat-Id: test" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
-```
-
-See [docs/MCP.md](docs/MCP.md) for the full self-host integration guide (LiteLLM, Claude Desktop, custom clients). The per-chat system prompt rides **six redundant MCP-native channels** (tool descriptions, `/home/assistant/README.md` in the sandbox, `InitializeResult.instructions`, `resources/list` for uploaded files, plus an HTTP `/system-prompt` endpoint for legacy integrations) — full map in [docs/system-prompt.md](docs/system-prompt.md).
+  Full self-host integration guide (LiteLLM, Claude Desktop, custom clients): [docs/MCP.md](docs/MCP.md). The per-chat system prompt rides **six redundant MCP-native channels** (tool descriptions, `/home/assistant/README.md` in the sandbox, `InitializeResult.instructions`, `resources/list` for uploaded files, plus an HTTP `/system-prompt` endpoint for legacy integrations) — full map in [docs/system-prompt.md](docs/system-prompt.md).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -194,11 +194,11 @@ The Computer Use Server speaks standard **MCP over Streamable HTTP** — any MCP
 
 | Client | Self-hosted URL | Hosted URL | Status |
 |--------|-----------------|------------|--------|
-| [**Open WebUI**](https://github.com/open-webui/open-webui) | Docker Compose stack included, auto-configured | [chat.yambr.com](https://chat.yambr.com) (ready-made) | Tested in production |
+| [**Open WebUI**](https://github.com/open-webui/open-webui) | Docker Compose stack included, auto-configured | n/a — use [chat.yambr.com](https://chat.yambr.com) directly (pointing your own Open WebUI at the hosted API isn't a documented path) | Tested in production |
 | [**Claude Desktop**](https://claude.ai/download) | `http://localhost:8081/mcp` — see [docs/MCP.md](docs/MCP.md) | `https://api.yambr.com/mcp/computer_use` — see [docs/CLOUD.md](docs/CLOUD.md) | Works |
 | [**n8n**](https://n8n.io) | MCP Tool node → `http://computer-use-server:8081/mcp` | MCP Tool node → `https://api.yambr.com/mcp/computer_use` | Works |
 | [**LiteLLM**](https://github.com/BerriAI/litellm) | MCP proxy config — see [docs/MCP.md](docs/MCP.md) | MCP proxy → `https://api.yambr.com/mcp/computer_use` | Works |
-| **Custom client** | Any HTTP client with MCP JSON-RPC — see curl examples in [docs/MCP.md](docs/MCP.md) | Same, with `Authorization: Bearer sk-yambr-...` | Works |
+| **Custom client** | Any HTTP client with MCP JSON-RPC — see curl examples in [docs/MCP.md](docs/MCP.md) | Same, with `Authorization: Bearer sk-...` (key from [app.yambr.com](https://app.yambr.com)) | Works |
 
 ## Open WebUI Integration
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,7 @@
 
 MCP server that gives any LLM its own computer — managed Docker workspaces with live browser, terminal, code execution, document skills, and autonomous sub-agents. Self-hosted, open-source, pluggable into any model.
 
-## Three ways to try it
-
-| Path | URL | What you need | Best for |
-|------|-----|---------------|----------|
-| **Free demo** — Open WebUI + Computer Use, models included | **[chat.yambr.com](https://chat.yambr.com)** | Sign in with GitHub or Google | Trying it end-to-end in 30 seconds, zero setup |
-| **Hosted MCP endpoint** — tools only, bring your own LLM | Key at **[app.yambr.com](https://app.yambr.com)** → connect to `https://api.yambr.com/mcp/computer_use` | GitHub or Google sign-in; your own OpenAI / Anthropic / OpenRouter key for inference | Adding Computer Use tools to an existing agent, Claude Desktop, n8n, OpenAI Agents SDK |
-| **Self-host** | [Quick Start](#quick-start) below | Docker, ~15 min first build, your own LLM key | Full control, air-gapped, heavy use |
-
-Sign-in is GitHub or Google OAuth — no email/password, no SMS. `chat.yambr.com` includes models as a free convenience; the hosted API is tools-only. Canonical cloud docs: [docs.yambr.com](https://docs.yambr.com). Short orientation: [docs/CLOUD.md](docs/CLOUD.md).
+> **Online demo:** **[chat.yambr.com](https://chat.yambr.com)** — Open WebUI with Computer Use already set up, sign in with GitHub or Google. ([More ways to try it](#ways-to-try-it) below.)
 
 ![Demo: AI reads GitHub README and creates a landing page](docs/demo-landing-page.gif)
 
@@ -71,6 +63,16 @@ See [docs/FEATURES.md](docs/FEATURES.md) for architecture details and [docs/SCRE
 ## Architecture
 
 ![Architecture](docs/architecture.svg)
+
+## Ways to try it
+
+| Path | URL | What you need | Best for |
+|------|-----|---------------|----------|
+| **Free online demo** — Open WebUI + Computer Use, models included | **[chat.yambr.com](https://chat.yambr.com)** | GitHub or Google sign-in | Trying it end-to-end in 30 seconds |
+| **Hosted MCP endpoint** — tools only, bring your own LLM | Key at [app.yambr.com](https://app.yambr.com) → connect to `https://api.yambr.com/mcp/computer_use` | GitHub/Google sign-in; your own OpenAI / Anthropic / OpenRouter key | Plugging Computer Use into Claude Desktop, n8n, OpenAI Agents SDK |
+| **Self-host** | [Quick Start](#quick-start) below | Docker, ~15 min first build | Full control, air-gapped, heavy use |
+
+OAuth only — no email/password, no SMS. On `chat.yambr.com` models are bundled as a free convenience; the hosted API is tools-only. Canonical cloud docs: [docs.yambr.com](https://docs.yambr.com). Repo-side orientation: [docs/CLOUD.md](docs/CLOUD.md).
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@
 
 MCP server that gives any LLM its own computer — managed Docker workspaces with live browser, terminal, code execution, document skills, and autonomous sub-agents. Self-hosted, open-source, pluggable into any model.
 
+## Three ways to try it
+
+| Path | URL | What you need | Best for |
+|------|-----|---------------|----------|
+| **Free demo** — Open WebUI + Computer Use, models included | **[chat.yambr.com](https://chat.yambr.com)** | Sign in with GitHub or Google | Trying it end-to-end in 30 seconds, zero setup |
+| **Hosted MCP endpoint** — tools only, bring your own LLM | Key at **[app.yambr.com](https://app.yambr.com)** → connect to `https://api.yambr.com/mcp/computer_use` | GitHub or Google sign-in, short manual approval, your own OpenAI / Anthropic / OpenRouter key | Adding Computer Use tools to an existing agent, Claude Desktop, n8n, OpenAI Agents SDK |
+| **Self-host** | [Quick Start](#quick-start) below | Docker, ~15 min first build, your own LLM key | Full control, air-gapped, heavy use |
+
+Sign-in is GitHub or Google OAuth — no email/password, no SMS. On the hosted API, Yambr provides the tools; your LLM inference stays on your provider (OpenAI, Anthropic, OpenRouter, …). On `chat.yambr.com` the hosted Open WebUI instance includes models too, as a free convenience. See [docs/CLOUD.md](docs/CLOUD.md) for the full hosted-vs-self-host picture; [docs.yambr.com](https://docs.yambr.com) holds the canonical cloud docs.
+
 ![Demo: AI reads GitHub README and creates a landing page](docs/demo-landing-page.gif)
 
 ## What is this?
@@ -135,7 +145,23 @@ See [docs/SKILLS.md](docs/SKILLS.md) for details.
 
 ## MCP Integration
 
-The server speaks standard MCP over Streamable HTTP. Connect it to anything:
+The server speaks standard MCP over Streamable HTTP. Connect it to anything — run the server yourself, or use the managed endpoint at `api.yambr.com`.
+
+### Hosted (managed)
+
+```bash
+# Request a key at app.yambr.com first, then:
+curl -X POST https://api.yambr.com/mcp/computer_use \
+  -H "Authorization: Bearer sk-yambr-..." \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "X-Chat-Id: my-session" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+```
+
+You bring your own model provider — Yambr doesn't resell inference. See [docs/CLOUD.md](docs/CLOUD.md) for Claude Desktop / OpenAI Agents SDK / n8n configs and [docs.yambr.com](https://docs.yambr.com) for the canonical cloud reference.
+
+### Self-hosted
 
 ```bash
 # Test with curl
@@ -145,7 +171,7 @@ curl -X POST http://localhost:8081/mcp \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 ```
 
-See [docs/MCP.md](docs/MCP.md) for full integration guide (LiteLLM, Claude Desktop, custom clients). The per-chat system prompt rides **six redundant MCP-native channels** (tool descriptions, `/home/assistant/README.md` in the sandbox, `InitializeResult.instructions`, `resources/list` for uploaded files, plus an HTTP `/system-prompt` endpoint for legacy integrations) — full map in [docs/system-prompt.md](docs/system-prompt.md).
+See [docs/MCP.md](docs/MCP.md) for the full self-host integration guide (LiteLLM, Claude Desktop, custom clients). The per-chat system prompt rides **six redundant MCP-native channels** (tool descriptions, `/home/assistant/README.md` in the sandbox, `InitializeResult.instructions`, `resources/list` for uploaded files, plus an HTTP `/system-prompt` endpoint for legacy integrations) — full map in [docs/system-prompt.md](docs/system-prompt.md).
 
 ## Configuration
 
@@ -178,13 +204,13 @@ By default, all 13 built-in skills are available to everyone. For per-user skill
 
 The Computer Use Server speaks standard **MCP over Streamable HTTP** — any MCP-compatible client can connect. Open WebUI is the primary tested frontend, but not the only option.
 
-| Client | How to connect | Status |
-|--------|---------------|--------|
-| [**Open WebUI**](https://github.com/open-webui/open-webui) | Docker Compose stack included, auto-configured | Tested in production |
-| [**Claude Desktop**](https://claude.ai/download) | Add to `claude_desktop_config.json` — see [docs/MCP.md](docs/MCP.md) | Works |
-| [**n8n**](https://n8n.io) | MCP Tool node → `http://computer-use-server:8081/mcp` | Works |
-| [**LiteLLM**](https://github.com/BerriAI/litellm) | MCP proxy config — see [docs/MCP.md](docs/MCP.md) | Works |
-| **Custom client** | Any HTTP client with MCP JSON-RPC — see curl examples in [docs/MCP.md](docs/MCP.md) | Works |
+| Client | Self-hosted URL | Hosted URL | Status |
+|--------|-----------------|------------|--------|
+| [**Open WebUI**](https://github.com/open-webui/open-webui) | Docker Compose stack included, auto-configured | [chat.yambr.com](https://chat.yambr.com) (ready-made) | Tested in production |
+| [**Claude Desktop**](https://claude.ai/download) | `http://localhost:8081/mcp` — see [docs/MCP.md](docs/MCP.md) | `https://api.yambr.com/mcp/computer_use` — see [docs/CLOUD.md](docs/CLOUD.md) | Works |
+| [**n8n**](https://n8n.io) | MCP Tool node → `http://computer-use-server:8081/mcp` | MCP Tool node → `https://api.yambr.com/mcp/computer_use` | Works |
+| [**LiteLLM**](https://github.com/BerriAI/litellm) | MCP proxy config — see [docs/MCP.md](docs/MCP.md) | MCP proxy → `https://api.yambr.com/mcp/computer_use` | Works |
+| **Custom client** | Any HTTP client with MCP JSON-RPC — see curl examples in [docs/MCP.md](docs/MCP.md) | Same, with `Authorization: Bearer sk-yambr-...` | Works |
 
 ## Open WebUI Integration
 
@@ -470,6 +496,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). PRs welcome!
 
 ## Community
 
+- **Managed hosting**: [yambr.com](https://yambr.com) — cloud version by the maintainers ([chat.yambr.com](https://chat.yambr.com) for the free demo, [app.yambr.com](https://app.yambr.com) for API keys, [docs.yambr.com](https://docs.yambr.com) for the cloud docs)
 - **Issues & Ideas**: [GitHub Issues](https://github.com/Yambr/open-computer-use/issues)
 - **Telegram**: [@yambrcom](https://t.me/yambrcom)
 

--- a/docs/CLOUD.md
+++ b/docs/CLOUD.md
@@ -1,0 +1,138 @@
+# Cloud (managed Yambr)
+
+This doc is for people who **don't want to self-host**. If you're running `docker compose up`, see [INSTALL.md](INSTALL.md) instead — that path is first-class and always will be.
+
+The managed version lives at **[yambr.com](https://yambr.com)**. The canonical cloud reference is **[docs.yambr.com](https://docs.yambr.com)** — this page is just the quick on-ramp.
+
+## The four Yambr services
+
+| Service | URL | Role |
+|---------|-----|------|
+| Dashboard | [app.yambr.com](https://app.yambr.com) | Sign in, request key, manage keys, live spend tracking |
+| MCP endpoint | `https://api.yambr.com/mcp/computer_use` | Public Streamable-HTTP MCP — the **tool server** |
+| Hosted chat | [chat.yambr.com](https://chat.yambr.com) | Managed Open WebUI with Computer Use pre-wired (models included) |
+| Artifact host | `https://cu.yambr.com` | Sandbox file/preview URLs (the URL itself is the access token) |
+
+> Yambr publishes one public surface: the Computer Use MCP endpoint. Model inference stays on your own provider — **you bring your own model provider, Yambr doesn't resell inference**.
+
+## Two hosted paths
+
+The cloud gives you two clearly distinct options. Pick based on whether you want models included or not.
+
+### Path A — `chat.yambr.com` (free end-to-end demo)
+
+Managed Open WebUI with Computer Use pre-installed globally. Yambr pays for the LLM models too, as a convenience for browser users. Zero setup.
+
+1. Open [chat.yambr.com](https://chat.yambr.com)
+2. Sign in with GitHub or Google (no email/password, no SMS)
+3. Pick a model from the dropdown, start chatting
+
+Drag files into chat input — they're mounted at `/home/assistant/uploads/{chat_id}/` inside the sandbox. Artifacts auto-render. Large tool results stream without truncation. Per-chat sandbox isolation (different chats = separate containers).
+
+### Path B — `api.yambr.com/mcp/computer_use` (tools only, bring your own LLM)
+
+A public MCP endpoint you point any agent/MCP client at. Your LLM traffic goes to *your* provider (OpenAI, Anthropic, OpenRouter…); your Yambr key unlocks the Computer Use sandbox, nothing else.
+
+**Issue a key:**
+
+1. Sign in at [app.yambr.com](https://app.yambr.com) via GitHub or Google (no email + password flow)
+2. Request access — approvals are a light manual review ("we eyeball requests and approve most of them quickly"). Urgent? Ping [@yambrcom](https://t.me/yambrcom) on Telegram
+3. Once approved, create a key from the dashboard. The full key `sk-yambr-...` is shown **once** — store it in a secret manager immediately. After that the dashboard only shows `sk-...{last-4}`
+4. Default budget: **$10 / 30 days rolling**. Up to 5 keys per account. Max 5 concurrent requests per key — `429` on exhaustion of either cap. Reissue rotates the key but keeps the budget and alias slot
+
+> Treat Yambr keys like database passwords: never commit them to git, never ship them to a browser, rotate on exposure.
+
+## Client configs
+
+Every config below targets `https://api.yambr.com/mcp/computer_use`. The `X-Chat-Id` header identifies the sandbox — **keep it stable for a persistent sandbox; rotate it to start fresh**.
+
+### Claude Desktop
+
+File path:
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "yambr-computer-use": {
+      "url": "https://api.yambr.com/mcp/computer_use",
+      "transport": "streamable-http",
+      "headers": {
+        "Authorization": "Bearer sk-yambr-...",
+        "X-Chat-Id": "claude-desktop"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop after editing.
+
+### OpenAI Agents SDK (Python)
+
+```python
+import os
+from agents import Agent, Runner
+from agents.mcp import MCPServerStreamableHttp
+
+yambr_mcp = MCPServerStreamableHttp(
+    params={
+        "url": "https://api.yambr.com/mcp/computer_use",
+        "headers": {"Authorization": f"Bearer {os.environ['YAMBR_API_KEY']}"},
+    },
+    name="yambr-computer-use",
+)
+
+agent = Agent(
+    name="computer-user",
+    model="gpt-4o",
+    mcp_servers=[yambr_mcp],
+)
+
+result = await Runner.run(agent, "Build me a landing page for a coffee shop")
+print(result.final_output)
+```
+
+### n8n
+
+Add an **MCP Tool** node → URL `https://api.yambr.com/mcp/computer_use`, auth `Bearer sk-yambr-...`, extra header `X-Chat-Id: {{ $json.chat_id }}`.
+
+### Plain curl
+
+```bash
+curl -sD - -X POST "https://api.yambr.com/mcp/computer_use" \
+  -H "Authorization: Bearer sk-yambr-..." \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "X-Chat-Id: my-session" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"my-client","version":"1.0"}}}'
+```
+
+> A bare `GET https://api.yambr.com/mcp/computer_use` returns `500` — that's expected, MCP requires `POST` + the headers above. Not a service outage.
+
+### Open WebUI
+
+If you want the hosted Computer Use tools inside your *own* Open WebUI: either use **[chat.yambr.com](https://chat.yambr.com)** (already wired up, models included) or **self-host** the full stack via [INSTALL.md](INSTALL.md). Pointing a third-party Open WebUI at `api.yambr.com` isn't a documented path today.
+
+## Pricing & limits (at a glance)
+
+| What | Value |
+|------|-------|
+| Sign-in providers | GitHub, Google (no email + password, no SMS) |
+| Default budget per key | $10 / 30-day rolling window |
+| Keys per account | Up to 5 |
+| Concurrent requests per key | 5 (429 on overflow) |
+| Budget exhaustion | 429 until the rolling window resets |
+| Key visibility after creation | `sk-...{last-4}` only — full key shown once |
+| Key rotation | Reissue keeps budget + alias; old value 401s immediately |
+
+Budgets, model lists, and approval flow are the authoritative truth on [app.yambr.com](https://app.yambr.com) and [docs.yambr.com](https://docs.yambr.com) — numbers here can drift.
+
+## See also
+
+- [docs.yambr.com](https://docs.yambr.com) — full cloud docs: platform overview, access model, API keys, dashboard tour, per-integration guides
+- [docs.yambr.com/platform/access-model](https://docs.yambr.com/platform/access-model) — which surfaces are public vs convenience
+- [docs.yambr.com/quickstart](https://docs.yambr.com/quickstart) — the three starting paths in one page
+- [INSTALL.md](INSTALL.md) — self-host Quick Start
+- [MCP.md](MCP.md) — MCP protocol reference (applies to both hosted and self-hosted)

--- a/docs/CLOUD.md
+++ b/docs/CLOUD.md
@@ -1,138 +1,29 @@
 # Cloud (managed Yambr)
 
-This doc is for people who **don't want to self-host**. If you're running `docker compose up`, see [INSTALL.md](INSTALL.md) instead — that path is first-class and always will be.
-
-The managed version lives at **[yambr.com](https://yambr.com)**. The canonical cloud reference is **[docs.yambr.com](https://docs.yambr.com)** — this page is just the quick on-ramp.
+This page exists so GitHub visitors know a managed version exists. It is intentionally thin — the canonical cloud reference is **[docs.yambr.com](https://docs.yambr.com)** and the source of truth for keys, budgets and limits is **[app.yambr.com](https://app.yambr.com)**. If you self-host, see [INSTALL.md](INSTALL.md) instead.
 
 ## The four Yambr services
 
 | Service | URL | Role |
 |---------|-----|------|
-| Dashboard | [app.yambr.com](https://app.yambr.com) | Sign in, request key, manage keys, live spend tracking |
-| MCP endpoint | `https://api.yambr.com/mcp/computer_use` | Public Streamable-HTTP MCP — the **tool server** |
-| Hosted chat | [chat.yambr.com](https://chat.yambr.com) | Managed Open WebUI with Computer Use pre-wired (models included) |
-| Artifact host | `https://cu.yambr.com` | Sandbox file/preview URLs (the URL itself is the access token) |
+| Dashboard | [app.yambr.com](https://app.yambr.com) | Sign in (GitHub / Google), manage keys, spend |
+| MCP endpoint | `https://api.yambr.com/mcp/computer_use` | Public Streamable-HTTP MCP — tools only |
+| Hosted chat | [chat.yambr.com](https://chat.yambr.com) | Open WebUI with Computer Use pre-wired, models included |
+| Artifact host | `https://cu.yambr.com` | Sandbox file/preview URLs |
 
-> Yambr publishes one public surface: the Computer Use MCP endpoint. Model inference stays on your own provider — **you bring your own model provider, Yambr doesn't resell inference**.
+Yambr publishes the MCP tool endpoint; it is **not** an LLM gateway. On `api.yambr.com` you bring your own model provider. On `chat.yambr.com` models are bundled as a free convenience.
 
-## Two hosted paths
+## Which path?
 
-The cloud gives you two clearly distinct options. Pick based on whether you want models included or not.
+- **Just want to try it?** Open [chat.yambr.com](https://chat.yambr.com), sign in with GitHub or Google.
+- **Want to plug Computer Use into your own agent?** Get a key from [app.yambr.com](https://app.yambr.com), point your MCP client at `https://api.yambr.com/mcp/computer_use` with a `Bearer` header. Client-specific configs (Claude Desktop, OpenAI Agents SDK, n8n, LiteLLM, curl) live under [docs.yambr.com/integrations](https://docs.yambr.com).
+- **Want full control / air-gap / heavy use?** See [INSTALL.md](INSTALL.md).
 
-### Path A — `chat.yambr.com` (free end-to-end demo)
-
-Managed Open WebUI with Computer Use pre-installed globally. Yambr pays for the LLM models too, as a convenience for browser users. Zero setup.
-
-1. Open [chat.yambr.com](https://chat.yambr.com)
-2. Sign in with GitHub or Google (no email/password, no SMS)
-3. Pick a model from the dropdown, start chatting
-
-Drag files into chat input — they're mounted at `/home/assistant/uploads/{chat_id}/` inside the sandbox. Artifacts auto-render. Large tool results stream without truncation. Per-chat sandbox isolation (different chats = separate containers).
-
-### Path B — `api.yambr.com/mcp/computer_use` (tools only, bring your own LLM)
-
-A public MCP endpoint you point any agent/MCP client at. Your LLM traffic goes to *your* provider (OpenAI, Anthropic, OpenRouter…); your Yambr key unlocks the Computer Use sandbox, nothing else.
-
-**Issue a key:**
-
-1. Sign in at [app.yambr.com](https://app.yambr.com) via GitHub or Google (no email + password flow)
-2. Request access — approvals are a light manual review ("we eyeball requests and approve most of them quickly"). Urgent? Ping [@yambrcom](https://t.me/yambrcom) on Telegram
-3. Once approved, create a key from the dashboard. The full key `sk-yambr-...` is shown **once** — store it in a secret manager immediately. After that the dashboard only shows `sk-...{last-4}`
-4. Default budget: **$10 / 30 days rolling**. Up to 5 keys per account. Max 5 concurrent requests per key — `429` on exhaustion of either cap. Reissue rotates the key but keeps the budget and alias slot
-
-> Treat Yambr keys like database passwords: never commit them to git, never ship them to a browser, rotate on exposure.
-
-## Client configs
-
-Every config below targets `https://api.yambr.com/mcp/computer_use`. The `X-Chat-Id` header identifies the sandbox — **keep it stable for a persistent sandbox; rotate it to start fresh**.
-
-### Claude Desktop
-
-File path:
-- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
-
-```json
-{
-  "mcpServers": {
-    "yambr-computer-use": {
-      "url": "https://api.yambr.com/mcp/computer_use",
-      "transport": "streamable-http",
-      "headers": {
-        "Authorization": "Bearer sk-yambr-...",
-        "X-Chat-Id": "claude-desktop"
-      }
-    }
-  }
-}
-```
-
-Restart Claude Desktop after editing.
-
-### OpenAI Agents SDK (Python)
-
-```python
-import os
-from agents import Agent, Runner
-from agents.mcp import MCPServerStreamableHttp
-
-yambr_mcp = MCPServerStreamableHttp(
-    params={
-        "url": "https://api.yambr.com/mcp/computer_use",
-        "headers": {"Authorization": f"Bearer {os.environ['YAMBR_API_KEY']}"},
-    },
-    name="yambr-computer-use",
-)
-
-agent = Agent(
-    name="computer-user",
-    model="gpt-4o",
-    mcp_servers=[yambr_mcp],
-)
-
-result = await Runner.run(agent, "Build me a landing page for a coffee shop")
-print(result.final_output)
-```
-
-### n8n
-
-Add an **MCP Tool** node → URL `https://api.yambr.com/mcp/computer_use`, auth `Bearer sk-yambr-...`, extra header `X-Chat-Id: {{ $json.chat_id }}`.
-
-### Plain curl
-
-```bash
-curl -sD - -X POST "https://api.yambr.com/mcp/computer_use" \
-  -H "Authorization: Bearer sk-yambr-..." \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "X-Chat-Id: my-session" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"my-client","version":"1.0"}}}'
-```
-
-> A bare `GET https://api.yambr.com/mcp/computer_use` returns `500` — that's expected, MCP requires `POST` + the headers above. Not a service outage.
-
-### Open WebUI
-
-If you want the hosted Computer Use tools inside your *own* Open WebUI: either use **[chat.yambr.com](https://chat.yambr.com)** (already wired up, models included) or **self-host** the full stack via [INSTALL.md](INSTALL.md). Pointing a third-party Open WebUI at `api.yambr.com` isn't a documented path today.
-
-## Pricing & limits (at a glance)
-
-| What | Value |
-|------|-------|
-| Sign-in providers | GitHub, Google (no email + password, no SMS) |
-| Default budget per key | $10 / 30-day rolling window |
-| Keys per account | Up to 5 |
-| Concurrent requests per key | 5 (429 on overflow) |
-| Budget exhaustion | 429 until the rolling window resets |
-| Key visibility after creation | `sk-...{last-4}` only — full key shown once |
-| Key rotation | Reissue keeps budget + alias; old value 401s immediately |
-
-Budgets, model lists, and approval flow are the authoritative truth on [app.yambr.com](https://app.yambr.com) and [docs.yambr.com](https://docs.yambr.com) — numbers here can drift.
+A bare `GET https://api.yambr.com/mcp/computer_use` returns `500` — that's expected, the endpoint requires `POST` with MCP headers. Not a service outage.
 
 ## See also
 
-- [docs.yambr.com](https://docs.yambr.com) — full cloud docs: platform overview, access model, API keys, dashboard tour, per-integration guides
-- [docs.yambr.com/platform/access-model](https://docs.yambr.com/platform/access-model) — which surfaces are public vs convenience
-- [docs.yambr.com/quickstart](https://docs.yambr.com/quickstart) — the three starting paths in one page
-- [INSTALL.md](INSTALL.md) — self-host Quick Start
+- [docs.yambr.com/quickstart](https://docs.yambr.com/quickstart) — the three starting paths, with copy-paste snippets
+- [docs.yambr.com/platform/overview](https://docs.yambr.com/platform/overview) — how the four services fit together
+- [docs.yambr.com/platform/api-keys](https://docs.yambr.com/platform/api-keys) — keys, budgets, rotation
 - [MCP.md](MCP.md) — MCP protocol reference (applies to both hosted and self-hosted)

--- a/docs/CLOUD.md
+++ b/docs/CLOUD.md
@@ -16,7 +16,7 @@ Yambr publishes the MCP tool endpoint; it is **not** an LLM gateway. On `api.yam
 ## Which path?
 
 - **Just want to try it?** Open [chat.yambr.com](https://chat.yambr.com), sign in with GitHub or Google.
-- **Want to plug Computer Use into your own agent?** Get a key from [app.yambr.com](https://app.yambr.com), point your MCP client at `https://api.yambr.com/mcp/computer_use` with a `Bearer` header. Client-specific configs (Claude Desktop, OpenAI Agents SDK, n8n, LiteLLM, curl) live under [docs.yambr.com/integrations](https://docs.yambr.com).
+- **Want to plug Computer Use into your own agent?** Get a key from [app.yambr.com](https://app.yambr.com), point your MCP client at `https://api.yambr.com/mcp/computer_use` with a `Bearer` header. Per-client configs (Claude Desktop, OpenAI Agents SDK, n8n, LiteLLM, curl) live on [docs.yambr.com](https://docs.yambr.com) under the Integrations section.
 - **Want full control / air-gap / heavy use?** See [INSTALL.md](INSTALL.md).
 
 A bare `GET https://api.yambr.com/mcp/computer_use` returns `500` — that's expected, the endpoint requires `POST` with MCP headers. Not a service outage.

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -11,6 +11,7 @@ Claude.ai and OpenAI Operator are cloud-only, not self-hosted — we drew inspir
 | Feature | Open Computer Use | [open-terminal](https://github.com/open-webui/open-terminal) | Claude.ai | OpenAI Operator |
 |---------|-------------------|---------------|-----------|-----------------|
 | **Self-hosted** | Yes | Yes | No | No |
+| **Managed SaaS option** | Yes — [yambr.com](https://yambr.com) (free demo at [chat.yambr.com](https://chat.yambr.com), hosted MCP at `api.yambr.com/mcp/computer_use`) | No | Yes (claude.ai) | Yes (operator) |
 | **Any LLM** | Yes (OpenAI-compatible) | Any (via Open WebUI) | Claude only | GPT only |
 | **Code execution** | Full Linux sandbox | Sandbox / bare metal | Sandbox | No |
 | **Live browser** | CDP streaming (shared, interactive) | No | Screenshot-based | Screenshot-based |

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,5 +1,7 @@
 # Installation Guide
 
+This guide is for **self-hosting**. For the managed version (GitHub/Google sign-in, no Docker), see [CLOUD.md](CLOUD.md) or try [chat.yambr.com](https://chat.yambr.com) directly.
+
 ## Prerequisites
 
 - **Docker Engine** 24+ with Docker Compose v2

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -14,7 +14,7 @@ Authorization: Bearer <YAMBR_API_KEY>
 X-Chat-Id: <session-id>
 ```
 
-Request a key at [app.yambr.com](https://app.yambr.com) (GitHub or Google sign-in). You bring your own model provider — Yambr doesn't resell inference. Full walkthrough with Claude Desktop / OpenAI Agents SDK / n8n configs: [CLOUD.md](CLOUD.md). Canonical cloud docs: [docs.yambr.com](https://docs.yambr.com).
+Request a key at [app.yambr.com](https://app.yambr.com) (GitHub or Google sign-in). You bring your own model provider — Yambr doesn't resell inference. Per-client configs (Claude Desktop, OpenAI Agents SDK, n8n, LiteLLM) live on [docs.yambr.com](https://docs.yambr.com); repo-side orientation in [CLOUD.md](CLOUD.md).
 
 The rest of this document covers **self-hosting** the same MCP server.
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -4,6 +4,20 @@ The Computer Use Server exposes a standard [MCP (Model Context Protocol)](https:
 
 This server is published in the [MCP Registry](https://github.com/modelcontextprotocol/registry) as `io.github.yambr/open-computer-use`.
 
+## Hosted endpoint (managed)
+
+Skip the self-host deployment and point any MCP client at the managed endpoint:
+
+```
+POST https://api.yambr.com/mcp/computer_use
+Authorization: Bearer <YAMBR_API_KEY>
+X-Chat-Id: <session-id>
+```
+
+Request a key at [app.yambr.com](https://app.yambr.com) (GitHub or Google sign-in). You bring your own model provider — Yambr doesn't resell inference. Full walkthrough with Claude Desktop / OpenAI Agents SDK / n8n configs: [CLOUD.md](CLOUD.md). Canonical cloud docs: [docs.yambr.com](https://docs.yambr.com).
+
+The rest of this document covers **self-hosting** the same MCP server.
+
 ## Deployment Prerequisite
 
 This is a **self-hosted** MCP server. You must deploy it before connecting:

--- a/openwebui/README.md
+++ b/openwebui/README.md
@@ -2,6 +2,8 @@
 
 Everything needed to connect [Open WebUI](https://github.com/open-webui/open-webui) to [Open Computer Use](https://github.com/Yambr/open-computer-use). Works with stock Open WebUI — no fork required.
 
+> Just want to try it? [chat.yambr.com](https://chat.yambr.com) is a ready-to-use Open WebUI with Computer Use already wired in (GitHub/Google sign-in, models included). This directory is for embedding Computer Use into **your own** Open WebUI stack.
+
 ## Components
 
 | # | Component | Type | Required | What it does |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced managed cloud hosting option with free demo access at `chat.yambr.com`
  * Added hosted MCP endpoint for tools-only integration
  * Clarified self-hosted vs. managed service deployment options
  * Added configuration guides for multiple client integrations (Claude Desktop, n8n, OpenAI Agents SDK)
  * Updated comparison documentation to highlight new SaaS offering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->