### PR TITLE
fix(helm): skip gh-pages publish for SemVer pre-release tags

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -90,8 +90,11 @@ jobs:
     name: Publish chart to gh-pages
     needs: lint
     runs-on: ubuntu-latest
-    # Only on release tags pushed to the repo (vX.Y.Z.W).
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    # Only on stable release tags. SemVer pre-release suffixes (`-rc.N`,
+    # `-alpha.N`, `-beta.N`) are routed to OCI publish via release-chart.yml
+    # — they must NOT land on gh-pages, otherwise stable users running
+    # `helm repo update && helm install` would resolve them.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     permissions:
       contents: write
       pages: write


### PR DESCRIPTION
## Issue

The \`release\` job in \`.github/workflows/helm.yml\` triggered on every \`v*\` tag, including \`v*-rc.*\`. The \`v0.9.2.5-rc.1\` tag push just failed in run [25990430498](https://github.com/Wide-Moat/open-computer-use/actions/runs/25990430498) with \`fatal: invalid reference: origin/gh-pages\`.

The visible cause was the missing \`gh-pages\` branch, but the real bug is **this job shouldn't run for pre-releases at all**. RCs go to OCI via \`release-chart.yml\`; if they also landed on \`gh-pages\` they'd contaminate the stable \`helm repo add open-computer-use https://wide-moat.github.io/...\` channel that plain \`helm install\` resolves against.

## Fix

Tightened the \`if:\` to skip any tag whose name contains a \`-\` (SemVer pre-release marker):

\`\`\`yaml
if: github.event_name == 'push' &&
    startsWith(github.ref, 'refs/tags/v') &&
    !contains(github.ref_name, '-')
\`\`\`

After this:
- \`v0.9.2.5\` → stable: chart-releaser publishes to \`gh-pages\` as before
- \`v0.9.2.5-rc.1\` → pre-release: job listed as "Skipping" instead of "Failure"

## Test plan

- [ ] CI on this PR stays green
- [ ] On merge, push a test tag \`v0.9.2.5-rc.2\` and observe:
  - \`Publish chart to gh-pages\` shows as **Skipping** in the run list
  - \`Release Helm Chart (OCI)\` still PASSes
- [ ] Eventually, when a stable \`v0.9.3.0\` ships, chart-releaser publishes it on gh-pages normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart publishing workflow to only release stable versions, excluding pre-release versions from automatic publication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wide-Moat/open-computer-use/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->