### PR TITLE
fix(opencode): add OPENCODE_CONFIG_EXTRA to passthrough allowlist

### DIFF
--- a/computer-use-server/docker_manager.py
+++ b/computer-use-server/docker_manager.py
@@ -130,6 +130,13 @@ OPENCODE_PASSTHROUGH_ENVS = (
     ("OPENAI_API_KEY", os.getenv("OPENAI_API_KEY", "")),
     ("ANTHROPIC_API_KEY", os.getenv("ANTHROPIC_API_KEY", "")),
     ("OPENCODE_MODEL", os.getenv("OPENCODE_MODEL", "")),
+    # Operator-supplied OpenCode config override (see docs/cli-config-templates.md
+    # "OpenCode — custom OpenAI-compat provider" recipe). Allows routing the
+    # opencode sub-agent through a self-hosted gateway (LiteLLM, OpenLLM, etc.)
+    # for proxy-only deployments. Without this entry the override never crosses
+    # the orchestrator → sandbox boundary and the entrypoint heredoc falls
+    # through to the canonical 3-provider default. Closes #77.
+    ("OPENCODE_CONFIG_EXTRA", os.getenv("OPENCODE_CONFIG_EXTRA", "")),
 )
 
 # Sub-agent CLI runtime selector (CLI-01, CLI-02). Read once at module load


### PR DESCRIPTION
## Summary

- Adds `OPENCODE_CONFIG_EXTRA` to `OPENCODE_PASSTHROUGH_ENVS` in `computer-use-server/docker_manager.py` so the operator override actually crosses the orchestrator → workspace-sandbox boundary.
- Without this, the documented "OpenCode — custom OpenAI-compat provider" recipe in `docs/cli-config-templates.md` cannot work in v0.9.2.2: the var is set on the host, but `_create_container` filters it out, so the entrypoint heredoc inside the sandbox falls through to the canonical 3-provider default and dials `https://openrouter.ai/api/v1` directly.
- Closes #77 (full reproducer + root cause analysis there).

## Why

Self-hosted deployments with a proxy-only invariant (LiteLLM, OpenLLM, etc.) for spend attribution / budget enforcement / no-direct-egress can't route opencode sub-agent traffic through their gateway without forking. This unblocks the documented configuration path.

## Test plan

- [ ] Build image from this branch
- [ ] On host: set `SUBAGENT_CLI=opencode`, `OPENAI_API_KEY=<gateway-key>`, `OPENCODE_CONFIG_EXTRA='{ "provider": { "litellm": { ... "options": { "baseURL": "http://litellm:4000/v1" } } }, "model": "litellm/<model>" }'`, `OPENCODE_SUB_AGENT_DEFAULT_MODEL=litellm/<model>`
- [ ] `docker compose up -d --force-recreate computer-use-server`
- [ ] Trigger any sub-agent invocation
- [ ] Inside the spawned sandbox: `printenv | grep OPENCODE_CONFIG_EXTRA` returns the JSON (was empty before this PR)
- [ ] `cat /tmp/opencode.json` renders the operator's `litellm` provider (was canonical 3-provider default before this PR)
- [ ] Gateway logs show the sub-agent traffic (was bypassed before this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OpenCode configuration overrides are now properly propagated to containerized sandbox environments, allowing operators to apply custom configurations during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->