### PR TITLE
fix: pass OPENCODE_CONFIG_EXTRA and CODEX_CONFIG_EXTRA to sandbox containers (closes #77)

### DIFF
--- a/computer-use-server/docker_manager.py
+++ b/computer-use-server/docker_manager.py
@@ -120,6 +120,7 @@ CODEX_PASSTHROUGH_ENVS = (
     ("AZURE_OPENAI_API_KEY", os.getenv("AZURE_OPENAI_API_KEY", "")),
     ("AZURE_OPENAI_ENDPOINT", os.getenv("AZURE_OPENAI_ENDPOINT", "")),
     ("AZURE_OPENAI_API_VERSION", os.getenv("AZURE_OPENAI_API_VERSION", "")),
+    ("CODEX_CONFIG_EXTRA", os.getenv("CODEX_CONFIG_EXTRA", "")),
 )
 
 # OpenCode passthrough envs (Phase 6 — only injected when SUBAGENT_CLI=opencode).
@@ -130,6 +131,7 @@ OPENCODE_PASSTHROUGH_ENVS = (
     ("OPENAI_API_KEY", os.getenv("OPENAI_API_KEY", "")),
     ("ANTHROPIC_API_KEY", os.getenv("ANTHROPIC_API_KEY", "")),
     ("OPENCODE_MODEL", os.getenv("OPENCODE_MODEL", "")),
+    ("OPENCODE_CONFIG_EXTRA", os.getenv("OPENCODE_CONFIG_EXTRA", "")),
 )
 
 # Sub-agent CLI runtime selector (CLI-01, CLI-02). Read once at module load

--- a/computer-use-server/docker_manager.py
+++ b/computer-use-server/docker_manager.py
@@ -120,6 +120,12 @@ CODEX_PASSTHROUGH_ENVS = (
     ("AZURE_OPENAI_API_KEY", os.getenv("AZURE_OPENAI_API_KEY", "")),
     ("AZURE_OPENAI_ENDPOINT", os.getenv("AZURE_OPENAI_ENDPOINT", "")),
     ("AZURE_OPENAI_API_VERSION", os.getenv("AZURE_OPENAI_API_VERSION", "")),
+    # Operator-supplied codex config override (see docs/cli-config-templates.md
+    # "Codex — custom OpenAI-compat gateway" recipe). Appended to the canonical
+    # ~/.codex/config.toml block by the Dockerfile entrypoint when set, so
+    # operators can route codex through a self-hosted gateway without forking.
+    # Without this entry the override never crosses the orchestrator → sandbox
+    # boundary. Same gap as #77; included here for codex parity.
     ("CODEX_CONFIG_EXTRA", os.getenv("CODEX_CONFIG_EXTRA", "")),
 )
 
@@ -131,6 +137,13 @@ OPENCODE_PASSTHROUGH_ENVS = (
     ("OPENAI_API_KEY", os.getenv("OPENAI_API_KEY", "")),
     ("ANTHROPIC_API_KEY", os.getenv("ANTHROPIC_API_KEY", "")),
     ("OPENCODE_MODEL", os.getenv("OPENCODE_MODEL", "")),
+    # Operator-supplied OpenCode config override (see docs/cli-config-templates.md
+    # "OpenCode — custom OpenAI-compat provider" recipe). Replaces /tmp/opencode.json
+    # verbatim when set, so operators can route the opencode sub-agent through a
+    # self-hosted gateway (LiteLLM, OpenLLM, etc.) for proxy-only deployments.
+    # Without this entry the override never crosses the orchestrator → sandbox
+    # boundary and the entrypoint heredoc falls through to the canonical
+    # 3-provider default. Closes #77.
     ("OPENCODE_CONFIG_EXTRA", os.getenv("OPENCODE_CONFIG_EXTRA", "")),
 )
 

--- a/tests/orchestrator/test_passthrough_isolation.py
+++ b/tests/orchestrator/test_passthrough_isolation.py
@@ -82,6 +82,8 @@ def _clear_phase6_auth_env():
         "AZURE_OPENAI_API_KEY",
         "AZURE_OPENAI_ENDPOINT",
         "AZURE_OPENAI_API_VERSION",
+        "CODEX_CONFIG_EXTRA",
+        "OPENCODE_CONFIG_EXTRA",
         "SUBAGENT_CLI",
     ):
         os.environ.pop(key, None)
