### PR TITLE
docs(requirements): add secrets/FD-passing, kata-fc squashfs, worker_epoch

### DIFF
--- a/docs/requirements/k8s-architecture.md
+++ b/docs/requirements/k8s-architecture.md
@@ -215,6 +215,18 @@ or pick a managed offering that includes it.
   `Secret` objects via `envFrom`, created per chat or shared per
   namespace depending on tenancy model.
 
+  For high-value tokens (e.g. an Anthropic API key on multi-tenant
+  deployments), prefer mounting the `Secret` as a file via a
+  read-only `projected` volume and passing an open file descriptor
+  to the workspace process at `exec` time. The agent reads the token
+  once (`os.fdopen(int(os.environ["ANTHROPIC_AUTH_TOKEN_FD"]))`) and
+  closes the FD. With this layout the environment contains only the
+  FD number, so the token does not leak into `/proc/<pid>/environ`,
+  child-process environments, crash dumps, or third-party
+  error-reporting libraries that auto-capture `os.environ`. The
+  pattern is standard in long-lived daemons (systemd socket
+  activation, sshd) and production AI-agent runtimes.
+
 ## Cleanup
 
 The current `cron/` reaper container moves into the orchestrator process
@@ -244,7 +256,12 @@ These decisions are deferred until prototypes provide evidence:
 - **Squashfs mount mechanism on `runc`**: kernel `mount -t squashfs`
   needs `CAP_SYS_ADMIN`, while `squashfuse` works in user space at the
   cost of needing FUSE in the Pod. Validate which is preferred for
-  Phase 1 once we have a measurement.
+  Phase 1 once we have a measurement. Under `kata-fc` (Phase 6) this
+  trade-off goes away: each blob can be attached as its own
+  virtio-blk device to the workspace microVM and mounted with the
+  kernel driver inside the guest, so neither host capabilities nor
+  FUSE are in the data path. The host can back the virtio-blk device
+  with a shared squashfs file across guests, reusing page cache.
 - **FUSE sidecar choice for user data**: `rclone mount`, `mountpoint-s3`,
   and `geesefs` have different write semantics. `mountpoint-s3` only
   supports sequential writes which suits `outputs/` but may break some

--- a/docs/requirements/roadmap.md
+++ b/docs/requirements/roadmap.md
@@ -117,12 +117,18 @@ Compose, and replace the standalone cleanup cron.
 
 - Implement the warm-pool manager described in
   [`k8s-architecture.md`](k8s-architecture.md#workspace-lifecycle-and-warm-pool).
+- Expose a monotonic `worker_epoch` on the `Workspace` identity
+  returned by `RuntimeBackend.ensure_workspace`. Clients reconnecting
+  after a pool recycle compare epoch values; a mismatch signals
+  "different underlying workspace, re-initialize per-chat state".
+  Without this, a tool-call arriving on a recycled Pod can land
+  against stale orchestrator-side assumptions.
 - Move the reaper loop from `cron/` into the orchestrator as an
   asyncio background task. It calls
   `RuntimeBackend.list_workspaces()` so the same code drives both
   backends.
 - Surface metrics (`prometheus_client`): pool size, claim latency
-  histogram, workspace lifetime, reap counts.
+  histogram, workspace lifetime, reap counts, epoch increments.
 
 **Exit criteria:** Pool hit gives sub-second time-to-ready in a real
 cluster. Compose users get cleanup-via-orchestrator and can remove


### PR DESCRIPTION
## Summary

Three small, self-contained additions to the forward-looking docs in
`docs/requirements/`. Each closes a concrete gap in the existing
Kubernetes architecture plan (PR #97) without touching code or the
Compose path.

- **`k8s-architecture.md` — Network and security**: document
  FD-passing for high-value tokens as an upgrade path beyond
  `envFrom`. The agent reads the secret once from an inherited file
  descriptor, so the token never appears in `/proc/<pid>/environ`,
  child-process environments, crash dumps, or third-party
  error-reporting libraries that auto-capture `os.environ`. Standard
  pattern in long-lived daemons (systemd socket activation, sshd)
  and production AI-agent runtimes.

- **`k8s-architecture.md` — Open questions**: note that the open
  question about `mount -t squashfs` vs `squashfuse` disappears
  under `kata-fc` (Phase 6). Each blob can be attached as its own
  virtio-blk device to the workspace microVM and mounted with the
  kernel driver inside the guest — no host `CAP_SYS_ADMIN`, no FUSE
  in the data path. The host can back the device with a shared
  squashfs file across guests, reusing page cache.

- **`roadmap.md` — Phase 5**: add a monotonic `worker_epoch` on the
  `Workspace` identity. Clients reconnecting after a pool recycle
  compare epoch values; a mismatch signals "different underlying
  workspace, re-initialize per-chat state". Without this, a
  tool-call arriving on a recycled Pod can land against stale
  orchestrator-side assumptions. Also surface epoch increments as a
  metric.

Total diff: +25 / −2, both files under `docs/requirements/`.

## Why now

These came up while sanity-checking the design in `k8s-architecture.md`
against an observed production AI-agent runtime. The four-tier storage
model, warm pool, kata-fc isolation, and `RuntimeBackend` abstraction
already in the doc are well-aligned with what production systems do.
The three deltas above are the only gaps where the public design
trailed observed practice in ways that affect downstream
implementation.

## Scope

- No code changes.
- No new dependencies.
- Compose path unaffected — these are architectural notes for Phase 4–6.
- No new docs files; edits land in existing `docs/requirements/` files.

## Test plan

- [ ] Manual: render the two markdown files and verify formatting
- [ ] Confirm no broken anchors in cross-references


---
_Generated by [Claude Code](https://claude.ai/code/session_01JEDna9h3sPmNFsbf61NMYT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes architecture documentation with enhanced secret-handling guidance and clarifications on mount mechanisms.
  * Updated Phase 5 roadmap with workspace identity tracking and monitoring metrics details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wide-Moat/open-computer-use/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->