### PR TITLE
docs(future-arch): research 18 + ADR-0009 on Open WebUI terminal dialects

### DIFF
--- a/docs/future-architecture/adr/0009-external-protocol-dialects.md
+++ b/docs/future-architecture/adr/0009-external-protocol-dialects.md
@@ -27,7 +27,7 @@ The question is whether L4 should expose only `/mcp` or accept additional extern
   3. **Wire contract must be stable.** If the dialect's wire format belongs to an upstream we don't control, the upstream's compatibility guarantees must be acceptable; otherwise pin and document supported version ranges.
 - **No adapter is committed by this ADR.** Each dialect is gated on its own validation gate (see Verification below).
 
-```
+```text
                   ┌─── /mcp                        Primary, frozen        (n8n, Claude Desktop, LiteLLM, OpenAI Agents SDK)
 L4 (Go) ──────────┼─── /api/v1/policies, /p/...    Proposed adapter       Open WebUI orchestrator dialect, status Hypothesis
                   ├─── /v1/chat/completions        Proposed adapter       OpenAI-compatible, status Hypothesis

--- a/docs/future-architecture/adr/0009-external-protocol-dialects.md
+++ b/docs/future-architecture/adr/0009-external-protocol-dialects.md
@@ -1,0 +1,94 @@
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+<!-- Copyright (c) 2025 Open Computer Use Contributors -->
+
+# ADR-0009 — L4 external surface: MCP primary, optional adapter dialects
+
+- **Status:** Proposed
+- **Date:** 2026-05-18
+- **Related:** [ADR-0005](./0005-mcp-as-control-plane-gateway.md), [ADR-0008](./0008-internal-grpc-external-rest-mcp.md), [research/18](../research/18-open-webui-terminals-observed.md)
+
+## Context
+
+We have one external protocol today (MCP at `/mcp`) and a confirmed requirement that **multiple clients reach an identical capability surface**: Open WebUI, n8n, Claude Desktop, LiteLLM, OpenAI Agents SDK. Skills must be portable across all of them — a tool that works in one client and not another splits the surface and is rejected by definition (see [`COMPARISON.md`](../../COMPARISON.md), [`MCP.md`](../../MCP.md)).
+
+Two distinct external-protocol pressures have emerged:
+
+1. **Open WebUI native UX.** Open WebUI ships a native "terminal connection" mechanism with embedded file browser (`FileNav`), embedded xterm.js (`XTerminal`), and OpenAPI-driven tool injection. To use it, a server must speak either the single-terminal wire contract (`open-webui/open-terminal`) or the orchestrator wire contract (`open-webui/terminals`). See [research/18](../research/18-open-webui-terminals-observed.md) §3 for the contract.
+2. **OpenAI-compatible API.** A non-trivial fraction of integration requests assume `/v1/chat/completions`. Not blocking today, but recurring.
+
+The question is whether L4 should expose only `/mcp` or accept additional external dialects as adapters.
+
+## Decision
+
+- **MCP remains the only frozen, primary user-facing contract** ([ADR-0005](./0005-mcp-as-control-plane-gateway.md) stands).
+- **Additional external dialects may be added as L4 adapters** over the same internal connect-go RPC ([ADR-0008](./0008-internal-grpc-external-rest-mcp.md)), under three conditions enforced per dialect:
+  1. **Skill parity.** Every skill we ship MUST behave identically through the dialect and through MCP. If a skill cannot be expressed losslessly in the dialect, the dialect is not added.
+  2. **No coupling to dialect-specific clients.** Removing the adapter must not affect any other client.
+  3. **Wire contract must be stable.** If the dialect's wire format belongs to an upstream we don't control, the upstream's compatibility guarantees must be acceptable; otherwise pin and document supported version ranges.
+- **No adapter is committed by this ADR.** Each dialect is gated on its own validation gate (see Verification below).
+
+```
+                  ┌─── /mcp                        Primary, frozen        (n8n, Claude Desktop, LiteLLM, OpenAI Agents SDK)
+L4 (Go) ──────────┼─── /api/v1/policies, /p/...    Proposed adapter       Open WebUI orchestrator dialect, status Hypothesis
+                  ├─── /v1/chat/completions        Proposed adapter       OpenAI-compatible, status Hypothesis
+                  └─── /admin/*                    Operator UI            REST, ADR-0008
+```
+
+## Rationale
+
+- **One internal contract, many external surfaces** is the same shape as ADR-0008's internal/external split — just extended to external. The cost of adding a dialect is bounded by the adapter; the cost of NOT being able to add one is permanent client lock-in.
+- **MCP as the parity floor.** Because MCP is the lowest-common-denominator protocol across all current target clients, locking MCP as the source of truth guarantees portability automatically. Any adapter that cannot match MCP's capability is by construction worse than the floor and is rejected.
+- **Adapter, not branch.** Dialects do not fork the tool set, do not add MCP-incompatible methods, and do not reshape the sandbox lifecycle. An adapter that needs internal RPC changes is no longer an adapter — it's a fork — and falls outside this ADR.
+
+## What this ADR does NOT do
+
+- It does **not** approve adding the Open WebUI dialect. That hypothesis lives in [research/18](../research/18-open-webui-terminals-observed.md) §5 with five explicit open questions; until they are answered the dialect is not built.
+- It does **not** approve adding an OpenAI-compatible dialect. Same status.
+- It does **not** change the MCP contract.
+- It does **not** authorise dropping the existing Open WebUI tool + filter integration. That decision is downstream of skill-parity validation per condition 1.
+
+## Consequences
+
+**Positive:**
+- Adapters become an explicit, bounded extension mechanism — not ad-hoc patches scattered across the codebase.
+- Conditions 1–3 make "should we add dialect X?" answerable with a checklist instead of a debate.
+- Skill portability is structurally enforced: anything that breaks MCP parity is out by definition.
+
+**Negative:**
+- Each adapter adopted is permanent surface area to maintain. The decision to add must include the decision to maintain.
+- Some upstream wire contracts (notably the Open WebUI orchestrator dialect) are at early version numbers and may break between releases. Adapters against them need a supported-version-range policy.
+
+**Neutral:**
+- Phase 6 L4 framework choice (HTTP router, middleware) must support multiple route trees mounted on the same connect-go core. Not a constraint on connect-go itself — every candidate router meets this.
+
+## Alternatives considered
+
+### MCP-only forever
+- **Pro:** Smallest surface; zero adapter maintenance.
+- **Con:** Locks us out of native UX in clients that don't speak MCP first-class. Open WebUI patches and our `computer_link_filter` then have to evolve in lockstep with upstream — the patch-maintenance burden grows with every Open WebUI release.
+- **Verdict:** Acceptable today; this ADR keeps it as the default by requiring per-dialect justification.
+
+### One adapter per client, deeply coupled
+- **Pro:** Each client gets its perfect UX.
+- **Con:** N adapters × M clients explosion; condition 1 (skill parity) becomes impossible to enforce; internal surface starts to bend toward dialects.
+- **Verdict:** Rejected.
+
+### Fork MCP with our own extensions
+- **Pro:** Single protocol, richer capability.
+- **Con:** Breaks every off-the-shelf MCP client. Loses the parity floor.
+- **Verdict:** Rejected by ADR-0005.
+
+## Verification
+
+For each proposed adapter, before it is built:
+
+1. **Skill-parity matrix.** Every skill in `skills/` must have a documented mapping that produces equivalent model behaviour via the dialect as via MCP. Discrepancies → adapter not built.
+2. **Removal test.** Acceptance includes a CI configuration that builds and runs L4 with the adapter disabled; all other clients must still pass their integration tests unchanged.
+3. **Version-range policy.** If the adapter speaks an upstream-owned wire format, the supported upstream version range is documented in the adapter's README and pinned in CI.
+4. **Phase placement.** Adapters land no earlier than Phase 6 (L4 rewrite). Adding adapters to the current Python `computer-use-server` is not authorised by this ADR — that would create migration debt against ADR-0001.
+
+## Migration notes
+
+- Phases 1–5: unchanged. Single MCP endpoint stays on Python.
+- Phase 6: L4 framework selection must explicitly preserve the option to mount additional route trees. No adapter built yet.
+- Phase 6+: adapters added one at a time, each gated by the conditions above.

