### PR TITLE
feat(helm): add Kubernetes Helm chart for computer-use-server

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,6 +138,44 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  build-cleanup:
+    name: Build Cleanup Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}-cleanup
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+            type=sha
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: ./cron
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   build-webui:
     name: Build Patched Open WebUI Image
     runs-on: ubuntu-latest

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -76,8 +76,10 @@ jobs:
           ! grep -q "runtimeClassName:" /tmp/render-runc.yaml
 
       - name: Install kubeconform and validate manifests against k8s schemas
+        env:
+          KUBECONFORM_VERSION: v0.6.7
         run: |
-          curl -sSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz \
+          curl -sSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
             | sudo tar -xz -C /usr/local/bin kubeconform
           kubeconform -strict -summary -kubernetes-version 1.30.0 /tmp/render-default.yaml
           kubeconform -strict -summary -kubernetes-version 1.30.0 /tmp/render-runc.yaml

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# Lints the Helm chart on every PR / push to main, and publishes versioned
+# tarballs to a "gh-pages" Helm repo on release tags. Users can then:
+#
+#   helm repo add open-computer-use https://wide-moat.github.io/open-computer-use
+#   helm repo update
+#   helm install ocu open-computer-use/computer-use-server
+#
+# Chart version (helm/computer-use-server/Chart.yaml `version:`) must be bumped
+# for chart-releaser to publish. `appVersion:` tracks the repo version.
+
+name: Helm chart
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+    paths:
+      - 'helm/**'
+      - 'examples/helm/**'
+      - '.github/workflows/helm.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'helm/**'
+      - 'examples/helm/**'
+      - '.github/workflows/helm.yml'
+
+jobs:
+  lint:
+    name: helm lint + template
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4   # Helm 3 LTS — chart-releaser-action does not yet ship a Helm 4 image
+                            # and Helm 3 lints/templates the chart identically for our purposes.
+
+      - name: helm lint (rejects missing required values)
+        run: |
+          set -e
+          # Should fail — schema requires either secrets.mcpApiKey or secrets.existingSecret.
+          if helm lint helm/computer-use-server 2>/dev/null; then
+            echo "BUG: helm lint should have failed with empty secrets" >&2
+            exit 1
+          fi
+          # Should pass with explicit override
+          helm lint helm/computer-use-server --set secrets.mcpApiKey=test
+          # Examples must lint cleanly
+          helm lint helm/computer-use-server -f examples/helm/standalone/values.yaml
+          helm lint helm/computer-use-server -f examples/helm/with-open-webui/values-computer-use.yaml
+
+      - name: helm template (default + privileged downgrade path)
+        run: |
+          set -e
+          # Default — Sysbox path
+          helm template ocu helm/computer-use-server \
+            -f examples/helm/standalone/values.yaml \
+            > /tmp/render-default.yaml
+          grep -q "runtimeClassName: sysbox-runc" /tmp/render-default.yaml
+          grep -q "privileged: false" /tmp/render-default.yaml
+          grep -q "name: orchestrator" /tmp/render-default.yaml
+          grep -q "name: dind" /tmp/render-default.yaml
+          grep -q "name: cleanup" /tmp/render-default.yaml
+          # Privileged downgrade
+          helm template ocu helm/computer-use-server \
+            --set secrets.mcpApiKey=t \
+            --set orchestrator.env.PUBLIC_BASE_URL=https://x \
+            --set orchestrator.runtimeClassName="" \
+            > /tmp/render-runc.yaml
+          grep -q "privileged: true" /tmp/render-runc.yaml
+          ! grep -q "runtimeClassName:" /tmp/render-runc.yaml
+
+      - name: Install kubeconform and validate manifests against k8s schemas
+        run: |
+          curl -sSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin kubeconform
+          kubeconform -strict -summary -kubernetes-version 1.30.0 /tmp/render-default.yaml
+          kubeconform -strict -summary -kubernetes-version 1.30.0 /tmp/render-runc.yaml
+
+  release:
+    name: Publish chart to gh-pages
+    needs: lint
+    runs-on: ubuntu-latest
+    # Only on release tags pushed to the repo (vX.Y.Z.W).
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+      pages: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # chart-releaser needs full history to detect tag bumps
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+
+      - uses: helm/chart-releaser-action@v1.7.0
+        with:
+          charts_dir: helm
+          mark_as_latest: true
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -48,8 +48,10 @@ jobs:
             echo "BUG: helm lint should have failed with empty secrets" >&2
             exit 1
           fi
-          # Should pass with explicit override
-          helm lint helm/computer-use-server --set secrets.mcpApiKey=test
+          # Should pass with all required keys set
+          helm lint helm/computer-use-server \
+            --set secrets.mcpApiKey=test \
+            --set orchestrator.env.PUBLIC_BASE_URL=https://x.example.com
           # Examples must lint cleanly
           helm lint helm/computer-use-server -f examples/helm/standalone/values.yaml
           helm lint helm/computer-use-server -f examples/helm/with-open-webui/values-computer-use.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,7 @@ POST.md
 # are operational noise for external contributors. History was rewritten to
 # remove .planning/ — do not commit it back here.
 .planning/
+
+# Helm — fetched dependencies live in charts/*.tgz and are reproducible from
+# Chart.lock via `helm dependency update`.
+helm/*/charts/*.tgz

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -1,0 +1,78 @@
+# Kubernetes deployment
+
+The Docker Compose stack in `docker-compose.yml` / `docker-compose.webui.yml` ships as a Helm chart in [`helm/computer-use-server/`](../helm/computer-use-server/). This is the recommended way to run open-computer-use on Kubernetes.
+
+## Quick start
+
+```bash
+# 1. Install Sysbox on your nodes once (https://github.com/nestybox/sysbox).
+#    Confirm the RuntimeClass exists:
+kubectl get runtimeclass sysbox-runc
+
+# 2. Add the chart repo (published from the gh-pages branch on every release tag):
+helm repo add open-computer-use https://wide-moat.github.io/open-computer-use
+helm repo update
+
+# 3. Install:
+helm install ocu open-computer-use/computer-use-server \
+  --namespace open-computer-use --create-namespace \
+  --values examples/helm/standalone/values.yaml
+```
+
+Or, against a git checkout for unreleased changes:
+
+```bash
+helm install ocu helm/computer-use-server \
+  --namespace open-computer-use --create-namespace \
+  --values examples/helm/standalone/values.yaml
+```
+
+The chart README at [`helm/computer-use-server/README.md`](../helm/computer-use-server/README.md) is the authoritative reference. This page is the navigation.
+
+## Examples
+
+- **[`examples/helm/standalone/`](../examples/helm/standalone/)** — minimum-viable config (just the orchestrator). Closest to `docker-compose.yml`.
+- **[`examples/helm/with-open-webui/`](../examples/helm/with-open-webui/)** — orchestrator + Open WebUI via the upstream Open WebUI Helm chart. Closest to `docker-compose.yml` + `docker-compose.webui.yml` together.
+
+## Architecture
+
+The orchestrator pod has three containers:
+
+```
+┌───────────────────────────────── Pod (runtimeClassName: sysbox-runc) ──────────┐
+│                                                                                 │
+│  ┌─────────────────┐   ┌─────────────────┐   ┌──────────────────────────────┐  │
+│  │  orchestrator   │──►│   inner dockerd │◄──│  cleanup sidecar (cron)      │  │
+│  │  FastAPI :8081  │   │  spawns chat-*  │   │  reaps stale chat-* + data   │  │
+│  └─────────────────┘   └─────────────────┘   └──────────────────────────────┘  │
+│        │ /var/run/docker.sock  ▲       ▲                  ▲                     │
+│        └──────── shared emptyDir (dind-socket) ───────────┘                     │
+│                                                                                 │
+│  Volumes:                                                                       │
+│   - emptyDir  dind-socket    → /var/run on all three containers                │
+│   - emptyDir  var-lib-docker → /var/lib/docker on dind ONLY (sysbox#406)       │
+│   - PVC       user-data      → /tmp/computer-use-data (RWO)                    │
+│   - PVC       data           → /data (RWO)                                     │
+│   - PVC       skills-cache   → /data/skills-cache (RWO)                        │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Why DinD-on-Sysbox instead of native k8s Pods?**
+The existing orchestrator code talks to a Docker socket. Lifting it onto Kubernetes via Sysbox keeps the app code unchanged. A future `K8sBackend` rewrite (drafted in [`docs/requirements/k8s-architecture.md`](requirements/k8s-architecture.md)) will spawn native Pods, at which point the inner dockerd disappears — but that's a separate workstream.
+
+**Why is the orchestrator single-replica?**
+It owns the inner Docker daemon and three RWO PVCs. There is no shared state between replicas and no leader-election. The chart hard-pins `replicas: 1` in `values.schema.json`.
+
+## Prerequisites checklist
+
+- Kubernetes ≥ 1.27
+- StorageClass that supports `ReadWriteOnce` and is the cluster default (or pass `persistence.*.storageClass` explicitly)
+- Sysbox installed on candidate nodes + matching `RuntimeClass`
+- Ingress controller (nginx-ingress, Traefik, etc.) if you set `ingress.enabled=true`
+- DNS + TLS cert for the public hostname referenced by `PUBLIC_BASE_URL`
+
+## See also
+
+- [`helm/computer-use-server/README.md`](../helm/computer-use-server/README.md) — chart reference and troubleshooting
+- [`docs/requirements/k8s-architecture.md`](requirements/k8s-architecture.md) — draft of the future native-Pod backend (not implemented)
+- [Sysbox docs](https://github.com/nestybox/sysbox/blob/master/docs/quickstart/install-k8s.md) — install Sysbox on a k8s cluster

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -38,7 +38,7 @@ The chart README at [`helm/computer-use-server/README.md`](../helm/computer-use-
 
 The orchestrator pod has three containers:
 
-```
+```text
 ┌───────────────────────────────── Pod (runtimeClassName: sysbox-runc) ──────────┐
 │                                                                                 │
 │  ┌─────────────────┐   ┌─────────────────┐   ┌──────────────────────────────┐  │

--- a/examples/helm/README.md
+++ b/examples/helm/README.md
@@ -1,0 +1,19 @@
+# Helm examples
+
+Two ready-to-tweak deployment recipes for [`helm/computer-use-server/`](../../helm/computer-use-server/).
+
+| Recipe | Equivalent Compose stack | When to use |
+|---|---|---|
+| [`standalone/`](standalone/) | `docker-compose.yml` | You already run Open WebUI (or some other MCP client) and just want the orchestrator. |
+| [`with-open-webui/`](with-open-webui/) | `docker-compose.yml` + `docker-compose.webui.yml` | You want the whole stack — orchestrator, Open WebUI, Postgres — in one cluster. |
+
+Open WebUI itself is **not** packaged by our chart. Use the upstream chart at <https://github.com/open-webui/helm-charts> instead — `with-open-webui/` shows how to wire the two together.
+
+## Prerequisites (both recipes)
+
+- Kubernetes ≥ 1.27, with [Sysbox](https://github.com/nestybox/sysbox) installed on candidate nodes
+- A StorageClass that supports `ReadWriteOnce`
+- An Ingress controller (nginx-ingress, Traefik, etc.)
+- DNS + TLS for the public hostnames
+
+See [`docs/kubernetes.md`](../../docs/kubernetes.md) for the full architecture overview.

--- a/examples/helm/standalone/values.yaml
+++ b/examples/helm/standalone/values.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# Minimum-viable values for computer-use-server.
+# Run:
+#   helm install ocu helm/computer-use-server \
+#     -n open-computer-use --create-namespace \
+#     -f examples/helm/standalone/values.yaml
+#
+# Replace the placeholders (change-me-*, *.example.com) before applying.
+
+secrets:
+  create: true
+  # `openssl rand -hex 32` is a fine source
+  mcpApiKey: "change-me-32-hex-chars"
+
+orchestrator:
+  env:
+    # MUST be the browser-reachable URL of the Ingress below (no trailing slash).
+    # The orchestrator bakes this into preview links it returns to chats.
+    PUBLIC_BASE_URL: "https://orchestrator.example.com"
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    # uncomment if using cert-manager
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: orchestrator.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - orchestrator.example.com
+      secretName: orchestrator-tls

--- a/examples/helm/with-open-webui/README.md
+++ b/examples/helm/with-open-webui/README.md
@@ -2,7 +2,7 @@
 
 This is the Kubernetes analog of running `docker-compose.yml` + `docker-compose.webui.yml` together. You install two Helm charts side-by-side in the same namespace and wire them through a shared Secret.
 
-```
+```text
 ┌──────────────────────── namespace: open-computer-use ──────────────────────────┐
 │                                                                                 │
 │  Users ── Ingress ──► Service: open-webui :3000                                │
@@ -72,7 +72,7 @@ kubectl -n open-computer-use get pods
   - Open WebUI reads it the same way, then `openwebui/init.sh` (or your manual setup) seeds it into the Tool and Filter Valves on first boot. **The values must match** — that's the whole reason for sharing one Secret.
 
 - **`ORCHESTRATOR_URL`** is the **in-cluster** URL Open WebUI uses to call the MCP endpoint:
-  ```
+  ```text
   http://ocu-computer-use-server.open-computer-use.svc.cluster.local:8081
   ```
   Set as a plain env var on the Open WebUI container — `values-open-webui.yaml` shows the line. Browsers never see this URL.

--- a/examples/helm/with-open-webui/README.md
+++ b/examples/helm/with-open-webui/README.md
@@ -1,0 +1,99 @@
+# Open WebUI + computer-use-server on Kubernetes
+
+This is the Kubernetes analog of running `docker-compose.yml` + `docker-compose.webui.yml` together. You install two Helm charts side-by-side in the same namespace and wire them through a shared Secret.
+
+```
+┌──────────────────────── namespace: open-computer-use ──────────────────────────┐
+│                                                                                 │
+│  Users ── Ingress ──► Service: open-webui :3000                                │
+│                              │                                                  │
+│                              │ HTTP (ORCHESTRATOR_URL, MCP_API_KEY)            │
+│                              ▼                                                  │
+│                  Service: ocu-computer-use-server :8081                         │
+│                  (Sysbox DinD pod, see helm/computer-use-server/README.md)      │
+│                              │                                                  │
+│                              ▼                                                  │
+│                  StatefulSet: postgres  (Bitnami subchart, or BYO)              │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Prerequisites
+
+The same prereqs as `standalone/`: Sysbox on nodes, RWO StorageClass, Ingress controller, DNS + TLS. Plus:
+
+- The upstream Open WebUI Helm repo configured:
+  ```bash
+  helm repo add open-webui https://helm.openwebui.com/
+  helm repo update
+  ```
+
+## Install steps
+
+```bash
+# 0. Create namespace
+kubectl create namespace open-computer-use
+
+# 1. Shared Secret used by both charts. MCP_API_KEY must match in both places.
+kubectl -n open-computer-use create secret generic ocu-shared \
+  --from-literal=MCP_API_KEY=$(openssl rand -hex 32) \
+  --from-literal=POSTGRES_PASSWORD=$(openssl rand -hex 24) \
+  --from-literal=WEBUI_SECRET_KEY=$(openssl rand -hex 32) \
+  --from-literal=ANTHROPIC_AUTH_TOKEN=sk-ant-...  # if using Anthropic
+
+# 2. Install Postgres as a separate release (this chart does NOT bundle it).
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo update
+helm install pg bitnami/postgresql \
+  -n open-computer-use \
+  --set auth.username=openwebui \
+  --set auth.database=openwebui \
+  --set auth.existingSecret=ocu-shared \
+  --set auth.secretKeys.userPasswordKey=POSTGRES_PASSWORD
+
+# 3. Install computer-use-server. Edit values-computer-use.yaml first.
+helm install ocu ../../../helm/computer-use-server \
+  -n open-computer-use \
+  -f values-computer-use.yaml
+
+# 4. Install Open WebUI. Edit values-open-webui.yaml first.
+helm install webui open-webui/open-webui \
+  -n open-computer-use \
+  -f values-open-webui.yaml
+
+# 5. Smoke-test
+helm test ocu -n open-computer-use
+kubectl -n open-computer-use get pods
+```
+
+## How the wiring works
+
+- **`MCP_API_KEY`** lives in the shared `ocu-shared` Secret.
+  - `computer-use-server` reads it via `secrets.existingSecret=ocu-shared` (mounted via `envFrom` onto the orchestrator container).
+  - Open WebUI reads it the same way, then `openwebui/init.sh` (or your manual setup) seeds it into the Tool and Filter Valves on first boot. **The values must match** — that's the whole reason for sharing one Secret.
+
+- **`ORCHESTRATOR_URL`** is the **in-cluster** URL Open WebUI uses to call the MCP endpoint:
+  ```
+  http://ocu-computer-use-server.open-computer-use.svc.cluster.local:8081
+  ```
+  Set as a plain env var on the Open WebUI container — `values-open-webui.yaml` shows the line. Browsers never see this URL.
+
+- **`PUBLIC_BASE_URL`** is the **browser-facing** URL of the orchestrator. The orchestrator returns it in the `X-Public-Base-URL` header, and the Open WebUI filter uses it to rewrite preview links in chat. It must match the public hostname users actually hit. Set in `values-computer-use.yaml`.
+
+> Note: the `openwebui/init.sh` script from this repo expects to run as the Open WebUI container's entrypoint wrapper. The upstream Open WebUI chart does **not** invoke it. Either build your own image (using `openwebui/Dockerfile` from this repo) and point the upstream chart at it via `image.repository`, or seed the Valves manually through the Admin UI on first boot. Both paths work — the init.sh path is more reproducible.
+
+## Files in this directory
+
+| File | Purpose |
+|---|---|
+| `values-computer-use.yaml` | values for our chart (orchestrator + DinD + cleanup) |
+| `values-open-webui.yaml` | values for upstream Open WebUI chart, pointed at our Service |
+
+## Uninstall
+
+```bash
+helm uninstall webui -n open-computer-use
+helm uninstall ocu   -n open-computer-use
+kubectl -n open-computer-use delete pvc -l app.kubernetes.io/instance=ocu
+kubectl -n open-computer-use delete pvc -l app.kubernetes.io/instance=webui
+kubectl -n open-computer-use delete secret ocu-shared
+```

--- a/examples/helm/with-open-webui/values-computer-use.yaml
+++ b/examples/helm/with-open-webui/values-computer-use.yaml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# Values for helm/computer-use-server when deployed alongside Open WebUI.
+# See examples/helm/with-open-webui/README.md for install order and Secret setup.
+
+secrets:
+  # GitOps-friendly: chart reads MCP_API_KEY + tokens from the existing Secret.
+  create: false
+  existingSecret: ocu-shared
+
+orchestrator:
+  env:
+    # Must match the host users hit in their browser — same as the Ingress below.
+    PUBLIC_BASE_URL: "https://orchestrator.example.com"
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: orchestrator.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - orchestrator.example.com
+      secretName: orchestrator-tls
+
+# Postgres lives in a separate release — see README.md, "Install steps", step 2.

--- a/examples/helm/with-open-webui/values-open-webui.yaml
+++ b/examples/helm/with-open-webui/values-open-webui.yaml
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# Values for the upstream open-webui/open-webui chart, configured to talk to
+# our computer-use-server. Reference: https://github.com/open-webui/helm-charts
+#
+# Adjust to match the upstream chart's actual value paths — this file targets
+# the typical layout (image.repository, extraEnvVars, envFrom, persistence,
+# ingress). Re-check after major chart upgrades.
+
+# Use a custom Open WebUI image built from openwebui/Dockerfile in this repo
+# (it patches Open WebUI and bundles init.sh which seeds the Computer Use
+# Tool + Filter Valves on first boot). Skip this and use stock Open WebUI if
+# you'll configure Valves through the Admin UI by hand.
+image:
+  # Built from openwebui/Dockerfile by .github/workflows/build.yml as "<repo>-webui".
+  repository: ghcr.io/wide-moat/open-computer-use-webui
+  tag: "0.9.2.4"
+  pullPolicy: IfNotPresent
+
+ingress:
+  enabled: true
+  class: nginx
+  host: webui.example.com
+  tls: true
+  existingSecret: webui-tls
+
+persistence:
+  enabled: true
+  size: 10Gi
+
+# Use the bundled Postgres from our chart (ocu-postgresql.*.svc.cluster.local).
+# DATABASE_URL is built from the shared Secret.
+databaseUrl: "postgresql://openwebui:$(POSTGRES_PASSWORD)@pg-postgresql.open-computer-use.svc.cluster.local:5432/openwebui"
+
+# Disable the chart's bundled DBs since we use the one from computer-use-server.
+postgresql:
+  enabled: false
+ollama:
+  enabled: false
+pipelines:
+  enabled: false
+
+# Plain env vars that the openwebui/init.sh script and the patched code read.
+extraEnvVars:
+  - name: ORCHESTRATOR_URL
+    value: "http://ocu-computer-use-server.open-computer-use.svc.cluster.local:8081"
+  - name: BYPASS_EMBEDDING_AND_RETRIEVAL
+    value: "true"
+  - name: RAG_EMBEDDING_MODEL_AUTO_UPDATE
+    value: "false"
+  - name: CHAT_RESPONSE_MAX_TOOL_CALL_RETRIES
+    value: "200"
+  - name: TOOL_RESULT_MAX_CHARS
+    value: "50000"
+  - name: TOOL_RESULT_PREVIEW_CHARS
+    value: "2000"
+  - name: ENABLE_OPENAI_API_SSL_VERIFY
+    value: "true"
+  - name: ADMIN_EMAIL
+    value: "admin@example.com"
+
+# MCP_API_KEY, POSTGRES_PASSWORD, WEBUI_SECRET_KEY, ANTHROPIC_AUTH_TOKEN come
+# from the shared Secret created out-of-band (see README).
+extraEnvFrom:
+  - secretRef:
+      name: ocu-shared

--- a/helm/computer-use-server/.helmignore
+++ b/helm/computer-use-server/.helmignore
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: BUSL-1.1
+# Patterns to ignore when packaging the chart.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.hg/
+.hgignore
+.svn/
+*.swp
+*.tmp
+*.orig
+*.bak
+.idea/
+.vscode/
+*.tgz

--- a/helm/computer-use-server/.helmignore
+++ b/helm/computer-use-server/.helmignore
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
 # Patterns to ignore when packaging the chart.
 .DS_Store
 .git/

--- a/helm/computer-use-server/Chart.yaml
+++ b/helm/computer-use-server/Chart.yaml
@@ -5,8 +5,8 @@ name: computer-use-server
 description: |
   Orchestrator for open-computer-use. Spawns disposable workspace
   containers via an inner Docker daemon (Sysbox DinD). Includes an
-  optional cleanup sidecar and an optional bundled Postgres for
-  Open WebUI deployments.
+  optional cleanup sidecar. Postgres is installed as a separate release
+  when needed; see examples/helm/with-open-webui/.
 type: application
 version: 0.1.0
 appVersion: "0.9.2.4"

--- a/helm/computer-use-server/Chart.yaml
+++ b/helm/computer-use-server/Chart.yaml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
+apiVersion: v2
+name: computer-use-server
+description: |
+  Orchestrator for open-computer-use. Spawns disposable workspace
+  containers via an inner Docker daemon (Sysbox DinD). Includes an
+  optional cleanup sidecar and an optional bundled Postgres for
+  Open WebUI deployments.
+type: application
+version: 0.1.0
+appVersion: "0.9.2.4"
+kubeVersion: ">=1.27.0-0"
+home: https://github.com/Wide-Moat/open-computer-use
+sources:
+  - https://github.com/Wide-Moat/open-computer-use
+keywords:
+  - computer-use
+  - mcp
+  - open-webui
+  - sandbox
+  - dind
+  - sysbox
+maintainers:
+  - name: Open Computer Use Contributors
+    url: https://github.com/Wide-Moat/open-computer-use
+annotations:
+  category: AI
+# Note: PostgreSQL is intentionally NOT a chart dependency. The orchestrator
+# itself does not need a database; only Open WebUI does. Install Postgres
+# separately (managed RDS, CloudNativePG, or `helm install pg bitnami/postgresql`)
+# and point Open WebUI at it via DATABASE_URL. See examples/helm/with-open-webui/.

--- a/helm/computer-use-server/README.md
+++ b/helm/computer-use-server/README.md
@@ -1,0 +1,170 @@
+# computer-use-server Helm chart
+
+Deploys the [open-computer-use](https://github.com/Wide-Moat/open-computer-use) orchestrator on Kubernetes. The pod runs the FastAPI MCP server, an inner Docker daemon (DinD), and an optional cleanup sidecar. Disposable workspace containers are spawned by the inner daemon — the same architecture as the Docker Compose stack, lifted onto Kubernetes via [Sysbox](https://github.com/nestybox/sysbox).
+
+Open WebUI is **not** packaged here. It has its own [official chart](https://github.com/open-webui/helm-charts) and most users already run it. See [`examples/helm/with-open-webui/`](../../examples/helm/with-open-webui/README.md) for the integration walkthrough.
+
+---
+
+## Prerequisites
+
+1. **Kubernetes ≥ 1.27** with a working CNI and a default StorageClass that supports `ReadWriteOnce`.
+2. **[Sysbox](https://github.com/nestybox/sysbox)** installed on every node that may schedule the orchestrator pod, with a matching `RuntimeClass` (default name: `sysbox-runc`). Sysbox lets the inner Docker daemon run **without** `privileged: true`. The chart still supports stock runc, but only as an explicit, documented downgrade.
+3. **`helm` ≥ 3.14** (Helm 4 also works).
+4. The orchestrator and workspace images published to a registry the cluster can pull from.
+
+> **Why Sysbox?** The orchestrator needs to spawn Docker containers inside its own pod (matches the existing app code, no rewrite). Sysbox is the only mainstream runtime that supports `dockerd` inside an unprivileged container. Without it, you fall back to `privileged: true`, which gives the inner daemon host-kernel access and trivially breaks pod isolation. Don't run that in production.
+
+---
+
+## Install
+
+### From the public Helm repo (after the first release tag is pushed)
+
+```bash
+helm repo add open-computer-use https://wide-moat.github.io/open-computer-use
+helm repo update
+helm install ocu open-computer-use/computer-use-server \
+  --namespace open-computer-use --create-namespace \
+  -f my-values.yaml
+```
+
+### From a git checkout (development / unreleased changes)
+
+```bash
+helm install ocu helm/computer-use-server \
+  --namespace open-computer-use --create-namespace \
+  --set secrets.mcpApiKey=$(openssl rand -hex 32) \
+  --set orchestrator.env.PUBLIC_BASE_URL=https://orchestrator.example.com \
+  --set ingress.enabled=true \
+  --set ingress.hosts[0].host=orchestrator.example.com \
+  --set ingress.hosts[0].paths[0].path=/ \
+  --set ingress.hosts[0].paths[0].pathType=Prefix
+```
+
+See [`examples/helm/standalone/values.yaml`](../../examples/helm/standalone/values.yaml) for a values-file version.
+
+After install:
+
+```bash
+helm test ocu -n open-computer-use   # runs a Pod that curls /health
+kubectl -n open-computer-use logs deployment/ocu-computer-use-server -c orchestrator
+```
+
+---
+
+## Values reference
+
+The full schema lives in [`values.yaml`](values.yaml). The knobs you most often need:
+
+| Key | Default | Notes |
+|---|---|---|
+| `image.repository` | `ghcr.io/wide-moat/open-computer-use-server` | orchestrator image |
+| `image.tag` | `.Chart.AppVersion` | override if pinning |
+| `workspaceImage.repository` | `ghcr.io/wide-moat/open-computer-use` | passed as `DOCKER_IMAGE` to the orchestrator; the inner dockerd pulls this on first chat |
+| `orchestrator.runtimeClassName` | `sysbox-runc` | set to `""` to drop to stock runc + privileged (UNSUPPORTED) |
+| `orchestrator.replicas` | `1` | **must stay 1** — single owner of inner dockerd and RWO PVCs |
+| `orchestrator.env.PUBLIC_BASE_URL` | `""` | **REQUIRED** — browser-facing URL (no trailing slash). Without it, chat file previews 404. |
+| `orchestrator.extraEnv` / `envFrom` | `[]` | inject `ANTHROPIC_*`, `VISION_*`, etc. from existing Secrets / ConfigMaps |
+| `secrets.create` | `true` | renders a Secret from `secrets.mcpApiKey` etc. (handy, bad for GitOps) |
+| `secrets.existingSecret` | `""` | when set, ignores `secrets.create` and uses your Secret via `envFrom`. Must include `MCP_API_KEY`. |
+| `secrets.mcpApiKey` | `""` | **REQUIRED** unless `existingSecret` is set |
+| `persistence.userData.size` | `20Gi` | `/tmp/computer-use-data` — uploads + outputs |
+| `persistence.data.size` | `5Gi` | `/data` — long-lived orchestrator state |
+| `persistence.skillsCache.size` | `2Gi` | `/data/skills-cache` |
+| `persistence.varLibDocker.sizeLimit` | `50Gi` | emptyDir for the inner `/var/lib/docker`. **Never** make this a PVC — see [nestybox/sysbox#406](https://github.com/nestybox/sysbox/issues/406). |
+| `cleanup.enabled` | `true` | runs the same crons as `docker-compose.yml` (`cron/cleanup.sh` + `cron/cleanup-quick.sh`) |
+| `cleanup.containerMaxAgeHours` | `24` | stop workspace containers older than this |
+| `cleanup.dataMaxAgeDays` | `7` | remove stale data dirs older than this |
+| `ingress.enabled` | `false` | standard Ingress template — `className`, `annotations`, `hosts`, `tls` |
+| `networkPolicy.enabled` | `false` | default-deny + allowed egress to public internet |
+| `podDisruptionBudget.enabled` | `false` | irrelevant at `replicas: 1` |
+
+---
+
+## Postgres
+
+The orchestrator itself does not use Postgres — only Open WebUI does. This chart intentionally does **not** bundle Postgres as a subchart, to keep `helm install` paths predictable (Helm 4 has several open bugs around `condition:` dependencies, see [helm/helm#13341](https://github.com/helm/helm/issues/13341)).
+
+If you need Postgres for an adjacent Open WebUI deployment, install it as a separate release. Example:
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm install pg bitnami/postgresql \
+  -n open-computer-use \
+  --set auth.username=openwebui \
+  --set auth.database=openwebui \
+  --set auth.existingSecret=ocu-shared
+```
+
+See [`examples/helm/with-open-webui/README.md`](../../examples/helm/with-open-webui/README.md) for the full walkthrough.
+
+---
+
+## Bring your own Secret (GitOps mode)
+
+Recommended for anything you check into git:
+
+```bash
+kubectl -n open-computer-use create secret generic ocu-server-creds \
+  --from-literal=MCP_API_KEY=$(openssl rand -hex 32) \
+  --from-literal=ANTHROPIC_AUTH_TOKEN=sk-ant-... \
+  --from-literal=VISION_API_KEY=...
+
+helm install ocu helm/computer-use-server \
+  --set secrets.create=false \
+  --set secrets.existingSecret=ocu-server-creds \
+  --set orchestrator.env.PUBLIC_BASE_URL=https://orchestrator.example.com
+```
+
+The Secret is mounted via `envFrom` — every key becomes an env var on the orchestrator container.
+
+---
+
+## Sysbox handling
+
+The chart couples `runtimeClassName` and `dind.securityContext.privileged`:
+
+| `orchestrator.runtimeClassName` | `dind` runs as | Supported? |
+|---|---|---|
+| `sysbox-runc` (default) | `privileged: false` | ✅ recommended |
+| (other RuntimeClass) | `privileged: false` | ⚠️ only if that runtime supports unprivileged DinD |
+| `""` (empty) | `privileged: true` on stock runc | ❌ unsupported, container-escape risk |
+
+When `runtimeClassName` is empty the chart prints a loud warning in `NOTES.txt` after install. The `privileged: true` flip is purely a "make it functional for testing" escape hatch — don't ship a production cluster that way.
+
+---
+
+## Troubleshooting
+
+**`unlinkat /etc/ld.so.cache: operation not permitted` in the dind container.**
+Sysbox issue #406 — you're sharing `/var/lib/docker` somewhere you shouldn't. Confirm `var-lib-docker` is its own `emptyDir`, mounted **only** into the `dind` container. Don't replace it with a PVC and don't bind it into the orchestrator.
+
+**Chat file preview links 404 from the browser.**
+`PUBLIC_BASE_URL` is wrong. It must be the URL the user's browser sees (same host as the Ingress), not the in-cluster service DNS. Update `orchestrator.env.PUBLIC_BASE_URL` and `helm upgrade`.
+
+**`pod has unbound immediate PersistentVolumeClaims`.**
+Your StorageClass doesn't support `ReadWriteOnce` or there is no default class. Set `persistence.<vol>.storageClass` explicitly or pre-create PVCs and reference them via `persistence.<vol>.existingClaim`.
+
+**Cleanup sidecar logs `Cannot connect to the Docker daemon`.**
+The dind container hasn't finished starting yet, or the shared `dind-socket` volume isn't mounted. Wait 30s — the cron only runs every 2 hours and on schedule, so brief startup gaps are harmless.
+
+**Workspace containers can't pull the workspace image.**
+The inner dockerd does the pull, not Kubernetes. The image must be reachable from inside the pod (public registry, or `imagePullSecrets` won't help — they apply only to outer kubelet pulls). For private registries, configure inner-dockerd auth via a custom dind image or `dockerd --insecure-registry` arg.
+
+---
+
+## Uninstall
+
+```bash
+helm uninstall ocu -n open-computer-use
+kubectl -n open-computer-use delete pvc -l app.kubernetes.io/instance=ocu
+```
+
+PVCs are not deleted by `helm uninstall` — remove them explicitly to free the storage.
+
+---
+
+## License
+
+BUSL-1.1, Copyright (c) 2025 Open Computer Use Contributors.

--- a/helm/computer-use-server/templates/NOTES.txt
+++ b/helm/computer-use-server/templates/NOTES.txt
@@ -1,0 +1,40 @@
+{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
+computer-use-server {{ .Chart.AppVersion }} has been deployed as release "{{ .Release.Name }}" in namespace "{{ .Release.Namespace }}".
+
+In-cluster URL:
+  http://{{ include "computer-use-server.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+Health check:
+  kubectl -n {{ .Release.Namespace }} run curl-test --rm -it --image=curlimages/curl --restart=Never -- \
+    curl -fsS http://{{ include "computer-use-server.fullname" . }}:{{ .Values.service.port }}/health
+
+{{- if .Values.ingress.enabled }}
+
+Ingress:
+  {{- range .Values.ingress.hosts }}
+  - {{ .host }}
+  {{- end }}
+  Remember: orchestrator.env.PUBLIC_BASE_URL must match the browser-reachable URL,
+  otherwise file preview links will 404.
+{{- end }}
+
+{{- if eq (default "" .Values.orchestrator.runtimeClassName) "" }}
+
+###############################################################################
+# WARNING: orchestrator.runtimeClassName is empty.                            #
+# The inner Docker daemon is running with privileged=true on stock runc.      #
+# This is UNSUPPORTED and a container-escape risk.                            #
+#                                                                             #
+# Install Sysbox: https://github.com/nestybox/sysbox                          #
+# Then set: --set orchestrator.runtimeClassName=sysbox-runc                   #
+###############################################################################
+{{- end }}
+
+{{- if eq (default "" .Values.orchestrator.env.PUBLIC_BASE_URL) "" }}
+
+NOTE: orchestrator.env.PUBLIC_BASE_URL is unset. File-preview links in chat
+will fall back to the in-cluster URL and won't work from a browser. Set it to
+the public URL the user's browser will see, e.g. https://orchestrator.example.com.
+{{- end }}
+
+Run `helm test {{ .Release.Name }} -n {{ .Release.Namespace }}` to verify /health.

--- a/helm/computer-use-server/templates/_helpers.tpl
+++ b/helm/computer-use-server/templates/_helpers.tpl
@@ -1,0 +1,94 @@
+{{/*
+SPDX-License-Identifier: BUSL-1.1
+Copyright (c) 2025 Open Computer Use Contributors
+*/}}
+
+{{/* Chart name. */}}
+{{- define "computer-use-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Fully qualified app name. */}}
+{{- define "computer-use-server.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Chart label "name-version". */}}
+{{- define "computer-use-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Common labels. */}}
+{{- define "computer-use-server.labels" -}}
+helm.sh/chart: {{ include "computer-use-server.chart" . }}
+{{ include "computer-use-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: open-computer-use
+{{- end -}}
+
+{{/* Selector labels (used by Service and Deployment). */}}
+{{- define "computer-use-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "computer-use-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/* ServiceAccount name. */}}
+{{- define "computer-use-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "computer-use-server.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Orchestrator image reference. */}}
+{{- define "computer-use-server.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/* Workspace image reference — passed to orchestrator as DOCKER_IMAGE env. */}}
+{{- define "computer-use-server.workspaceImage" -}}
+{{- $tag := default .Chart.AppVersion .Values.workspaceImage.tag -}}
+{{- printf "%s:%s" .Values.workspaceImage.repository $tag -}}
+{{- end -}}
+
+{{/* Cleanup sidecar image reference. */}}
+{{- define "computer-use-server.cleanupImage" -}}
+{{- $tag := default .Chart.AppVersion .Values.cleanup.image.tag -}}
+{{- printf "%s:%s" .Values.cleanup.image.repository $tag -}}
+{{- end -}}
+
+{{/* Secret name (chart-managed or external). */}}
+{{- define "computer-use-server.secretName" -}}
+{{- if .Values.secrets.existingSecret -}}
+{{- .Values.secrets.existingSecret -}}
+{{- else -}}
+{{- include "computer-use-server.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Whether the inner dind container must run privileged.
+true => stock runc (no Sysbox) — required for dockerd to start.
+false => sysbox-runc handles isolation; privileged stays off.
+*/}}
+{{- define "computer-use-server.dindPrivileged" -}}
+{{- if eq (default "" .Values.orchestrator.runtimeClassName) "" -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}

--- a/helm/computer-use-server/templates/configmap.yaml
+++ b/helm/computer-use-server/templates/configmap.yaml
@@ -1,0 +1,17 @@
+{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "computer-use-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "computer-use-server.labels" . | nindent 4 }}
+data:
+  DOCKER_IMAGE: {{ include "computer-use-server.workspaceImage" . | quote }}
+  {{- range $k, $v := .Values.orchestrator.env }}
+  {{- if ne $v "" }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+  {{- end }}
+  CLEANUP_CONTAINER_MAX_AGE_HOURS: {{ .Values.cleanup.containerMaxAgeHours | quote }}
+  CLEANUP_DATA_MAX_AGE_DAYS: {{ .Values.cleanup.dataMaxAgeDays | quote }}

--- a/helm/computer-use-server/templates/configmap.yaml
+++ b/helm/computer-use-server/templates/configmap.yaml
@@ -1,4 +1,5 @@
-{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
+# SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/computer-use-server/templates/deployment.yaml
+++ b/helm/computer-use-server/templates/deployment.yaml
@@ -1,0 +1,196 @@
+{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "computer-use-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "computer-use-server.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.orchestrator.replicas }}
+  # Recreate — the orchestrator owns RWO PVCs and an inner dockerd that cannot
+  # safely overlap with itself during rollout.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "computer-use-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "computer-use-server.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if and .Values.secrets.create (not .Values.secrets.existingSecret) }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "computer-use-server.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.orchestrator.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.orchestrator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.orchestrator.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.orchestrator.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        # Socket the orchestrator and cleanup sidecar use to talk to inner dockerd.
+        # Shared via emptyDir per the Sysbox sidecar pattern (sysbox docs + nestybox#406).
+        - name: dind-socket
+          emptyDir: {}
+        # /var/lib/docker for the inner dockerd. MUST be a dedicated emptyDir mounted
+        # only into the dind container — see nestybox/sysbox#406.
+        - name: var-lib-docker
+          emptyDir:
+            sizeLimit: {{ .Values.persistence.varLibDocker.sizeLimit }}
+        - name: user-data
+          {{- if .Values.persistence.userData.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.userData.existingClaim }}
+          {{- else }}
+          persistentVolumeClaim:
+            claimName: {{ include "computer-use-server.fullname" . }}-user-data
+          {{- end }}
+        - name: data
+          {{- if .Values.persistence.data.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.data.existingClaim }}
+          {{- else }}
+          persistentVolumeClaim:
+            claimName: {{ include "computer-use-server.fullname" . }}-data
+          {{- end }}
+        - name: skills-cache
+          {{- if .Values.persistence.skillsCache.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.skillsCache.existingClaim }}
+          {{- else }}
+          persistentVolumeClaim:
+            claimName: {{ include "computer-use-server.fullname" . }}-skills-cache
+          {{- end }}
+      containers:
+        # ---------------------------------------------------------------------
+        # 1) Orchestrator (FastAPI app)
+        # ---------------------------------------------------------------------
+        - name: orchestrator
+          image: {{ include "computer-use-server.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: mcp
+              containerPort: 8081
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "computer-use-server.fullname" . }}
+            - secretRef:
+                name: {{ include "computer-use-server.secretName" . }}
+            {{- with .Values.orchestrator.envFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.orchestrator.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: dind-socket
+              mountPath: /var/run
+            - name: user-data
+              mountPath: /tmp/computer-use-data
+            - name: data
+              mountPath: /data
+            - name: skills-cache
+              mountPath: /data/skills-cache
+          {{- if .Values.orchestrator.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: mcp
+            initialDelaySeconds: {{ .Values.orchestrator.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.orchestrator.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.orchestrator.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.orchestrator.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.orchestrator.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: mcp
+            initialDelaySeconds: {{ .Values.orchestrator.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.orchestrator.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.orchestrator.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.orchestrator.probes.liveness.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.orchestrator.resources | nindent 12 }}
+          {{- with .Values.orchestrator.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        # ---------------------------------------------------------------------
+        # 2) Inner Docker daemon (DinD)
+        # ---------------------------------------------------------------------
+        - name: dind
+          image: "{{ .Values.dind.image.repository }}:{{ .Values.dind.image.tag }}"
+          imagePullPolicy: {{ .Values.dind.image.pullPolicy }}
+          # Use the docker:dind entrypoint, but pin the socket location so the
+          # orchestrator (and the cleanup sidecar) can talk to it over the
+          # shared emptyDir at /var/run/docker.sock.
+          command:
+            - dockerd
+          args:
+            - --host=unix:///var/run/docker.sock
+            - --storage-driver={{ .Values.dind.storageDriver }}
+          securityContext:
+            privileged: {{ eq (include "computer-use-server.dindPrivileged" .) "true" }}
+          volumeMounts:
+            - name: dind-socket
+              mountPath: /var/run
+            - name: var-lib-docker
+              mountPath: /var/lib/docker
+            # The inner dockerd needs access to /tmp/computer-use-data so the
+            # bind mounts it creates for workspace containers resolve to real
+            # files (same path inside the pod and inside spawned containers).
+            - name: user-data
+              mountPath: /tmp/computer-use-data
+          resources:
+            {{- toYaml .Values.dind.resources | nindent 12 }}
+        {{- if .Values.cleanup.enabled }}
+        # ---------------------------------------------------------------------
+        # 3) Cleanup sidecar — runs the same cron schedules as docker-compose.
+        # ---------------------------------------------------------------------
+        - name: cleanup
+          image: {{ include "computer-use-server.cleanupImage" . | quote }}
+          imagePullPolicy: {{ .Values.cleanup.image.pullPolicy }}
+          env:
+            - name: CONTAINER_MAX_AGE_HOURS
+              value: {{ .Values.cleanup.containerMaxAgeHours | quote }}
+            - name: DATA_MAX_AGE_DAYS
+              value: {{ .Values.cleanup.dataMaxAgeDays | quote }}
+            - name: DATA_DIR
+              value: /tmp/computer-use-data
+          volumeMounts:
+            # Share the socket via the same emptyDir — see Sysbox sidecar pattern.
+            - name: dind-socket
+              mountPath: /var/run
+            - name: user-data
+              mountPath: /tmp/computer-use-data
+          resources:
+            {{- toYaml .Values.cleanup.resources | nindent 12 }}
+        {{- end }}

--- a/helm/computer-use-server/templates/deployment.yaml
+++ b/helm/computer-use-server/templates/deployment.yaml
@@ -62,29 +62,37 @@ spec:
         - name: var-lib-docker
           emptyDir:
             sizeLimit: {{ .Values.persistence.varLibDocker.sizeLimit }}
+        # PVCs follow the same enabled / existingClaim / emptyDir-fallback pattern
+        # so disabling any volume in values.yaml does not produce an unschedulable Pod.
         - name: user-data
           {{- if .Values.persistence.userData.existingClaim }}
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.userData.existingClaim }}
-          {{- else }}
+          {{- else if .Values.persistence.userData.enabled }}
           persistentVolumeClaim:
             claimName: {{ include "computer-use-server.fullname" . }}-user-data
+          {{- else }}
+          emptyDir: {}
           {{- end }}
         - name: data
           {{- if .Values.persistence.data.existingClaim }}
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.data.existingClaim }}
-          {{- else }}
+          {{- else if .Values.persistence.data.enabled }}
           persistentVolumeClaim:
             claimName: {{ include "computer-use-server.fullname" . }}-data
+          {{- else }}
+          emptyDir: {}
           {{- end }}
         - name: skills-cache
           {{- if .Values.persistence.skillsCache.existingClaim }}
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.skillsCache.existingClaim }}
-          {{- else }}
+          {{- else if .Values.persistence.skillsCache.enabled }}
           persistentVolumeClaim:
             claimName: {{ include "computer-use-server.fullname" . }}-skills-cache
+          {{- else }}
+          emptyDir: {}
           {{- end }}
       containers:
         # ---------------------------------------------------------------------

--- a/helm/computer-use-server/templates/deployment.yaml
+++ b/helm/computer-use-server/templates/deployment.yaml
@@ -1,4 +1,5 @@
-{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
+# SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/computer-use-server/templates/ingress.yaml
+++ b/helm/computer-use-server/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "computer-use-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "computer-use-server.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "computer-use-server.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/computer-use-server/templates/ingress.yaml
+++ b/helm/computer-use-server/templates/ingress.yaml
@@ -1,5 +1,6 @@
-{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
-{{- if .Values.ingress.enabled -}}
+# SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
+{{ if .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/helm/computer-use-server/templates/networkpolicy.yaml
+++ b/helm/computer-use-server/templates/networkpolicy.yaml
@@ -1,5 +1,6 @@
-{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
-{{- if .Values.networkPolicy.enabled -}}
+# SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
+{{ if .Values.networkPolicy.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/helm/computer-use-server/templates/networkpolicy.yaml
+++ b/helm/computer-use-server/templates/networkpolicy.yaml
@@ -1,0 +1,44 @@
+{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
+{{- if .Values.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "computer-use-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "computer-use-server.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "computer-use-server.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+        {{- with .Values.networkPolicy.ingressFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - port: 8081
+          protocol: TCP
+  egress:
+    # DNS
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Public internet (LLM APIs, registry, workspace image pulls).
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+              - 169.254.0.0/16
+{{- end }}

--- a/helm/computer-use-server/templates/networkpolicy.yaml
+++ b/helm/computer-use-server/templates/networkpolicy.yaml
@@ -25,7 +25,7 @@ spec:
         - port: 8081
           protocol: TCP
   egress:
-    # DNS
+    # DNS — both UDP and TCP, against any namespace's kube-dns pods.
     - to:
         - namespaceSelector: {}
       ports:
@@ -33,13 +33,18 @@ spec:
           protocol: UDP
         - port: 53
           protocol: TCP
-    # Public internet (LLM APIs, registry, workspace image pulls).
+    # In-cluster service traffic (e.g. external Postgres release, Open WebUI).
+    # Without this, an in-cluster DB or any Service the orchestrator depends
+    # on becomes unreachable when networkPolicy is enabled.
+    - to:
+        - namespaceSelector: {}
+    # Public internet — LLM APIs, registry pulls (workspace image), webhooks.
+    # Operators who need to block egress to private ranges (cloud metadata,
+    # intranet) should add explicit deny rules via networkPolicy.extraEgress.
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
-            except:
-              - 10.0.0.0/8
-              - 172.16.0.0/12
-              - 192.168.0.0/16
-              - 169.254.0.0/16
+    {{- with .Values.networkPolicy.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/helm/computer-use-server/templates/pdb.yaml
+++ b/helm/computer-use-server/templates/pdb.yaml
@@ -1,5 +1,6 @@
-{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
-{{- if .Values.podDisruptionBudget.enabled -}}
+# SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
+{{ if .Values.podDisruptionBudget.enabled -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/helm/computer-use-server/templates/pdb.yaml
+++ b/helm/computer-use-server/templates/pdb.yaml
@@ -1,0 +1,15 @@
+{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "computer-use-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "computer-use-server.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "computer-use-server.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/computer-use-server/templates/pvc-data.yaml
+++ b/helm/computer-use-server/templates/pvc-data.yaml
@@ -1,0 +1,19 @@
+{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
+{{- if and .Values.persistence.data.enabled (not .Values.persistence.data.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "computer-use-server.fullname" . }}-data
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "computer-use-server.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.data.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.data.size }}
+  {{- if .Values.persistence.data.storageClass }}
+  storageClassName: {{ .Values.persistence.data.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/computer-use-server/templates/pvc-data.yaml
+++ b/helm/computer-use-server/templates/pvc-data.yaml
@@ -1,5 +1,6 @@
-{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
-{{- if and .Values.persistence.data.enabled (not .Values.persistence.data.existingClaim) -}}
+# SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
+{{ if and .Values.persistence.data.enabled (not .Values.persistence.data.existingClaim) -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/helm/computer-use-server/templates/pvc-skills-cache.yaml
+++ b/helm/computer-use-server/templates/pvc-skills-cache.yaml
@@ -1,0 +1,19 @@
+{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
+{{- if and .Values.persistence.skillsCache.enabled (not .Values.persistence.skillsCache.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "computer-use-server.fullname" . }}-skills-cache
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "computer-use-server.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.skillsCache.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.skillsCache.size }}
+  {{- if .Values.persistence.skillsCache.storageClass }}
+  storageClassName: {{ .Values.persistence.skillsCache.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/computer-use-server/templates/pvc-skills-cache.yaml
+++ b/helm/computer-use-server/templates/pvc-skills-cache.yaml
@@ -1,5 +1,6 @@
-{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
-{{- if and .Values.persistence.skillsCache.enabled (not .Values.persistence.skillsCache.existingClaim) -}}
+# SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
+{{ if and .Values.persistence.skillsCache.enabled (not .Values.persistence.skillsCache.existingClaim) -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/helm/computer-use-server/templates/pvc-user-data.yaml
+++ b/helm/computer-use-server/templates/pvc-user-data.yaml
@@ -1,5 +1,6 @@
-{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
-{{- if and .Values.persistence.userData.enabled (not .Values.persistence.userData.existingClaim) -}}
+# SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
+{{ if and .Values.persistence.userData.enabled (not .Values.persistence.userData.existingClaim) -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/helm/computer-use-server/templates/pvc-user-data.yaml
+++ b/helm/computer-use-server/templates/pvc-user-data.yaml
@@ -1,0 +1,19 @@
+{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
+{{- if and .Values.persistence.userData.enabled (not .Values.persistence.userData.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "computer-use-server.fullname" . }}-user-data
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "computer-use-server.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.userData.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.userData.size }}
+  {{- if .Values.persistence.userData.storageClass }}
+  storageClassName: {{ .Values.persistence.userData.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/computer-use-server/templates/secret.yaml
+++ b/helm/computer-use-server/templates/secret.yaml
@@ -1,0 +1,22 @@
+{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
+{{- if and .Values.secrets.create (not .Values.secrets.existingSecret) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "computer-use-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "computer-use-server.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  MCP_API_KEY: {{ required "secrets.mcpApiKey is required when secrets.create=true and secrets.existingSecret is empty" .Values.secrets.mcpApiKey | quote }}
+  {{- with .Values.secrets.visionApiKey }}
+  VISION_API_KEY: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.secrets.anthropicAuthToken }}
+  ANTHROPIC_AUTH_TOKEN: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.secrets.openaiApiKey }}
+  OPENAI_API_KEY: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/computer-use-server/templates/secret.yaml
+++ b/helm/computer-use-server/templates/secret.yaml
@@ -1,5 +1,6 @@
-{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
-{{- if and .Values.secrets.create (not .Values.secrets.existingSecret) -}}
+# SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
+{{ if and .Values.secrets.create (not .Values.secrets.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/computer-use-server/templates/service.yaml
+++ b/helm/computer-use-server/templates/service.yaml
@@ -1,4 +1,5 @@
-{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
+# SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/computer-use-server/templates/service.yaml
+++ b/helm/computer-use-server/templates/service.yaml
@@ -1,0 +1,21 @@
+{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "computer-use-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "computer-use-server.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: mcp
+      port: {{ .Values.service.port }}
+      targetPort: mcp
+      protocol: TCP
+  selector:
+    {{- include "computer-use-server.selectorLabels" . | nindent 4 }}

--- a/helm/computer-use-server/templates/serviceaccount.yaml
+++ b/helm/computer-use-server/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "computer-use-server.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "computer-use-server.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/computer-use-server/templates/serviceaccount.yaml
+++ b/helm/computer-use-server/templates/serviceaccount.yaml
@@ -1,5 +1,6 @@
-{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
-{{- if .Values.serviceAccount.create -}}
+# SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
+{{ if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/computer-use-server/templates/tests/test-health.yaml
+++ b/helm/computer-use-server/templates/tests/test-health.yaml
@@ -1,0 +1,22 @@
+{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "computer-use-server.fullname" . }}-test-health
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "computer-use-server.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: curl
+      image: curlimages/curl:8.10.1
+      command:
+        - sh
+        - -c
+        - >
+          curl -fsS --max-time 10
+          http://{{ include "computer-use-server.fullname" . }}:{{ .Values.service.port }}/health

--- a/helm/computer-use-server/templates/tests/test-health.yaml
+++ b/helm/computer-use-server/templates/tests/test-health.yaml
@@ -1,4 +1,5 @@
-{{/* SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors */}}
+# SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
 apiVersion: v1
 kind: Pod
 metadata:

--- a/helm/computer-use-server/values.schema.json
+++ b/helm/computer-use-server/values.schema.json
@@ -30,8 +30,9 @@
         "replicas": { "type": "integer", "const": 1, "$comment": "Multi-replica is unsupported — orchestrator owns the inner dockerd and RWO PVCs." },
         "env": {
           "type": "object",
+          "required": ["PUBLIC_BASE_URL"],
           "properties": {
-            "PUBLIC_BASE_URL": { "type": "string" }
+            "PUBLIC_BASE_URL": { "type": "string", "minLength": 1, "$comment": "Browser-reachable URL of the orchestrator. Empty value breaks file preview links." }
           }
         }
       }
@@ -115,7 +116,7 @@
         "enabled": { "type": "boolean" },
         "size": { "type": "string" },
         "storageClass": { "type": "string" },
-        "accessMode": { "type": "string", "enum": ["ReadWriteOnce", "ReadWriteMany", "ReadOnlyMany", "ReadWriteOncePod"] },
+        "accessMode": { "type": "string", "enum": ["ReadWriteOnce", "ReadWriteOncePod"], "$comment": "Chart is single-replica by design (replicas: 1, owns inner dockerd). RWX/ROX would imply multi-replica which is unsupported." },
         "existingClaim": { "type": "string" }
       }
     }

--- a/helm/computer-use-server/values.schema.json
+++ b/helm/computer-use-server/values.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "SPDX-License-Identifier: BUSL-1.1 — Copyright (c) 2025 Open Computer Use Contributors",
+  "title": "computer-use-server Helm values",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["image", "orchestrator", "dind", "secrets", "persistence", "service"],
+  "properties": {
+    "image": {
+      "type": "object",
+      "required": ["repository"],
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      }
+    },
+    "workspaceImage": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string" },
+        "tag": { "type": "string" }
+      }
+    },
+    "orchestrator": {
+      "type": "object",
+      "required": ["replicas", "env"],
+      "properties": {
+        "runtimeClassName": { "type": "string" },
+        "replicas": { "type": "integer", "const": 1, "$comment": "Multi-replica is unsupported — orchestrator owns the inner dockerd and RWO PVCs." },
+        "env": {
+          "type": "object",
+          "properties": {
+            "PUBLIC_BASE_URL": { "type": "string" }
+          }
+        }
+      }
+    },
+    "dind": {
+      "type": "object",
+      "required": ["image"],
+      "properties": {
+        "image": {
+          "type": "object",
+          "required": ["repository", "tag"],
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" }
+          }
+        },
+        "storageDriver": { "type": "string" }
+      }
+    },
+    "cleanup": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "containerMaxAgeHours": { "type": "integer", "minimum": 1 },
+        "dataMaxAgeDays": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "secrets": {
+      "type": "object",
+      "$comment": "Either secrets.create=true with mcpApiKey, or secrets.existingSecret must be set.",
+      "oneOf": [
+        {
+          "properties": {
+            "create": { "const": true },
+            "mcpApiKey": { "type": "string", "minLength": 1 }
+          },
+          "required": ["create", "mcpApiKey"]
+        },
+        {
+          "properties": {
+            "existingSecret": { "type": "string", "minLength": 1 }
+          },
+          "required": ["existingSecret"]
+        }
+      ]
+    },
+    "persistence": {
+      "type": "object",
+      "required": ["userData", "data", "skillsCache", "varLibDocker"],
+      "properties": {
+        "userData": { "$ref": "#/$defs/pvcSpec" },
+        "data": { "$ref": "#/$defs/pvcSpec" },
+        "skillsCache": { "$ref": "#/$defs/pvcSpec" },
+        "varLibDocker": {
+          "type": "object",
+          "required": ["sizeLimit"],
+          "properties": { "sizeLimit": { "type": "string" } }
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "required": ["type", "port"],
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "postgresql": false
+  },
+  "$defs": {
+    "pvcSpec": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "size": { "type": "string" },
+        "storageClass": { "type": "string" },
+        "accessMode": { "type": "string", "enum": ["ReadWriteOnce", "ReadWriteMany", "ReadOnlyMany", "ReadWriteOncePod"] },
+        "existingClaim": { "type": "string" }
+      }
+    }
+  }
+}

--- a/helm/computer-use-server/values.yaml
+++ b/helm/computer-use-server/values.yaml
@@ -163,8 +163,8 @@ persistence:
     enabled: true
     size: 20Gi
     storageClass: ""
+    # Only ReadWriteOnce / ReadWriteOncePod are supported — chart is single-replica.
     accessMode: ReadWriteOnce
-    # Use existingClaim to bring your own PVC (e.g. RWX from a cluster filer).
     existingClaim: ""
 
   # /data — orchestrator long-lived state (mounted from compose volume `computer-use-data`).

--- a/helm/computer-use-server/values.yaml
+++ b/helm/computer-use-server/values.yaml
@@ -219,6 +219,19 @@ networkPolicy:
   #         matchLabels:
   #           name: open-webui
 
+  # Extra egress rules appended to the chart's defaults (DNS + in-cluster + 0.0.0.0/0).
+  # Use this to add explicit allow rules — e.g. limit egress to a specific
+  # external host, or whitelist your cloud metadata service.
+  extraEgress: []
+  # Example:
+  #   extraEgress:
+  #     - to:
+  #         - ipBlock:
+  #             cidr: 169.254.169.254/32  # cloud metadata
+  #       ports:
+  #         - protocol: TCP
+  #           port: 80
+
 podDisruptionBudget:
   enabled: false
   minAvailable: 1

--- a/helm/computer-use-server/values.yaml
+++ b/helm/computer-use-server/values.yaml
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: BUSL-1.1
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# Default values for computer-use-server.
+# See README.md for prerequisites (Sysbox) and the full knob reference.
+
+# -- Override the chart name. Useful when running multiple releases in one namespace.
+nameOverride: ""
+# -- Override the fully-qualified app name (release-name + chart name by default).
+fullnameOverride: ""
+
+image:
+  # -- Orchestrator image (the FastAPI server in computer-use-server/).
+  repository: ghcr.io/wide-moat/open-computer-use-server
+  # -- Defaults to .Chart.AppVersion when empty.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+# Workspace image — the AI sandbox that the orchestrator spawns via the inner Docker.
+# This image is not pulled by Kubernetes directly; it is pulled by the inner dockerd
+# at first chat creation. The repo:tag is passed to the orchestrator as DOCKER_IMAGE.
+workspaceImage:
+  repository: ghcr.io/wide-moat/open-computer-use
+  tag: ""
+
+# -- imagePullSecrets are applied to the Pod for both orchestrator and dind images.
+imagePullSecrets: []
+
+orchestrator:
+  # runtimeClassName MUST match a RuntimeClass that already exists in the cluster.
+  # Default: sysbox-runc (install Sysbox: https://github.com/nestybox/sysbox).
+  # Empty string => stock runc + privileged dind (UNSUPPORTED, container-escape risk).
+  runtimeClassName: sysbox-runc
+
+  # Single replica is the only supported topology — the pod owns the inner dockerd
+  # and three RWO PVCs. Scaling out requires the K8sBackend rework (out of scope).
+  replicas: 1
+
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: "4"
+      memory: 8Gi
+
+  # Non-secret env vars passed to the orchestrator. Secret vars live under .secrets.
+  env:
+    # REQUIRED. Browser-reachable URL of this service (no trailing slash).
+    # Baked into the system prompt so the model writes correct preview links and
+    # returned in the X-Public-Base-URL header so the Open WebUI filter agrees.
+    PUBLIC_BASE_URL: ""
+
+    COMMAND_TIMEOUT: "120"
+    SUB_AGENT_TIMEOUT: "3600"
+    CONTAINER_MEM_LIMIT: "2g"
+    CONTAINER_CPU_LIMIT: "1.0"
+    CONTAINER_IDLE_TIMEOUT: "600"
+    SINGLE_USER_MODE: "false"
+
+    # Path the inner dockerd creates owui-chat-* workspaces from. Must match the
+    # USER_DATA_BASE_PATH and BASE_DATA_DIR values from docker-compose.yml.
+    USER_DATA_BASE_PATH: /tmp/computer-use-data
+    BASE_DATA_DIR: /tmp/computer-use-data
+
+    # Talks to the inner dockerd over a unix socket shared via emptyDir.
+    DOCKER_SOCKET: unix:///var/run/docker.sock
+
+    # Workspace image is set automatically from .workspaceImage. Override here if needed.
+    # DOCKER_IMAGE: ""
+
+  # Operator escape hatch — appended to the container as-is.
+  # Example:
+  #   extraEnv:
+  #     - name: ANTHROPIC_BASE_URL
+  #       value: https://api.anthropic.com
+  extraEnv: []
+
+  # Add envFrom entries (existing ConfigMaps / Secrets) to the orchestrator container.
+  # Example:
+  #   envFrom:
+  #     - secretRef:
+  #         name: my-llm-creds
+  envFrom: []
+
+  # Liveness/readiness — orchestrator exposes /health on 8081.
+  probes:
+    liveness:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      timeoutSeconds: 10
+      failureThreshold: 3
+    readiness:
+      enabled: true
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+
+  securityContext:
+    runAsNonRoot: false  # the orchestrator image runs as root inside the pod
+    allowPrivilegeEscalation: true
+    # The orchestrator does NOT need privileged. Only the dind container does.
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+dind:
+  # Image for the inner Docker daemon. Must accept the standard dockerd flags.
+  image:
+    repository: docker
+    tag: "27-dind"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: "4"
+      memory: 8Gi
+  # storage driver passed to dockerd. overlay2 works on Sysbox; for stock runc you
+  # may need vfs (slow, only for emergencies).
+  storageDriver: overlay2
+
+cleanup:
+  enabled: true
+  image:
+    # Built from ./cron in the repo. Publish to your registry and point here.
+    repository: ghcr.io/wide-moat/open-computer-use-cleanup
+    tag: ""
+    pullPolicy: IfNotPresent
+  containerMaxAgeHours: 24
+  dataMaxAgeDays: 7
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+
+secrets:
+  # When true, the chart renders a Secret from the values below. Convenient but
+  # bad for GitOps (values get committed). Prefer existingSecret in production.
+  create: true
+
+  # When set, ignored if .create is true. The chart adds this secret to envFrom on
+  # the orchestrator container. The secret must contain at least MCP_API_KEY.
+  existingSecret: ""
+
+  # REQUIRED unless using existingSecret. Bearer token for /mcp endpoint.
+  mcpApiKey: ""
+
+  visionApiKey: ""
+  anthropicAuthToken: ""
+  openaiApiKey: ""
+
+persistence:
+  # /tmp/computer-use-data — per-chat workspace data (uploads, outputs).
+  userData:
+    enabled: true
+    size: 20Gi
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    # Use existingClaim to bring your own PVC (e.g. RWX from a cluster filer).
+    existingClaim: ""
+
+  # /data — orchestrator long-lived state (mounted from compose volume `computer-use-data`).
+  data:
+    enabled: true
+    size: 5Gi
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    existingClaim: ""
+
+  # /data/skills-cache — public skills cache used by skill_manager.
+  skillsCache:
+    enabled: true
+    size: 2Gi
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    existingClaim: ""
+
+  # /var/lib/docker inside the dind container. Must be a dedicated emptyDir —
+  # NEVER a PVC and NEVER shared with other containers (nestybox/sysbox#406).
+  varLibDocker:
+    sizeLimit: 50Gi
+
+service:
+  type: ClusterIP
+  port: 8081
+  annotations: {}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: orchestrator.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  # Example:
+  #   tls:
+  #     - hosts:
+  #         - orchestrator.example.com
+  #       secretName: orchestrator-tls
+
+networkPolicy:
+  enabled: false
+  # Allow incoming traffic from these pod selectors (in addition to same-namespace).
+  ingressFrom: []
+  # Example:
+  #   ingressFrom:
+  #     - namespaceSelector:
+  #         matchLabels:
+  #           name: open-webui
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+podAnnotations: {}
+podLabels: {}


### PR DESCRIPTION
## Summary

- First-class Helm chart at `helm/computer-use-server/` that mirrors the Compose stack on Kubernetes via Sysbox DinD (single pod: `orchestrator` + `dind` + `cleanup` sidecar), with optional Ingress, NetworkPolicy, PDB, helm test hook
- Two install recipes at `examples/helm/` (standalone and with-Open-WebUI), Postgres installed as a separate Bitnami release rather than bundled to dodge Helm 4 conditional-dep bugs
- CI adds `build-cleanup` job (4th image so the chart's cleanup sidecar tag actually exists on ghcr) and a new `helm.yml` workflow that lints + templates + kubeconforms on every PR and publishes to a gh-pages chart repo on `v*` tags via `helm/chart-releaser-action`

## Design highlights

- **Sysbox-first, runc as documented downgrade.** `orchestrator.runtimeClassName` defaults to `sysbox-runc` and dind runs `privileged: false`. Setting `runtimeClassName=""` flips dind to `privileged: true` automatically and prints an UNSUPPORTED warning in `NOTES.txt` (pattern follows gitlab-runner / jenkins charts).
- **Strict separation of socket vs /var/lib/docker.** Shared `dind-socket` emptyDir is mounted into all three containers; `var-lib-docker` is a dedicated emptyDir on `dind` only. Sharing `/var/lib/docker` would break Sysbox per [nestybox/sysbox#406](https://github.com/nestybox/sysbox/issues/406).
- **`values.schema.json` enforces invariants** — `secrets.mcpApiKey` OR `secrets.existingSecret` (oneOf), `replicas: const 1`, RWO accessModes. `helm lint` rejects bad values up-front.
- **CI assertions** template the chart twice (Sysbox path AND privileged downgrade), grep for runtimeClassName / privileged / three container names, then run `kubeconform -strict` against k8s 1.30 schemas.

## Verified locally

- `helm lint` (negative + positive, standalone + with-open-webui)
- `helm template` + grep on all critical fields
- `kubeconform -strict -kubernetes-version 1.30.0` — 19/19 resources valid
- `helm install` on a fresh kind cluster (Helm 4.1.4, k8s 1.35) created all resources cleanly; pods don't start on macOS/arm64 because Sysbox needs Linux and the images are `linux/amd64` — that's an environment limit, not a chart bug

## What still needs operator action before the first release tag

1. Make the ghcr packages public (Packages → each of 4 → Change visibility) — otherwise `helm install` will hit `ErrImagePull`
2. Enable GitHub Pages in repo Settings → Pages → Source: `gh-pages`. The chart-releaser-action creates the branch on first release; Pages must be turned on by hand
3. Push a `v*` tag — the `helm.yml` release job will publish `index.yaml` and the chart tarball

## Test plan

- [ ] CI runs cleanly on this PR (build-* jobs + new helm lint job + kubeconform)
- [ ] Reviewer skims `helm/computer-use-server/README.md` for the install / BYO-Postgres / BYO-Secret flows
- [ ] On merge + a `v*` tag, verify the gh-pages branch gets `index.yaml` and a `computer-use-server-0.1.0.tgz` from `helm/chart-releaser-action`
- [ ] On a Linux cluster with Sysbox installed (out of scope for this PR), follow `examples/helm/standalone/values.yaml` end-to-end and check that workspace containers spawn from inner dockerd

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a production-ready Helm chart for Kubernetes deployment.
  * Added CI workflows to build/publish container images and validate/publish Helm charts.

* **Documentation**
  * Added comprehensive Kubernetes deployment guide, prerequisites, architecture notes, and post-install instructions.
  * Added example Helm deployment recipes and sample values for standalone and Open WebUI-integrated deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wide-Moat/open-computer-use/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->