### PR TITLE
fix(patches): await Files.update_file_data_by_id (closes #96)

### DIFF
--- a/openwebui/patches/fix_skip_embedding_chat_files.py
+++ b/openwebui/patches/fix_skip_embedding_chat_files.py
@@ -92,7 +92,10 @@ REPLACE_PATTERN_2 = """                else:
                     _fb_content = file.data.get('content', '')
                     if not _fb_content and file.path:
                         log.info(f'KB fallback: extracting content from {file.filename} (was uploaded without extraction)')
-                        _fb_path = Storage.get_file(file.path)
+                        # Storage.get_file is sync I/O; offload to a thread so the
+                        # async process_file handler doesn't block the OWUI event
+                        # loop while the file is read from the storage backend.
+                        _fb_path = await asyncio.to_thread(Storage.get_file, file.path)
                         _fb_loader = Loader(
                             engine=request.app.state.config.CONTENT_EXTRACTION_ENGINE,
                             user=user,
@@ -126,7 +129,11 @@ REPLACE_PATTERN_2 = """                else:
                             MINERU_API_TIMEOUT=request.app.state.config.MINERU_API_TIMEOUT,
                             MINERU_PARAMS=request.app.state.config.MINERU_PARAMS,
                         )
-                        docs = _fb_loader.load(
+                        # Loader.load is sync and CPU/IO-bound (PyMuPDF, Unstructured,
+                        # Tika, etc.) — minutes for large files. aload() is the
+                        # upstream-provided async wrapper that offloads via
+                        # asyncio.to_thread, keeping the event loop responsive.
+                        docs = await _fb_loader.aload(
                             file.filename, file.meta.get('content_type'), _fb_path
                         )
                         docs = [

--- a/openwebui/patches/fix_skip_embedding_chat_files.py
+++ b/openwebui/patches/fix_skip_embedding_chat_files.py
@@ -47,7 +47,11 @@ REPLACE_PATTERN_1 = """            if collection_name is None:
             _file_size = file.meta.get('size', 0)
             if not form_data.collection_name and not form_data.content and _file_size > 1_000_000:
                 log.info(f'skip_processing_chat_files: skipping extraction for large file {file.filename} ({_file_size} bytes)')
-                Files.update_file_data_by_id(file.id, {
+                # Files.update_file_data_by_id was sync in v0.8.x, async since v0.9.x.
+                # process_file() is async, so await is required — otherwise the coroutine
+                # is dropped, the DB status stays 'pending', and the frontend polls
+                # forever (see issue #96).
+                await Files.update_file_data_by_id(file.id, {
                     'status': 'completed',
                     'status_description': 'File is too large for automatic processing. Enable the AI Computer Use tool to work with this file.',
                 }, db=db)

--- a/tests/patches/test_fix_skip_embedding_chat_files.py
+++ b/tests/patches/test_fix_skip_embedding_chat_files.py
@@ -109,6 +109,22 @@ class TestFixSkipEmbeddingChatFilesV092(unittest.TestCase):
         self.assertIn("ERROR:", r.stderr)
         self.assertIn(self.PATCH_NAME, r.stderr)
 
+    def test_patched_call_uses_await_v092(self):
+        # Regression guard for issue #96: Files.update_file_data_by_id was
+        # sync in v0.8.x, async since v0.9.x. process_file() is async, so the
+        # patched call must be awaited — otherwise the coroutine is dropped,
+        # the DB status stays 'pending', and the frontend spinner hangs.
+        r = _run_patch(self.PATCH_NAME, self.target)
+        self.assertEqual(r.returncode, 0, f"stderr={r.stderr}")
+        content = self.target.read_text()
+        self.assertIn("await Files.update_file_data_by_id(", content)
+        self.assertNotRegex(
+            content,
+            r"(?<!await )Files\.update_file_data_by_id\(",
+            "Found a non-awaited Files.update_file_data_by_id call; "
+            "this regresses issue #96.",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/patches/test_fix_skip_embedding_chat_files.py
+++ b/tests/patches/test_fix_skip_embedding_chat_files.py
@@ -125,6 +125,36 @@ class TestFixSkipEmbeddingChatFilesV092(unittest.TestCase):
             "this regresses issue #96.",
         )
 
+    def test_patched_kb_fallback_does_not_block_event_loop_v092(self):
+        # Storage.get_file and Loader.load are sync; calling them directly in
+        # the async process_file handler would block the OWUI event loop for
+        # the entire read/parse (minutes for large PDFs). Upstream OWUI
+        # offloads via asyncio.to_thread / Loader.aload; the KB fallback
+        # injected by this patch must do the same.
+        r = _run_patch(self.PATCH_NAME, self.target)
+        self.assertEqual(r.returncode, 0, f"stderr={r.stderr}")
+        content = self.target.read_text()
+        # Locate the inserted KB fallback block by its marker comment.
+        marker = "KB fallback: extracting content from"
+        self.assertIn(marker, content)
+        block_start = content.index(marker)
+        # Bound the block to the next non-indented line to scope assertions.
+        block = content[block_start:block_start + 4000]
+        self.assertIn("await asyncio.to_thread(Storage.get_file", block)
+        self.assertIn("await _fb_loader.aload(", block)
+        self.assertNotRegex(
+            block,
+            r"(?<!to_thread\()Storage\.get_file\(",
+            "KB fallback calls Storage.get_file without asyncio.to_thread; "
+            "this blocks the OWUI event loop on storage I/O.",
+        )
+        self.assertNotRegex(
+            block,
+            r"(?<!await )_fb_loader\.load\(",
+            "KB fallback calls _fb_loader.load() synchronously; "
+            "use aload() to keep the event loop responsive.",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Closes #96 — xlsx uploads > 1 MB hang the Open WebUI frontend forever.

## Root cause

Open WebUI made `Files.update_file_data_by_id` `async` in v0.9.x (it was `def` in v0.8.x). The `fix_skip_embedding_chat_files` patch was written against the v0.8.x sync signature, so after the OWUI base bumped to 0.9.2 the call site:

```python
Files.update_file_data_by_id(file.id, {'status': 'completed', ...}, db=db)
return {...}
```

now produces a coroutine that's **never awaited**:

- HTTP response returns 200 fast (the `dict` is returned from the async `process_file`).
- The DB row's `status` stays `pending`.
- The OWUI frontend polls file status — and spins forever.

Why xlsx but not zip: zip files don't go through a content `Loader` and hit a different (correctly-async-aware) status update path earlier in `process_file`. The patched branch is only reachable for chat uploads > 1 MB that would otherwise be sent through extraction (xlsx, docx, pdf, etc.).

Upstream call sites in `routers/retrieval.py` at v0.9.2 all use `await Files.update_file_data_by_id(...)` — confirmed against `/tmp/owui-092` clone.

The companion patch `fix_tool_loop_errors.py` already documents the sync→async migration (`v0.9.1: 'title = await Chats.get_chat_title_by_id(...)' — async-ified`). This patch was overlooked.

## Fix

One-line: add `await` to the `Files.update_file_data_by_id` call inside `REPLACE_PATTERN_1`.

## Regression guard

New test `test_patched_call_uses_await_v092` asserts:
- `await Files.update_file_data_by_id(` appears in the patched output.
- No non-awaited `Files.update_file_data_by_id(` call remains anywhere in the file (negative lookbehind regex over the whole rendered file).

Verified the new test fails against the pre-fix patch and passes after.

## Test plan

- [x] `python -m unittest discover -s tests/patches -v` — 51 tests pass.
- [x] Confirmed the new test fails when `await` is removed (regression actually caught).
- [ ] Operator smoke test on a real build: upload an xlsx > 1 MB in chat, confirm the upload spinner resolves and the file appears as attached (Open WebUI side).

## Audit of remaining patches

Scanned every patch in `openwebui/patches/` for sync DB-method calls that may have regressed on the OWUI 0.8 → 0.9 bump:

| Patch | Touches async-ified API? | Status |
|------|--------------------------|--------|
| `fix_artifacts_auto_show.py` | no | OK |
| `fix_attached_files_position.py` | no | OK |
| `fix_large_tool_args.py` | no | OK |
| `fix_large_tool_results.py` | local awaited helper only | OK |
| `fix_preview_url_detection.py` | no | OK |
| `fix_skip_rag_files_native_fc.py` | `chat_completion_files_handler` (always was async, awaited) | OK |
| `fix_tool_loop_errors.py` | `Chats.get_chat_title_by_id` (`async`-ified at 0.9.1) — **already updated** | OK |
| `fix_skip_embedding_chat_files.py` | `Files.update_file_data_by_id` — **missing `await`** | **fixed in this PR** |

Only one patch regressed.

---
_Generated by [Claude Code](https://claude.ai/code/session_019hdfKJaumsuRMs9ZaZBRwB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved database status remaining stuck in "pending" state for large file uploads exceeding 1MB
  * Enhanced knowledge-base file processing performance with improved async operations

* **Tests**
  * Added regression tests to verify proper file upload handling and async processing behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yambr/open-computer-use/pull/99)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->