### PR TITLE
fix(release): normalize dispatch v-prefix, document chart vs app version

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -72,7 +72,10 @@ jobs:
           # 4th segment from the tag and re-attaching the suffix.
 
           if [ -n "${{ inputs.version }}" ]; then
+            # Normalize dispatch input — strip an optional leading `v` so users
+            # can paste either `v0.9.2.5-rc.1` or `0.9.2.5-rc.1`.
             tag_v="${{ inputs.version }}"
+            tag_v="${tag_v#v}"
           elif [ "${{ github.ref_type }}" = "tag" ]; then
             tag_v="${GITHUB_REF_NAME#v}"
           else

--- a/helm/computer-use-server/README.md
+++ b/helm/computer-use-server/README.md
@@ -31,18 +31,27 @@ helm install ocu open-computer-use/computer-use-server \
 
 ### From the OCI registry (any `v*` tag, including release candidates)
 
-Every `v*` git tag — stable and pre-release — pushes the chart to `oci://ghcr.io/wide-moat/charts/computer-use-server`. Use this path to install an `-rc.N` build for testing without contaminating users on the stable `helm repo`:
+Every `v*` git tag — stable and pre-release — pushes the chart to `oci://ghcr.io/wide-moat/charts/computer-use-server`. Use this path to install an `-rc.N` build for testing without contaminating users on the stable `helm repo`.
+
+The chart and the Docker images use different version strings:
+
+- **`APP_VERSION`** (Docker image tags + chart `appVersion`): full 4-segment app version, e.g. `0.9.2.5-rc.1`. Comes directly from the git tag.
+- **`CHART_VERSION`** (Helm chart `version`, what `helm install --version` resolves): strict 3-segment SemVer, e.g. `0.9.2-rc.1`. The 4th segment of the app version is dropped because Helm rejects 4-segment chart versions.
 
 ```bash
-VERSION=0.9.2.5-rc.1
+APP_VERSION=0.9.2.5-rc.1     # Docker image tag
+CHART_VERSION=0.9.2-rc.1     # Helm chart version (4th segment dropped)
+
 helm install ocu-rc oci://ghcr.io/wide-moat/charts/computer-use-server \
-  --version "$VERSION" \
+  --version "$CHART_VERSION" \
   --namespace open-computer-use --create-namespace \
   -f my-values.yaml \
-  --set image.tag="$VERSION" \
-  --set workspaceImage.tag="$VERSION" \
-  --set cleanup.image.tag="$VERSION"
+  --set image.tag="$APP_VERSION" \
+  --set workspaceImage.tag="$APP_VERSION" \
+  --set cleanup.image.tag="$APP_VERSION"
 ```
+
+The `release-chart.yml` workflow prints both values in the Actions Job Summary on every tag push, so you don't have to derive them yourself.
 
 Stable users running `helm repo add open-computer-use https://wide-moat.github.io/...` are unaffected — Helm excludes SemVer pre-releases from `helm install` resolution unless `--devel` or an explicit `--version X.Y.Z-rc.N` is passed.
 


### PR DESCRIPTION
Two leftover CodeRabbit fixes from #110 that didn't make it to main when #109 was merged in (the workflows landed but these two specific items did not). Both are real and easily testable.

## What's fixed

1. **`release-chart.yml` dispatch input normalization** — strip an optional leading \`v\` so operators can paste either \`v0.9.2.5-rc.1\` or \`0.9.2.5-rc.1\` into the workflow_dispatch input field. Git-tag inputs already do this via \`\${GITHUB_REF_NAME#v}\`; dispatch needed parity.

2. **`helm/computer-use-server/README.md` OCI install example** — the previous example used a single \`\$VERSION\` variable for both \`--version\` (chart) and \`--set image.tag\` (Docker tag). That works by coincidence for 3-segment stable releases but breaks for any 4-segment release because Helm chart version must be strict 3-segment SemVer. Replaced with explicit \`APP_VERSION\` + \`CHART_VERSION\` variables and a paragraph explaining why they differ.

## Why a small follow-up PR

PR #110 had four CodeRabbit findings; two were applied separately during #109's review pass (the prerelease regex and the release-body \`\$CHART_VERSION\` substitution) but these two didn't carry over. PR #110 had a hard merge conflict with main after #109, so I closed it and split out just these two changes.

## Test plan

- [ ] CI on this PR stays green
- [ ] On merge, push \`v0.9.2.5-rc.1\` and observe:
  - \`release-chart.yml\` runs successfully
  - the Job Summary shows the resolved chart_version/app_version pair
  - the README's exact install command works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OCI registry installation instructions with clearer guidance on version mapping between Docker image and Helm chart versions, including practical examples for setting and using version parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wide-Moat/open-computer-use/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->