### PR TITLE
fix(build): extract docker image tag via match-pattern (handle 4-segment versions)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,12 @@ jobs:
           images: ${{ env.SANDBOX_IMAGE }}
           tags: |
             type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+            # Extract the tag name verbatim — docker/metadata-action's SemVer
+            # parser rejects our 4-segment scheme (0.9.2.5-rc.1) and falls back
+            # to sha-only tags. The match pattern is permissive — it works for
+            # both 3-segment SemVer and 4-segment tags, with or without a
+            # pre-release suffix.
+            type=match,pattern=v(.*),group=1
             type=sha
 
       - uses: docker/build-push-action@v7
@@ -125,8 +129,12 @@ jobs:
           images: ${{ env.SERVER_IMAGE }}
           tags: |
             type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+            # Extract the tag name verbatim — docker/metadata-action's SemVer
+            # parser rejects our 4-segment scheme (0.9.2.5-rc.1) and falls back
+            # to sha-only tags. The match pattern is permissive — it works for
+            # both 3-segment SemVer and 4-segment tags, with or without a
+            # pre-release suffix.
+            type=match,pattern=v(.*),group=1
             type=sha
 
       - uses: docker/build-push-action@v7
@@ -163,8 +171,12 @@ jobs:
           images: ghcr.io/${{ github.repository }}-cleanup
           tags: |
             type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+            # Extract the tag name verbatim — docker/metadata-action's SemVer
+            # parser rejects our 4-segment scheme (0.9.2.5-rc.1) and falls back
+            # to sha-only tags. The match pattern is permissive — it works for
+            # both 3-segment SemVer and 4-segment tags, with or without a
+            # pre-release suffix.
+            type=match,pattern=v(.*),group=1
             type=sha
 
       - uses: docker/build-push-action@v7
@@ -201,8 +213,12 @@ jobs:
           images: ghcr.io/${{ github.repository }}-webui
           tags: |
             type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+            # Extract the tag name verbatim — docker/metadata-action's SemVer
+            # parser rejects our 4-segment scheme (0.9.2.5-rc.1) and falls back
+            # to sha-only tags. The match pattern is permissive — it works for
+            # both 3-segment SemVer and 4-segment tags, with or without a
+            # pre-release suffix.
+            type=match,pattern=v(.*),group=1
             type=sha
 
       - uses: docker/build-push-action@v7


### PR DESCRIPTION
## What's wrong

When the \`v0.9.2.5-rc.1\` tag was pushed, only \`sha-01546e5\` image tags were created in ghcr. No \`0.9.2.5-rc.1\` tag exists, so every install command in the release notes and README dead-ends on \`manifest unknown\`.

## Root cause

\`docker/metadata-action\`'s \`type=semver,pattern={{version}}\` parser requires **strict 3-segment SemVer** (major.minor.patch). Our app uses 4 segments (\`0.9.2.5-rc.1\`). The build logs show:

\`\`\`
##[warning] v0.9.2.5-rc.1 is not a valid semver
\`\`\`

The action silently falls back to \`type=sha\` and we end up with sha-only tags.

This is the **fourth time** the 4-segment scheme has tripped over something built for strict SemVer:

1. \`helm package\` rejected 4-seg chart version → fixed by deriving 3-seg chart_version in release-chart.yml
2. Pre-release regex in release.yml regex was 3-seg only → fixed with the \`(\.[0-9]+)?-\` extension
3. Release-notes \`--version\` mixed app vs chart version → fixed with explicit substitution
4. **This one**: \`docker/metadata-action\` skipped semver patterns entirely

## Fix

Replaced \`type=semver,pattern={{version}}\` + \`type=semver,pattern={{major}}.{{minor}}.{{patch}}\` with a single \`type=match,pattern=v(.*),group=1\` in all 4 build jobs (sandbox, server, cleanup, webui). It extracts the tag name verbatim — works for 3-segment SemVer, 4-segment app versions, with or without pre-release suffix.

Dropped the duplicate \`{{major}}.{{minor}}.{{patch}}\` pattern — it always equaled \`{{version}}\` for us.

## After merge

Re-tag to rebuild RC images with proper tags:

\`\`\`bash
git tag -f v0.9.2.5-rc.1 origin/main
git push --force origin v0.9.2.5-rc.1
\`\`\`

(Or just push a new \`v0.9.2.5-rc.2\` if force-push is too invasive.)

## Test plan

- [ ] CI on this PR stays green
- [ ] After merge + re-tag: \`docker pull ghcr.io/wide-moat/open-computer-use-server:0.9.2.5-rc.1\` succeeds
- [ ] \`gh api /v2/wide-moat/open-computer-use-server/tags/list\` returns \`0.9.2.5-rc.1\` in the tag list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image tag generation in CI/CD workflows. Changed from semantic versioning patterns to extracting Git tag names directly for build-sandbox, build-server, build-cleanup, and build-webui jobs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wide-Moat/open-computer-use/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->