### PR TITLE
chore: migrate repo references from Yambr to Wide-Moat org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,7 @@ Build proof: `open-computer-use:0.9.2-test` built from the full production `open
 
 ### Features — Claude Code gateway compatibility rollup (Phase 3, GATEWAY-01..12)
 
-Phase 3 code shipped on `main` on 2026-04-12 (commit `38347fd`) but never had its own release — it is cut here. Fixes issue [#40](https://github.com/Yambr/open-computer-use/issues/40); inspired by PR [#41](https://github.com/Yambr/open-computer-use/pull/41), rewritten with tests and without deploy-specific churn. Full operator guide in [docs/claude-code-gateway.md](docs/claude-code-gateway.md).
+Phase 3 code shipped on `main` on 2026-04-12 (commit `38347fd`) but never had its own release — it is cut here. Fixes issue [#40](https://github.com/Wide-Moat/open-computer-use/issues/40); inspired by PR [#41](https://github.com/Wide-Moat/open-computer-use/pull/41), rewritten with tests and without deploy-specific churn. Full operator guide in [docs/claude-code-gateway.md](docs/claude-code-gateway.md).
 
 - **GATEWAY-01** — Root-cause bug fix. `computer-use-server/context_vars.py:14` `current_anthropic_base_url` default changed from `"https://api.anthropic.com/"` to `None`, restoring the `or ANTHROPIC_BASE_URL` env fallback at `docker_manager.py:359`. Previously the truthy default blocked every env override silently.
 - **GATEWAY-02** — Ten module-level env constants added to `docker_manager.py` (captured at import time via `os.getenv(NAME, "")`): `ANTHROPIC_MODEL`, `ANTHROPIC_DEFAULT_{SONNET,OPUS,HAIKU}_MODEL`, `CLAUDE_CODE_SUBAGENT_MODEL`, `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS`, `DISABLE_PROMPT_CACHING{,_SONNET,_OPUS,_HAIKU}`. Organised into model-IDs and compat-flags sub-groups.
@@ -282,7 +282,7 @@ production *or* in the upgrade story:
 ### Privacy / packaging
 - `.planning/` gitignored on the public GitHub remote; pre-push hook enforces the rule.
 - Internal-fork references scrubbed; `tests/test-no-corporate.sh` extended to catch regressions.
-- MCP Registry: added project logo, fixed `server.json` schema, simplified manifest for publication as `io.github.yambr/open-computer-use`.
+- MCP Registry: added project logo, fixed `server.json` schema, simplified manifest for publication as `io.github.Wide-Moat/open-computer-use`.
 
 ### Code removed
 - Filter's hardcoded ~460-line prompt f-string.
@@ -296,7 +296,7 @@ production *or* in the upgrade story:
   - Not set (default): lenient — uses shared container + warning in tool response and server logs
   - `true`: single-user — one container, no headers needed (recommended for Claude Desktop)
   - `false`: strict multi-user — `X-Chat-Id` required, error if missing
-- **MCP Registry manifest** (`server.json`): published as `io.github.yambr/open-computer-use`
+- **MCP Registry manifest** (`server.json`): published as `io.github.Wide-Moat/open-computer-use`
 - **Dynamic config endpoints**: documented `/system-prompt`, `/skill-list`, `/mcp-info` in docs/MCP.md
 - **System prompt reference**: new `docs/system-prompt.md` with prompt structure documentation
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Open Computer Use
 
-[![Build](https://github.com/Yambr/open-computer-use/actions/workflows/build.yml/badge.svg)](https://github.com/Yambr/open-computer-use/actions/workflows/build.yml)
-[![CodeQL](https://github.com/Yambr/open-computer-use/actions/workflows/codeql.yml/badge.svg)](https://github.com/Yambr/open-computer-use/actions/workflows/codeql.yml)
-[![Release](https://img.shields.io/github/v/release/Yambr/open-computer-use)](https://github.com/Yambr/open-computer-use/releases)
+[![Build](https://github.com/Wide-Moat/open-computer-use/actions/workflows/build.yml/badge.svg)](https://github.com/Wide-Moat/open-computer-use/actions/workflows/build.yml)
+[![CodeQL](https://github.com/Wide-Moat/open-computer-use/actions/workflows/codeql.yml/badge.svg)](https://github.com/Wide-Moat/open-computer-use/actions/workflows/codeql.yml)
+[![Release](https://img.shields.io/github/v/release/Wide-Moat/open-computer-use)](https://github.com/Wide-Moat/open-computer-use/releases)
 [![License](https://img.shields.io/badge/license-BSL%201.1-blue)](LICENSE)
-[![Stars](https://img.shields.io/github/stars/Yambr/open-computer-use)](https://github.com/Yambr/open-computer-use/stargazers)
-[![Issues](https://img.shields.io/github/issues/Yambr/open-computer-use)](https://github.com/Yambr/open-computer-use/issues)
+[![Stars](https://img.shields.io/github/stars/Wide-Moat/open-computer-use)](https://github.com/Wide-Moat/open-computer-use/stargazers)
+[![Issues](https://img.shields.io/github/issues/Wide-Moat/open-computer-use)](https://github.com/Wide-Moat/open-computer-use/issues)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/Yambr/open-computer-use?utm_source=oss&utm_medium=github&utm_campaign=Yambr%2Fopen-computer-use&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://coderabbit.ai)
+[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/Wide-Moat/open-computer-use?utm_source=oss&utm_medium=github&utm_campaign=Wide-Moat%2Fopen-computer-use&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://coderabbit.ai)
 
 MCP server that gives any LLM its own computer — managed Docker workspaces with live browser, terminal, code execution, document skills, and autonomous sub-agents. Self-hosted, open-source, pluggable into any model.
 
@@ -102,7 +102,7 @@ OAuth only — no email/password, no SMS. On `chat.yambr.com` models are bundled
 ## Quick Start
 
 ```bash