--- a/docs/future-architecture/research/18-open-webui-terminals-observed.md
+++ b/docs/future-architecture/research/18-open-webui-terminals-observed.md
@@ -14,7 +14,7 @@
 
 Open WebUI integrates both natively. The backend (`backend/open_webui/routers/configs.py:277-323`) auto-detects which one the user pointed at:
 
-```
+```text
 GET {url}/api/v1/policies → 200 → server_type = "orchestrator"  (terminals)
 GET {url}/api/config      → 200 → server_type = "terminal"      (open-terminal)
 ```
@@ -47,7 +47,7 @@ Useful to record verbatim because the protocol is what unlocks native integratio
 
 ### 3.1 Auto-detection probes
 
-```
+```text
 GET /api/v1/policies          → orchestrator dialect
 GET /api/config               → single-terminal dialect, returns { features: { terminal: bool } }
 ```
@@ -89,7 +89,7 @@ This constraint **takes precedence** over any UX gain from native Open WebUI int
 
 Add an **external protocol dialect** to L4 that speaks the orchestrator wire contract from §3.2 alongside the primary MCP endpoint, while internal tool execution stays MCP-shaped end-to-end.
 
-```
+```text
                   ┌─── /mcp                        primary, frozen          (n8n, Claude Desktop, LiteLLM, OpenAI Agents)
 L4 (Go) ──────────┼─── /api/v1/policies, /p/...    Open WebUI native UX     (FileNav, XTerminal, OpenAPI tools)
                   ├─── /v1/chat/completions        OpenAI-compat            (future, for OpenAI-API consumers)
