### PR TITLE
docs: restore Yambr cloud sections removed in v0.9.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 MCP server that gives any LLM its own computer — managed Docker workspaces with live browser, terminal, code execution, document skills, and autonomous sub-agents. Self-hosted, open-source, pluggable into any model.
 
+> **Online demo:** **[chat.yambr.com](https://chat.yambr.com)** — Open WebUI with Computer Use already set up, sign in with GitHub or Google. ([More ways to try it](#ways-to-try-it) below.)
+
 ![Demo: AI reads GitHub README and creates a landing page](docs/demo-landing-page.gif)
 
 ## What is this?
@@ -61,6 +63,16 @@ See [docs/FEATURES.md](docs/FEATURES.md) for architecture details and [docs/SCRE
 ## Architecture
 
 ![Architecture](docs/architecture.svg)
+
+## Ways to try it
+
+| Path | URL | What you need | Best for |
+|------|-----|---------------|----------|
+| **Free online demo** — Open WebUI + Computer Use, models included | **[chat.yambr.com](https://chat.yambr.com)** | GitHub or Google sign-in | Trying it end-to-end in 30 seconds |
+| **Hosted MCP endpoint** — tools only, bring your own LLM | Key at [app.yambr.com](https://app.yambr.com) → connect to `https://api.yambr.com/mcp/computer_use` | GitHub/Google sign-in; your own OpenAI / Anthropic / OpenRouter key | Plugging Computer Use into Claude Desktop, n8n, OpenAI Agents SDK |
+| **Self-host** | [Quick Start](#quick-start) below | Docker, ~15 min first build | Full control, air-gapped, heavy use |
+
+OAuth only — no email/password, no SMS. On `chat.yambr.com` models are bundled as a free convenience; the hosted API is tools-only. Canonical cloud docs: [docs.yambr.com](https://docs.yambr.com). Repo-side orientation: [docs/CLOUD.md](docs/CLOUD.md).
 
 ## Quick Start
 
@@ -135,17 +147,17 @@ See [docs/SKILLS.md](docs/SKILLS.md) for details.
 
 ## MCP Integration
 
-The server speaks standard MCP over Streamable HTTP. Connect it to anything:
+The server speaks standard MCP over Streamable HTTP. Point any MCP client at it — hosted or self-hosted.
 
-```bash
-# Test with curl
-curl -X POST http://localhost:8081/mcp \
-  -H "Content-Type: application/json" \
-  -H "X-Chat-Id: test" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
-```
-
-See [docs/MCP.md](docs/MCP.md) for full integration guide (LiteLLM, Claude Desktop, custom clients). The per-chat system prompt rides **six redundant MCP-native channels** (tool descriptions, `/home/assistant/README.md` in the sandbox, `InitializeResult.instructions`, `resources/list` for uploaded files, plus an HTTP `/system-prompt` endpoint for legacy integrations) — full map in [docs/system-prompt.md](docs/system-prompt.md).
+- **Hosted**: `https://api.yambr.com/mcp/computer_use` with `Authorization: Bearer <key from app.yambr.com>`. Client configs and full reference live on [docs.yambr.com](https://docs.yambr.com).
+- **Self-hosted**: `http://localhost:8081/mcp`. Quick sanity check:
+  ```bash
+  curl -X POST http://localhost:8081/mcp \
+    -H "Content-Type: application/json" \
+    -H "X-Chat-Id: test" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+  ```
+  Full self-host integration guide (LiteLLM, Claude Desktop, custom clients): [docs/MCP.md](docs/MCP.md). The per-chat system prompt rides **six redundant MCP-native channels** (tool descriptions, `/home/assistant/README.md` in the sandbox, `InitializeResult.instructions`, `resources/list` for uploaded files, plus an HTTP `/system-prompt` endpoint for legacy integrations) — full map in [docs/system-prompt.md](docs/system-prompt.md).
 
 ## Configuration
 
@@ -178,13 +190,13 @@ By default, all 13 built-in skills are available to everyone. For per-user skill
 
 The Computer Use Server speaks standard **MCP over Streamable HTTP** — any MCP-compatible client can connect. Open WebUI is the primary tested frontend, but not the only option.
 
-| Client | How to connect | Status |
-|--------|---------------|--------|
-| [**Open WebUI**](https://github.com/open-webui/open-webui) | Docker Compose stack included, auto-configured | Tested in production |
-| [**Claude Desktop**](https://claude.ai/download) | Add to `claude_desktop_config.json` — see [docs/MCP.md](docs/MCP.md) | Works |
-| [**n8n**](https://n8n.io) | MCP Tool node → `http://computer-use-server:8081/mcp` | Works |
-| [**LiteLLM**](https://github.com/BerriAI/litellm) | MCP proxy config — see [docs/MCP.md](docs/MCP.md) | Works |
-| **Custom client** | Any HTTP client with MCP JSON-RPC — see curl examples in [docs/MCP.md](docs/MCP.md) | Works |
+| Client | Self-hosted URL | Hosted URL | Status |
+|--------|-----------------|------------|--------|
+| [**Open WebUI**](https://github.com/open-webui/open-webui) | Docker Compose stack included, auto-configured | n/a — use [chat.yambr.com](https://chat.yambr.com) directly (pointing your own Open WebUI at the hosted API isn't a documented path) | Tested in production |
+| [**Claude Desktop**](https://claude.ai/download) | `http://localhost:8081/mcp` — see [docs/MCP.md](docs/MCP.md) | `https://api.yambr.com/mcp/computer_use` — see [docs/CLOUD.md](docs/CLOUD.md) | Works |
+| [**n8n**](https://n8n.io) | MCP Tool node → `http://computer-use-server:8081/mcp` | MCP Tool node → `https://api.yambr.com/mcp/computer_use` | Works |
+| [**LiteLLM**](https://github.com/BerriAI/litellm) | MCP proxy config — see [docs/MCP.md](docs/MCP.md) | MCP proxy → `https://api.yambr.com/mcp/computer_use` | Works |
+| **Custom client** | Any HTTP client with MCP JSON-RPC — see curl examples in [docs/MCP.md](docs/MCP.md) | Same, with `Authorization: Bearer sk-...` (key from [app.yambr.com](https://app.yambr.com)) | Works |
 
 ## Open WebUI Integration
 
@@ -462,6 +474,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). PRs welcome!
 
 ## Community
 
+- **Managed hosting**: [yambr.com](https://yambr.com) — cloud version by the maintainers ([chat.yambr.com](https://chat.yambr.com) for the free demo, [app.yambr.com](https://app.yambr.com) for API keys, [docs.yambr.com](https://docs.yambr.com) for the cloud docs)
 - **Issues & Ideas**: [GitHub Issues](https://github.com/Yambr/open-computer-use/issues)
 - **Telegram**: [@yambrcom](https://t.me/yambrcom)
 


### PR DESCRIPTION
## Summary

The v0.9.2.0 release PR (#73) accidentally removed the Yambr cloud / hosted-MCP narrative from README.md. The deletions happened in cleanup commits (\`9897ecf\` and \`867a169\`) that restructured embedding instructions and version-pinning prose — and the cloud sections got swept along.

This restores them verbatim from PR #67 (commit \`117620e\`).

## Restored

- README:13 — \"Online demo\" banner pointing to chat.yambr.com
- README:67-75 — \"## Ways to try it\" table (Free demo / Hosted MCP / Self-host)
- README:148-160 — \"## MCP Integration\" lead with Hosted vs Self-hosted split
- README:189-199 — \"## MCP Client Integrations\" table with Hosted URL column
- README:477 — \"Managed hosting\" bullet in Community section

## Not restored (correctly removed in v0.9.2.0)

- \`bn.set/Jr.set\` verification snippets (replaced by FIX_ARTIFACTS_AUTO_SHOW marker)
- \`COMPUTER_USE_SERVER_URL\` build-arg references (build-arg removed; patch is host-agnostic)
- \"Three URL settings\" section (now two URL roles)
- v0.8.11-0.8.12 compatibility range (strict-pin to v0.9.2)

## Test plan

- [x] \`grep -c \"yambr.com\" README.md\` → 11 (matches pre-#73 state)
- [x] All 4 sections (banner, Ways to try, MCP Integration, Clients table) render correctly with the restored markdown
- [x] No conflicts with the v0.9.2.0 strict-pin language (yambr cloud refs are orthogonal to Open WebUI base versioning)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added online demo banner and "Ways to try it" guidance
  * Clarified OAuth-only access requirements
  * Updated MCP integration section with hosted vs self-hosted endpoint details and authorization methods
  * Updated Open WebUI instructions to reference hosted chat instance
  * Added community entry for managed hosting options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->