-git clone https://github.com/Yambr/open-computer-use.git
+git clone https://github.com/Wide-Moat/open-computer-use.git
 cd open-computer-use
 cp .env.example .env
 # Edit .env — set OPENAI_API_KEY (or any OpenAI-compatible provider)
@@ -209,7 +209,7 @@ All settings via `.env`:
 
 By default, all 13 built-in skills are available to everyone. For per-user skill access and custom skills, deploy the **Settings Wrapper** — see [settings-wrapper/README.md](settings-wrapper/README.md).
 
-**Personal Access Tokens (PATs):** The settings wrapper can also store encrypted per-user PATs for external services (GitLab, Confluence, Jira, etc.). The server fetches them by user email and injects into the sandbox — so each user's AI has access to their repos/docs without sharing credentials. The server-side code for token injection is implemented (`docker_manager.py`), but the Open WebUI tool doesn't pass the required headers yet. This is on the roadmap — if you need PAT management, [open an issue](https://github.com/Yambr/open-computer-use/issues).
+**Personal Access Tokens (PATs):** The settings wrapper can also store encrypted per-user PATs for external services (GitLab, Confluence, Jira, etc.). The server fetches them by user email and injects into the sandbox — so each user's AI has access to their repos/docs without sharing credentials. The server-side code for token injection is implemented (`docker_manager.py`), but the Open WebUI tool doesn't pass the required headers yet. This is on the roadmap — if you need PAT management, [open an issue](https://github.com/Wide-Moat/open-computer-use/issues).
 
 ## MCP Client Integrations
 
@@ -476,7 +476,7 @@ We plan to address these in future releases:
 - [ ] **Secret management** — move credentials from headers to encrypted server-side storage
 - [ ] **gVisor (runsc) runtime** — optional container sandboxing for stronger isolation (like Claude.ai)
 
-Ideas? Open a [GitHub Issue](https://github.com/Yambr/open-computer-use/issues). Want to contribute? See [CONTRIBUTING.md](CONTRIBUTING.md) or reach out on Telegram [@yambrcom](https://t.me/yambrcom).
+Ideas? Open a [GitHub Issue](https://github.com/Wide-Moat/open-computer-use/issues). Want to contribute? See [CONTRIBUTING.md](CONTRIBUTING.md) or reach out on Telegram [@yambrcom](https://t.me/yambrcom).
 
 ## Development
 
@@ -500,7 +500,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). PRs welcome!
 ## Community
 
 - **Managed hosting**: [yambr.com](https://yambr.com) — cloud version by the maintainers ([chat.yambr.com](https://chat.yambr.com) for the free demo, [app.yambr.com](https://app.yambr.com) for API keys, [docs.yambr.com](https://docs.yambr.com) for the cloud docs)
-- **Issues & Ideas**: [GitHub Issues](https://github.com/Yambr/open-computer-use/issues)
+- **Issues & Ideas**: [GitHub Issues](https://github.com/Wide-Moat/open-computer-use/issues)
 - **Telegram**: [@yambrcom](https://t.me/yambrcom)
 
 ## License

--- a/computer-use-server/docker_manager.py
+++ b/computer-use-server/docker_manager.py
@@ -199,7 +199,7 @@ def warn_if_public_base_url_is_default() -> bool:
             "reachable from inside the compose network — the Open WebUI preview "
             "panel will never appear until you set it to a browser-reachable URL.\n"
             "  Fix: in .env, set PUBLIC_BASE_URL=http://<browser-reachable-host>:8081.\n"
-            "  Docs: https://github.com/Yambr/open-computer-use/blob/main/docs/openwebui-filter.md"
+            "  Docs: https://github.com/Wide-Moat/open-computer-use/blob/main/docs/openwebui-filter.md"
         )
         return True
     return False

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -2,7 +2,7 @@
 
 Both projects are self-hosted and give LLMs a place to run code. They solve the same core problem with two fundamentally different architectural approaches — both for the technical stack and for the AI/user interaction model. This is not a "which is better" document; it's a map of trade-offs to help you pick the right tool for your use case.
 
-> **Note:** We respect the open-terminal team and their work. If you spot any inaccuracies in this comparison, please [open an issue](https://github.com/Yambr/open-computer-use/issues) — we want this to be fair and factual.
+> **Note:** We respect the open-terminal team and their work. If you spot any inaccuracies in this comparison, please [open an issue](https://github.com/Wide-Moat/open-computer-use/issues) — we want this to be fair and factual.
 
 Claude.ai and OpenAI Operator are cloud-only, not self-hosted — we drew inspiration from them, but a detailed comparison isn't useful here. See the overview table for a quick reference.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -11,7 +11,7 @@ This guide is for **self-hosting**. For the managed version (GitHub/Google sign-
 ## Quick Start
 
 ```bash
-git clone https://github.com/Yambr/open-computer-use.git
+git clone https://github.com/Wide-Moat/open-computer-use.git
 cd open-computer-use
 cp .env.example .env
 # Edit .env — see the REQUIRED section at the top of .env.example.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -2,7 +2,7 @@
 
 The Computer Use Server exposes a standard [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) endpoint that works with any MCP-compatible client.
 
-This server is published in the [MCP Registry](https://github.com/modelcontextprotocol/registry) as `io.github.yambr/open-computer-use`.
+This server is published in the [MCP Registry](https://github.com/modelcontextprotocol/registry) as `io.github.Wide-Moat/open-computer-use`.
 
 ## Hosted endpoint (managed)
 
@@ -23,7 +23,7 @@ The rest of this document covers **self-hosting** the same MCP server.
 This is a **self-hosted** MCP server. You must deploy it before connecting:
 
 ```bash
-git clone https://github.com/yambr/open-computer-use.git
+git clone https://github.com/Wide-Moat/open-computer-use.git
 cd open-computer-use
 docker build --platform linux/amd64 -t open-computer-use:latest .
 docker compose up -d

--- a/docs/SKILLS-USER-GUIDE.md
+++ b/docs/SKILLS-USER-GUIDE.md
@@ -77,7 +77,7 @@ In our production setup, we built a **skill registry** (settings-wrapper) where:
 
 For community use, we provide a [mock settings-wrapper](../settings-wrapper/README.md) with the API contract. All 13 public skills work out of the box without it.
 
-**Want a public skill management tool?** We'd love to build one that works with your setup. Open a [GitHub Issue](https://github.com/Yambr/open-computer-use/issues) and tell us what you use (LiteLLM, Open WebUI standalone, Claude Desktop, etc.) — this helps us prioritize.
+**Want a public skill management tool?** We'd love to build one that works with your setup. Open a [GitHub Issue](https://github.com/Wide-Moat/open-computer-use/issues) and tell us what you use (LiteLLM, Open WebUI standalone, Claude Desktop, etc.) — this helps us prioritize.
 
 ## Related Docs
 

--- a/docs/claude-code-gateway.md
+++ b/docs/claude-code-gateway.md
@@ -144,7 +144,7 @@ Two checks, in order:
    editing `.env`. `docker compose up -d` does not pick up `.env` changes
    on already-running services without `--force-recreate` or `down`/`up`.
 2. Confirm you are on a version with the Phase 3 `context_vars.py` fix
-   (<https://github.com/Yambr/open-computer-use/issues/40>). Earlier
+   (<https://github.com/Wide-Moat/open-computer-use/issues/40>). Earlier
    versions had a ContextVar default of `"https://api.anthropic.com/"`
    that short-circuited the `or os.environ["ANTHROPIC_BASE_URL"]` fallback
    in `docker_manager`. Symptom: the sandbox received

--- a/openwebui/README.md
+++ b/openwebui/README.md
@@ -1,6 +1,6 @@
 # Open WebUI Integration
 
-Everything needed to connect [Open WebUI](https://github.com/open-webui/open-webui) to [Open Computer Use](https://github.com/Yambr/open-computer-use). Works with stock Open WebUI — no fork required.
+Everything needed to connect [Open WebUI](https://github.com/open-webui/open-webui) to [Open Computer Use](https://github.com/Wide-Moat/open-computer-use). Works with stock Open WebUI — no fork required.
 
 > Just want to try it? [chat.yambr.com](https://chat.yambr.com) is a ready-to-use Open WebUI with Computer Use already wired in (GitHub/Google sign-in, models included). This directory is for embedding Computer Use into **your own** Open WebUI stack.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-computer-use",
-  "mcpName": "io.github.yambr/open-computer-use",
+  "mcpName": "io.github.Wide-Moat/open-computer-use",
   "version": "1.0.0",
   "description": "Open Computer Use - Node.js Dependencies",
   "license": "BUSL-1.1",

--- a/server.json
+++ b/server.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.Yambr/open-computer-use",
+  "name": "io.github.Wide-Moat/open-computer-use",
   "title": "Open Computer Use",
   "version": "0.8.12.6",
   "description": "Give any LLM its own computer — Docker sandboxes with bash, browser, docs, and sub-agents",
-  "websiteUrl": "https://github.com/Yambr/open-computer-use",
+  "websiteUrl": "https://github.com/Wide-Moat/open-computer-use",
   "repository": {
-    "url": "https://github.com/Yambr/open-computer-use",
+    "url": "https://github.com/Wide-Moat/open-computer-use",
     "source": "github",
-    "id": "Yambr/open-computer-use"
+    "id": "Wide-Moat/open-computer-use"
   }
 }


### PR DESCRIPTION
## Summary

Repo moved from `github.com/Yambr/open-computer-use` to `github.com/Wide-Moat/open-computer-use` on 2026-05-16. GitHub auto-redirects old URLs, but in-repo canonical refs should point to the new org.

**Changed (11 files, 26 lines):**

- `README.md` — Build / CodeQL / Release / Stars / Issues / CodeRabbit badges + clone URL + issue links
- `server.json`, `package.json` — MCP Registry manifest (`io.github.Wide-Moat/open-computer-use`)
- `CHANGELOG.md` — historical PR/issue links + manifest references
- `docs/{INSTALL,COMPARISON,SKILLS-USER-GUIDE,claude-code-gateway,MCP}.md` — clone URLs, issue links
- `openwebui/README.md` — repo link
- `computer-use-server/docker_manager.py:202` — error-hint URL pointing at docs/openwebui-filter.md

**NOT touched:** SaaS brand domain `yambr.com` (chat.yambr.com, api.yambr.com, app.yambr.com, docs.yambr.com, t.me/yambrcom). Only the GitHub org path differs — the brand stays.

## Test plan

- [ ] CI "Test" status check passes
- [ ] `tests/test-no-corporate.sh` green (no Yambr GitHub refs remain)
- [ ] After merge: README badges render under the new org URL

## Post-merge manual steps

1. Republish MCP Registry under new ID `io.github.Wide-Moat/open-computer-use` (registry doesn't follow GitHub repo moves).
2. Check CodeRabbit / any external integrations for hardcoded `Yambr/` org refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository URLs, GitHub issue tracker links, installation commands, and CI/release badges across all documentation files, installation guides, and integration documentation to reflect the current project namespace and location.

* **Chores**
  * Updated server configuration identifiers and package metadata in configuration files to maintain consistency with repository changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wide-Moat/open-computer-use/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->