@@ -106,7 +106,7 @@ All four are adapters over the same internal connect-go RPC ([ADR-0008](../adr/0
 ### What still has to be proven before this becomes decision-grade
 
 1. **Skill parity check.** The Open WebUI dialect would deliver tools via OpenAPI 3.0, not MCP `tools/call`. We have to confirm that for every skill we ship, the OpenAPI representation and the MCP representation produce identical model behaviour. If not, the dialect splits the skill surface and §4 forces rejection.
-2. **CDP and live browser viewer.** Open WebUI's terminal dialect has no concept of a Chrome DevTools Protocol stream. Either we extend the dialect with our own WebSocket endpoint under `/p/{policy_id}/devtools/...` (and patch Open WebUI to recognise it — back to the patch-mainenance problem), or we accept that Computer Use's primary fronted-killer feature is unavailable through this path.
+2. **CDP and live browser viewer.** Open WebUI's terminal dialect has no concept of a Chrome DevTools Protocol stream. Either we extend the dialect with our own WebSocket endpoint under `/p/{policy_id}/devtools/...` (and patch Open WebUI to recognise it — back to the patch-maintenance problem), or we accept that Computer Use's primary fronted-killer feature is unavailable through this path.
 3. **`computer_link_filter` value.** Today the filter injects skill descriptions into the system prompt and rewrites output URLs into iframe previews. Open WebUI's native flow injects OpenAPI tool descriptions automatically but does **not** rewrite output URLs. We have to decide whether the URL-rewriting UX is essential — if yes, we still need the filter even when using the native dialect, and the simplification budget shrinks.
 4. **State of the contract.** `open-webui/terminals` is at `v0.0.3` with an Enterprise License. Backwards-compat guarantees on the orchestrator wire format are unclear; pinning to a specific Open WebUI version range may be necessary.
 5. **`X-Session-Id` semantics.** Open WebUI assumes sessions outlive single requests (CWD persists). Our session model is sandbox-per-chat with a TTL. Confirm the mapping doesn't surprise anyone — e.g. what happens to file ops sent during sandbox cold-start.

--- a/docs/future-architecture/research/18-open-webui-terminals-observed.md
+++ b/docs/future-architecture/research/18-open-webui-terminals-observed.md
@@ -1,0 +1,135 @@
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+<!-- Copyright (c) 2025 Open Computer Use Contributors -->
+
+# 18 — Open WebUI `open-terminal` + `terminals` (observed)
+
+> Source: [`open-webui/open-terminal`](https://github.com/open-webui/open-terminal) (sandbox shell server) and [`open-webui/terminals`](https://github.com/open-webui/terminals) (per-user orchestrator). Reviewed 2026-05.
+>
+> Status: **observation, hypothesis only.** Their target audience is single-user / SMB self-host. Our target is multi-tenant enterprise (financial-sector infosec, multi-cluster, BYOK, compliance-grade audit). This document records what they do at the wire-protocol level, and frames one open hypothesis about reusing that wire protocol as an external dialect — nothing here locks any architectural decision.
+
+## 1. What the two projects are
+
+- **`open-terminal`**: a FastAPI service that runs inside a single container and exposes a REST API + WebSocket terminal. Tools: bash exec, file CRUD, document extraction, port reverse-proxy, Jupyter kernels, optional in-process MCP via `FastMCP.from_fastapi(app)`.
+- **`terminals`**: a separate FastAPI control-plane that provisions one `open-terminal` container *per `(user_id, policy_id)`* and reverse-proxies requests to it. Three backends: Docker socket, Kubernetes direct, Kubernetes via Kopf operator + `Terminal` CRD (`openwebui.com/v1alpha1`).
+
+Open WebUI integrates both natively. The backend (`backend/open_webui/routers/configs.py:277-323`) auto-detects which one the user pointed at:
+
+```
+GET {url}/api/v1/policies → 200 → server_type = "orchestrator"  (terminals)
+GET {url}/api/config      → 200 → server_type = "terminal"      (open-terminal)
+```
+
+For an orchestrator, requests are routed as `/p/{policy_id}/{path}`. For a single terminal, paths pass through as-is.
+
+## 2. Audience and scope difference
+
+This is **not a critique** — these are different products solving different problems.
+
+| Dimension | Open WebUI stack | Our target |
+|---|---|---|
+| Primary user | Self-hoster, single-team install | Multi-tenant enterprise, paid SaaS |
+| Tenancy boundary | Linux UID inside one container (multi-user mode) or one container per user (orchestrator) | One sandbox per session, microVM-isolated for untrusted tier |
+| Runtime isolation | `runc` only | runc / sysbox / gVisor / kata-fc / kata-ch per template ([04-layer2-runtimes.md](../architecture/04-layer2-runtimes.md)) |
+| Cluster model | Single cluster, single namespace | Multi-cluster, multi-AZ, federated |
+| Identity | Static API key or Open WebUI JWT | OIDC + per-session JWT + secret broker ([07-security.md](../architecture/07-security.md)) |
+| Secrets | env vars / K8s `Secret` | Per-session STS, key rotation ≤90d without restart |
+| Egress | iptables + dnsmasq inside each container | Centralized JWT-allowlist egress proxy with audit pipeline ([08-networking.md](../architecture/08-networking.md), Phase 8) |
+| Storage | `/home/user` bind-mount or PVC | 4-tier (image / squashfs skills / ephemeral workspace / S3 user-data) ([06-storage.md](../architecture/06-storage.md)) |
+| Audit | SQL `audit_log` table | Append-only S3 with object-lock, ≥90d retention |
+| HA control plane | Single process, in-memory `_instances` dict | 3+ replicas, leader election via `coordination.k8s.io/Lease`, external KV |
+| Compliance posture | None specifically targeted | SOC2 / PCI / FedRAMP-class workloads in scope |
+
+Their stack would be a regression for our targets. Ours would be over-engineering for theirs. Both can be correct.
+
+## 3. Wire contract (what Open WebUI expects)
+
+Useful to record verbatim because the protocol is what unlocks native integration in Open WebUI's UI.
+
+### 3.1 Auto-detection probes
+
+```
+GET /api/v1/policies          → orchestrator dialect
+GET /api/config               → single-terminal dialect, returns { features: { terminal: bool } }
+```
+
+### 3.2 Orchestrator dialect (used by `terminals`)
+
+- `GET /api/v1/policies` — list policies (`PolicyData`: image, env, cpu_limit, memory_limit, storage, storage_mode, idle_timeout_minutes)
+- `POST/PUT/DELETE /api/v1/policies/{id}` — CRUD from admin UI
+- `ALL /p/{policy_id}/{path:path}` — reverse-proxy to the provisioned sandbox; `X-User-Id` header required; orchestrator resolves `(user_id, policy_id) → sandbox`, replaces auth with the sandbox's internal API key, streams body bidirectionally
+- `WS /p/{policy_id}/api/terminals/{session_id}` — WebSocket proxy with first-message `{"type":"auth","token":"..."}` handshake
+
+### 3.3 Single-terminal dialect (used by `open-terminal`)
+
+The endpoints under `/p/{policy_id}/` in orchestrator mode are exactly the endpoints `open-terminal` exposes at root. Open WebUI clients used by the UI:
+
+- `GET /openapi.json` — OpenAPI 3.0 spec; tools from this spec are surfaced to the model as function-calling tools
+- `GET /files/cwd`, `POST /files/cwd` — session-scoped CWD (keyed on `X-Session-Id`)
+- `GET /files/list?directory=`, `GET /files/read?path=`, `GET /files/view?path=`
+- `POST /files/upload?directory=` (multipart), `POST /files/mkdir`, `DELETE /files/delete`, `POST /files/move`, `POST /files/archive`
+- `POST /api/terminals` → `{ id }`; then `WS /api/terminals/{id}` with first-message auth, binary frames for PTY I/O, JSON `{type:"resize",cols,rows}` / `{type:"ping"}` for control
+
+All HTTP requests authenticated by `Authorization: Bearer <key>`; `X-Session-Id` keys per-chat state; `X-User-Id` keys per-user provisioning in orchestrator mode.
+
+### 3.4 What Open WebUI gives back if a server implements this
+
+- **`FileNav.svelte`** — full file browser in the chat sidebar (list, read, upload via drag-drop, download, mkdir, delete, move, archive)
+- **`XTerminal.svelte`** — embedded xterm.js with the WebSocket protocol above
+- **Tool calling** — OpenAPI tools auto-injected into the inference loop when the model has `capabilities.terminal = true`
+- **`AddTerminalServerModal.svelte`** — admin / per-user UI to add a server, with orchestrator-mode policy editor
+- **Per-chat `X-Session-Id`** — Open WebUI passes the chat id automatically, sandboxes can scope CWD and state to a session
+
+## 4. Hard constraint: client parity
+
+Current explicit requirement: **Open WebUI and n8n must reach an identical capability surface** so that skills are portable between clients. The MCP protocol is the only common denominator across the target clients today (Open WebUI MCP support, n8n MCP nodes, OpenAI Agents SDK, LiteLLM, Claude Desktop). See [`../../MCP.md`](../../MCP.md), [`../../COMPARISON.md`](../../COMPARISON.md).
+
+This constraint **takes precedence** over any UX gain from native Open WebUI integration. Anything that splits the skill surface — i.e. tools that work in Open WebUI but not in n8n, or vice versa — is rejected by definition. ADR-0005 (MCP as user-facing control-plane gateway, frozen contract) stands.
+
+## 5. Hypothesis (open, not decided)
+
+Add an **external protocol dialect** to L4 that speaks the orchestrator wire contract from §3.2 alongside the primary MCP endpoint, while internal tool execution stays MCP-shaped end-to-end.
+
+```
+                  ┌─── /mcp                        primary, frozen          (n8n, Claude Desktop, LiteLLM, OpenAI Agents)
+L4 (Go) ──────────┼─── /api/v1/policies, /p/...    Open WebUI native UX     (FileNav, XTerminal, OpenAPI tools)
+                  ├─── /v1/chat/completions        OpenAI-compat            (future, for OpenAI-API consumers)
+                  └─── /admin/*                    operator UI
+```
+
+All four are adapters over the same internal connect-go RPC ([ADR-0008](../adr/0008-internal-grpc-external-rest-mcp.md)).
+
+### What this would unlock
+
+- Open WebUI users get the native file browser + embedded terminal + OpenAPI-tool injection out of the box, without our `computer_link_filter` and Open WebUI source patches.
+- No regression for n8n / Claude Desktop / LiteLLM — they keep using `/mcp` unchanged.
+
+### What still has to be proven before this becomes decision-grade
+
+1. **Skill parity check.** The Open WebUI dialect would deliver tools via OpenAPI 3.0, not MCP `tools/call`. We have to confirm that for every skill we ship, the OpenAPI representation and the MCP representation produce identical model behaviour. If not, the dialect splits the skill surface and §4 forces rejection.
+2. **CDP and live browser viewer.** Open WebUI's terminal dialect has no concept of a Chrome DevTools Protocol stream. Either we extend the dialect with our own WebSocket endpoint under `/p/{policy_id}/devtools/...` (and patch Open WebUI to recognise it — back to the patch-mainenance problem), or we accept that Computer Use's primary fronted-killer feature is unavailable through this path.
+3. **`computer_link_filter` value.** Today the filter injects skill descriptions into the system prompt and rewrites output URLs into iframe previews. Open WebUI's native flow injects OpenAPI tool descriptions automatically but does **not** rewrite output URLs. We have to decide whether the URL-rewriting UX is essential — if yes, we still need the filter even when using the native dialect, and the simplification budget shrinks.
+4. **State of the contract.** `open-webui/terminals` is at `v0.0.3` with an Enterprise License. Backwards-compat guarantees on the orchestrator wire format are unclear; pinning to a specific Open WebUI version range may be necessary.
+5. **`X-Session-Id` semantics.** Open WebUI assumes sessions outlive single requests (CWD persists). Our session model is sandbox-per-chat with a TTL. Confirm the mapping doesn't surprise anyone — e.g. what happens to file ops sent during sandbox cold-start.
+
+### Phase to evaluate
+
+If pursued, this is a Phase 6 concern (L4 rewrite) at the earliest — the adapter lives in L4 and benefits from connect-go's HTTP+JSON pluralism. Not earlier: doing it on top of the current FastAPI server would create migration debt.
+
+## 6. Patterns observed, not borrowed
+
+For completeness, things their code does competently that we should make sure are covered in our own design (these are CNCF / k8s-api-convention basics, not their inventions — listing only to confirm we don't drop them):
+
+- Status `phase` + `conditions[]` array on the CRD (k8s API conventions). Their flat `cpuLimit: "2"` vs nested `resources.limits.cpu` is the opposite — non-standard, breaks generic k8s tooling. **Antipattern note added below.**
+- Finalizer-driven teardown (`settings.persistence.finalizer = "..."`) — standard. Required for our S3-cleanup / secret-revocation / egress-JWT-invalidation flows.
+- PVC lifecycle separated from CR lifecycle (PVC outlives the controller object). Useful pattern for stateful workloads; **not directly applicable to us** since our default workspace home is ephemeral and persistence is S3-mediated.
+- Reverse-proxy with retry on cold-start (5 attempts, 1s backoff) — required behaviour for warm-pool misses; should be explicit in [`03-layer3-providers.md`](../architecture/03-layer3-providers.md) and [`02-layer4-control-plane.md`](../architecture/02-layer4-control-plane.md).
+
+## 7. Antipattern note candidate
+
+For [`../antipatterns.md`](../antipatterns.md):
+
+> **Flat resource fields on a CRD spec.** Using `spec.cpuLimit: "2"` and `spec.memoryLimit: "4Gi"` instead of the canonical `spec.resources.limits.{cpu,memory}` breaks `kubectl explain`, generic policy admission controllers (Kyverno, Gatekeeper templates that target `resources.limits`), and Helm-chart introspection tooling. Save the typing, lose the ecosystem. Always nest under `resources`.
+
+## 8. Summary
+
+`open-terminal` and `terminals` are well-scoped products for a different audience. Their wire protocol is the one piece worth recording for possible reuse as an external dialect of our L4 — strictly as a **hypothesis** subordinated to the MCP-first / client-parity constraint. No architecture commitment is made by this file.


### PR DESCRIPTION
## Summary

Two new documents under `docs/future-architecture/`, both subordinated to the explicit n8n / Open WebUI skill-parity constraint. No architecture commitment is made — these are observation + proposal.

### `research/18-open-webui-terminals-observed.md`

Wire-contract observation of [`open-webui/open-terminal`](https://github.com/open-webui/open-terminal) and [`open-webui/terminals`](https://github.com/open-webui/terminals) (Python control-plane + Kopf operator, single-cluster, `runc`-only).

- Records the auto-detection probes Open WebUI uses (`GET /api/v1/policies` → orchestrator dialect, `GET /api/config` → single-terminal dialect) and the full set of endpoints and WebSocket protocol Open WebUI's UI consumes (`FileNav`, `XTerminal`, OpenAPI tool injection).
- Frames the audience difference neutrally: their target is single-user / SMB self-host, ours is multi-tenant enterprise with microVM isolation, multi-cluster, BYOK, compliance-grade audit. Both can be correct.
- Lists what would have to be proven before any reuse of their wire protocol becomes decision-grade (skill parity, CDP path, filter URL-rewriting, upstream stability, session semantics) — five explicit open questions.

### `adr/0009-external-protocol-dialects.md` (Status: Proposed)

Generalises the question raised by research/18 into a policy:

- **MCP remains the only frozen, primary user-facing contract.** ADR-0005 stands.
- Additional external dialects MAY be added as L4 adapters over the same internal connect-go core (ADR-0008), but only when they pass three gates: (1) skill-parity with MCP, (2) removal independence, (3) stable upstream wire contract.
- **No adapter is approved by this ADR.** Both candidates currently on the table — the Open WebUI orchestrator dialect and an OpenAI-compatible `/v1/chat/completions` — remain hypotheses.

## Why now

- Recurring integration requests for Open WebUI native UX and OpenAI-compatible endpoints surface a pattern; better to have a policy for the question than to answer ad-hoc each time.
- Records the wire contract while it's fresh so future work isn't blocked on re-discovery.

## Test plan

- [ ] Docs-only change — no code paths affected.
- [ ] Verify cross-references resolve: research/18 → architecture/04, architecture/06, architecture/07, architecture/08, antipatterns.md; ADR-0009 → ADR-0005, ADR-0008, research/18, COMPARISON.md, MCP.md.
- [ ] License headers (BUSL-1.1) present on both new files per CLAUDE.md.
- [ ] No bashing of the upstream projects — strictly factual, audience-difference framing.

https://claude.ai/code/session_01Akosnnt1tu1asAE45VfNWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Akosnnt1tu1asAE45VfNWT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an ADR defining the external-protocol strategy: keep the primary MCP contract frozen, allow bounded external dialect adapters under strict per-dialect requirements, include a verification checklist, and outline phased migration constraints.
  * Added research notes on observed Open WebUI wire-protocol behaviors, integration hypotheses for an orchestrator-style dialect, implementation patterns, potential antipatterns, and Phase‑6 evaluation considerations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wide-Moat/open-computer-use/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->