@@ -93,19 +95,19 @@ def _clear_phase6_auth_env():
         (
             "claude",
             {"ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL"},
-            {"OPENAI_API_KEY", "OPENROUTER_API_KEY", "OPENAI_BASE_URL", "OPENCODE_CONFIG"},
+            {"OPENAI_API_KEY", "OPENROUTER_API_KEY", "OPENAI_BASE_URL", "OPENCODE_CONFIG", "OPENCODE_CONFIG_EXTRA", "CODEX_CONFIG_EXTRA"},
             None,  # OPENCODE_CONFIG must NOT be set for non-opencode runtimes
         ),
         (
             "codex",
-            {"OPENAI_API_KEY", "OPENAI_BASE_URL"},
-            {"ANTHROPIC_AUTH_TOKEN", "OPENROUTER_API_KEY", "OPENCODE_CONFIG"},
+            {"OPENAI_API_KEY", "OPENAI_BASE_URL", "CODEX_CONFIG_EXTRA"},
+            {"ANTHROPIC_AUTH_TOKEN", "OPENROUTER_API_KEY", "OPENCODE_CONFIG", "OPENCODE_CONFIG_EXTRA"},
             None,
         ),
         (
             "opencode",
-            {"OPENROUTER_API_KEY", "OPENAI_API_KEY"},
-            {"ANTHROPIC_AUTH_TOKEN"},
+            {"OPENROUTER_API_KEY", "OPENAI_API_KEY", "OPENCODE_CONFIG_EXTRA"},
+            {"ANTHROPIC_AUTH_TOKEN", "CODEX_CONFIG_EXTRA"},
             "/tmp/opencode.json",  # Plan 06-01 Edit 1c — ROADMAP success #2
         ),
     ],
@@ -128,6 +130,8 @@ def test_passthrough_isolation(
         "OPENAI_API_KEY": "sk-oai-stub",
         "OPENAI_BASE_URL": "https://gateway.example",
         "OPENROUTER_API_KEY": "sk-or-stub",
+        "OPENCODE_CONFIG_EXTRA": '{"stub":"opencode"}',
+        "CODEX_CONFIG_EXTRA": "[stub-codex]",
     }
 
     with patch.dict(os.environ, {}, clear=False):


### PR DESCRIPTION
## Summary

- Adds `OPENCODE_CONFIG_EXTRA` to `OPENCODE_PASSTHROUGH_ENVS` and `CODEX_CONFIG_EXTRA` to `CODEX_PASSTHROUGH_ENVS` in `computer-use-server/docker_manager.py`, so the orchestrator passes operator-supplied config overrides into spawned sandbox containers.
- Extends `tests/orchestrator/test_passthrough_isolation.py` to lock in the new allowlist entries and the per-CLI isolation contract (Pitfall 1): claude forbids both, codex expects only `CODEX_CONFIG_EXTRA`, opencode expects only `OPENCODE_CONFIG_EXTRA`.

## Why

Per issue #77: the Dockerfile entrypoint (line 428–449) already consumes `OPENCODE_CONFIG_EXTRA` to render `/tmp/opencode.json` from operator-supplied JSON, and `docs/cli-config-templates.md` documents this as the supported override surface for proxy-only routing (LiteLLM, OpenLLM, etc.). But the var was missing from the orchestrator's per-CLI passthrough allowlist, so it never crossed the orchestrator → sandbox boundary — operators could not route opencode through a self-hosted gateway without a local source patch. Same gap applied to `CODEX_CONFIG_EXTRA`.

This PR is a 2-line allowlist addition; no version bump, no docs changes (docs were already correct — this makes the code match).

## Test plan

- [x] `pytest tests/orchestrator/test_passthrough_isolation.py -v` — 3 parametrize cases pass
- [x] `pytest tests/orchestrator/test_docker_manager.py -v` — 10 module-load tests, no regression
- [ ] E2E (optional, matches issue #77 reproducer): rebuild image with `--platform linux/amd64`, set `OPENCODE_CONFIG_EXTRA` in `.env`, recreate `computer-use-server`, confirm `docker exec <sandbox> printenv | grep OPENCODE_CONFIG_EXTRA` is non-empty and `/tmp/opencode.json` reflects the operator override.

Closes #77.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Environment variables `CODEX_CONFIG_EXTRA` and `OPENCODE_CONFIG_EXTRA` can now be passed through to their respective runtimes.

* **Tests**
  * Enhanced test coverage for environment variable isolation in container environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->