### PR TITLE
docs(future-arch): Firecracker microVM deep dive + lock A37 (no PVC for session workspace)

### DIFF
--- a/docs/future-architecture/README.md
+++ b/docs/future-architecture/README.md
@@ -66,7 +66,11 @@ docs/future-architecture/
     ├── 12-docker-socket-proxy.md      (Phase 2, 8)
     ├── 13-anthropic-sandbox-runtime.md (Phase 7, 9)
     ├── 14-e2b-desktop-and-surf.md     (Phase 7)
-    └── 15-claude-code-reverse-engineering.md (Phase 6, 7, 10)
+    ├── 15-claude-code-reverse-engineering.md (Phase 6, 7, 10)
+    ├── 16-anthropic-production-sandbox-observed.md (Phase 3, 7, 9)
+    ├── 17-anthropic-claude-code-remote-env-observed.md (Phase 4, 6, 10)
+    ├── 18-open-webui-terminals-observed.md (Phase 6)
+    └── 19-anthropic-firecracker-microvm-internals-observed.md ⭐ (Phase 3, 7, 9, 10) — locks A37 "no PVC for sandbox session workspace"
 ```
 
 ## Reference repositories

--- a/docs/future-architecture/antipatterns.md
+++ b/docs/future-architecture/antipatterns.md
@@ -139,10 +139,10 @@ Ordered by phase where they FIRST become possible.
 
 - **Source.** `sandboxd/antipatterns.md:302-316`.
 - **Failure.** Disk bloat; compliance liability (GDPR/HIPAA — old PII on disk); compromised sandbox reads prior tenant's data.
-- **Our choice — ephemeral by default, persistence opt-in.**
+- **Our choice — ephemeral by default, no persistent sandbox-workspace tier.**
   - Computer Use sessions are hours, not days.
-  - If Phase 3+ adds "continue yesterday's session" → opt-in PVC with per-session encryption ([A34](#a34--no-per-session-encryption-for-persistent-data)) and explicit cleanup policy.
-  - No default PVC in any template.
+  - "Continue yesterday's session" is served by **Tier 4 (S3 with `filesystem_id` token auth)**, not by a persistent Tier 3 workspace. The next VM re-binds to the same `filesystem_id` prefix — the user's files reappear without any persistent workspace volume.
+  - **No PVC for the session workspace tier in any template.** Locked — see [A37](#a37--pvc-for-sandbox-session-workspace).
 - **Phase.** 3 (storage MVP) + ongoing.
 - **Detection.** Helm chart's default `SandboxTemplate.persistence: ephemeral`. Validate at admission.
 
@@ -402,6 +402,27 @@ Ordered by phase where they FIRST become possible.
 - **Phase.** 6 (L4 KV management).
 - **Detection.** Integration test from A5.
 
+### A37 — PVC for sandbox session workspace
+
+- **Source.** [`research/19-anthropic-firecracker-microvm-internals-observed.md` §2.3](./19-anthropic-firecracker-microvm-internals-observed.md#23-rootfs-as-cow-snapshot--the-pvc-replacement-pattern-). Observation: Anthropic's production Firecracker microVM serves `/home/claude` from a per-VM CoW snapshot (qcow2 backing / dm-thin / ZFS clone) of a golden rootfs — **not** from a per-session PVC.
+- **Failure.**
+  - **Cross-tenant leak (security).** A reused PVC that isn't scrubbed exactly right between sessions = previous tenant's data to the next one. The scrub step is operationally fragile; CoW snapshots eliminate the failure mode by design (delta is discarded, golden image is the only shared state and it is read-only).
+  - **Reset isn't free.** Wiping a 10 GiB PVC before a session lease takes seconds-to-minutes; discarding a qcow2 delta is constant-time.
+  - **Claim controller drag.** Per-session PVC create/delete melts the apiserver at high session churn ([A2](#a2--service-per-pod--service-per-session)-class failure). CoW snapshots are a storage-layer concern, no k8s object on the create path.
+  - **No multi-region story.** PVCs are AZ-pinned (RWO). The CoW-rootfs + S3-FUSE pattern is location-agnostic: the next VM can spawn in a different region and re-bind to the same `filesystem_id` prefix.
+  - **Wrong primitive shape.** "Continue yesterday's session" is a **Tier 4** concern (the user's *data*), not a Tier 3 concern (the agent's *runtime fs*). The PVC tries to solve the wrong problem.
+- **Our choice — Tier 3 is always ephemeral; CoW snapshot is the implementation.**
+  - **No PVC for the session workspace tier in any template.** Helm admission rejects `persistence != ephemeral` on Tier 3.
+  - **Phase 9 (Kata / FC):** Tier 3 = CoW snapshot of golden rootfs via `qcow2` backing files / `dm-thin` snapshots / ZFS `clone`.
+  - **Phase 5 (sysbox / runc):** Tier 3 = tmpfs or overlayfs over the image layer.
+  - **Persistence for the user, when needed,** is served by Tier 4 (S3 + FUSE) with `filesystem_id` session-token auth — the next VM re-binds to the same prefix.
+  - PVC remains the right primitive for **classical platform workloads** (PostgreSQL, Redis, Prometheus, etcd) — none of which our sandbox runtime hosts. This antipattern is scoped to the sandbox session workspace tier specifically.
+- **Phase.** 3 (storage MVP) — admission rule lands here. 9 (Kata templates) — CoW backend wires in.
+- **Detection.**
+  - Grep every Helm template / `SandboxTemplate` for `kind: PersistentVolumeClaim` inside a sandbox spec — should not exist outside platform-services charts.
+  - Admission webhook: `SandboxTemplate.mounts[type=workspace].persistence` must be `ephemeral`; any other value rejected with a link to this entry.
+  - Integration test: spawn → write file → terminate → spawn fresh → assert file absent (clean reset). No scrub step in the provisioning path.
+
 ---
 
 ## Section C — Antipatterns specific to OUR stack (not in sandboxd)
@@ -511,13 +532,13 @@ Quick lookup: when planning Phase N, scan these entries.
 | 0.5 (docs polish) | A18 (don't build yet another platform — record decisions, don't reimplement) |
 | 1 (provider interface) | A10, A11 (start image hygiene + reproducibility) |
 | 2 (HTTP pool sidecar) | A12 (warm pool bounds), A13 (idle timeout skeleton) |
-| 3 (S3 + squashfs) | A9 (ephemeral by default), A10 (no secrets in image), A34 (encryption if persistence) |
+| 3 (S3 + squashfs) | A9 (ephemeral by default), A10 (no secrets in image), A34 (encryption if persistence), **A37 (no PVC for sandbox session workspace)** |
 | 4 (secret broker) | A8 (per-session JWT), A33 (signing key rotation) |
-| 5 (Helm + K8sProvider) | A2 (no per-session Service), A3 (overprovisioning), A5/A36 (pod IP cache + watch), A11 (cosign verify), A12 (warm pool real), A15 (graceful shutdown), A16 (`restartPolicy: Never`), A17 (cattle/pets), A29 (smoke tests), A30 (kernel version validation) |
+| 5 (Helm + K8sProvider) | A2 (no per-session Service), A3 (overprovisioning), A5/A36 (pod IP cache + watch), A11 (cosign verify), A12 (warm pool real), A15 (graceful shutdown), A16 (`restartPolicy: Never`), A17 (cattle/pets), A29 (smoke tests), A30 (kernel version validation), **A37 (no PVC for sandbox session workspace — admission rule)** |
 | 6 (Go control plane) | A4 (no ClientIP affinity), A5/A36 (informer-driven cache), A8 (mint JWT), A14 (audit metadata only), A26 (no env values in logs), C5 (3 replicas), C6 (leader-only reconcile), C8 (buf-lint), C9 (single ToolCall), C10 (HTTP/JSON debug-only) |
 | 7 (Go guest agent) | A1 (defense in depth, all 4 layers), A6 (Configure-before-Chrome), A7 (no auth in agent), A15 (cooperative Shutdown RPC), A27 (versioned agent), A35 (tight seccomp), C1 (vsock auto-detect), C3 (4 RPC shapes), C4 (push model) |
 | 8 (egress proxy + audit) | A8 (token lifetime), A14/A25/A26 (log discipline), A24 (DNS rebinding), A31 (wildcard rejection), A32 (CONNECT timeouts), A33 (key rotation overlap) |
-| 9 (Kata + CH) | A20 (`cache=never`), A21 (seccomp ON), A23 (Landlock pre-declare), A28 (template-level RuntimeClass), C2 (dedicated node pool), C7 (don't bake runtime) |
+| 9 (Kata + CH) | A20 (`cache=never`), A21 (seccomp ON), A23 (Landlock pre-declare), A28 (template-level RuntimeClass), **A37 (CoW snapshot backend for Tier 3, not PVC)**, C2 (dedicated node pool), C7 (don't bake runtime) |
 | 10 (snapshot/HA) | A19 (measure first), A22 (no GPU on snapshottable), A34 (KMS per session), and the sandboxd post-restore hardening triad (CRNG reseed, `init_on_free=1`, `CAP_SYS_RESOURCE` drop) |
 
 ---

--- a/docs/future-architecture/architecture/06-storage.md
+++ b/docs/future-architecture/architecture/06-storage.md
@@ -10,10 +10,10 @@
 
 | Tier | What | Mode | Lifetime | Backend |
 |---|---|---|---|---|
-| **1. Image layers** | OS, runtimes, guest agent | RO | per release | OCI registry (cached on host) |
-| **2. Skills** | AI capability bundles (`skills/`) | RO | per release, immutable | Object store (S3) as squashfs blobs |
-| **3. Workspace home** | `/home/assistant` per session | RW | per session (ephemeral default; opt-in PVC) | tmpfs / overlayfs / RWO PVC |
-| **4. User data** | uploads, outputs, tool results | RW | per tenant | S3-compatible object storage, mounted via FUSE sidecar |
+| **1. Image layers** | OS, runtimes, guest agent | RO | per release | OCI registry (cached on host); sealed `squashfs` block disks for the binaries / skills split once Phase 9 lands |
+| **2. Skills** | AI capability bundles (`skills/`) | RO | per release, immutable | Object store (S3) as squashfs blobs; **materialized at provisioning, not runtime** ([no hot-reload](../research/19-anthropic-firecracker-microvm-internals-observed.md#layer-5--skills-as-a-provisioning-time-concern-not-a-runtime-one)) |
+| **3. Workspace home** | `/home/assistant` per session | RW | per session, ephemeral | **CoW snapshot of golden rootfs** (qcow2 backing / dm-thin / ZFS clone) on Kata/CH; tmpfs / overlayfs on sysbox/runc. **Never PVC** (see [A37](../antipatterns.md#a37--pvc-for-sandbox-session-workspace)) |
+| **4. User data** | uploads, outputs, tool results | RW | per tenant | S3-compatible object storage, mounted via FUSE sidecar; **no S3 credentials inside the guest** ([session-token auth](../research/19-anthropic-firecracker-microvm-internals-observed.md#layer-4--credentials-identity-and-the-no-s3-keys-in-the-guest-rule)) |
 
 ## Tier 1 — Image
 
@@ -39,9 +39,11 @@ Benefits:
 
 ## Tier 3 — Workspace home
 
-- `/home/assistant` is the AI agent's working directory.
-- **Default ephemeral:** tmpfs or overlayfs over image layer. Vanishes when sandbox dies.
-- **Opt-in persistent:** RWO PVC (k8s) or named volume (Compose), keyed by `session_id` or `tenant_id+project_id`. Single-writer always — no RWX. Explicit cleanup policy required.
+- `/home/assistant` is the AI agent's working directory. **Always ephemeral.** Vanishes when the sandbox dies.
+- **Compose / k8s today (sysbox, runc):** tmpfs or overlayfs over the image layer.
+- **Phase 9 target (Kata + CH / FC):** **CoW snapshot of a golden rootfs image** at the storage layer — `qcow2` backing files, `dm-thin` snapshots, or ZFS `clone`. This is the pattern observed in Anthropic's production sandbox ([`research/19-anthropic-firecracker-microvm-internals-observed.md` §2.3](../research/19-anthropic-firecracker-microvm-internals-observed.md#23-rootfs-as-cow-snapshot--the-pvc-replacement-pattern-)). Per-session ext4 deltas live on the snapshot; the delta is discarded at session end. The golden image is shared and untouched.
+- **No PVC for the session workspace tier in any template.** RWO PVC is rejected — CoW snapshot is cheaper, faster, and gives stronger reset-on-spawn guarantees with no claim controller, no quota controller, no garbage collection. See [A37](../antipatterns.md#a37--pvc-for-sandbox-session-workspace) for the locked-decision rationale. "Continue yesterday's session" is served by Tier 4 (S3) — the workspace re-binds to the same `filesystem_id` prefix on the next VM, no PVC needed.
+- **Per-VM soft cap.** Phase 9 templates set ext4 `resuid=65534,resgid=65534` so reserved blocks are claimable by no one, yielding a cheap per-VM ENOSPC ceiling without a quota daemon ([§2.2](../research/19-anthropic-firecracker-microvm-internals-observed.md#22-the-ext4-reserved-blocks-quota-trick)). Phase 3 / 5 can ship with a plain 10 GiB volume.
 
 ## Tier 4 — User data
 
@@ -67,7 +69,8 @@ mounts:
     path: /usr/local/share/skills/pptx
     mode: ro
   - type: workspace
-    persistence: ephemeral            # or "pvc:claim-name"
+    persistence: ephemeral            # only "ephemeral"; PVC rejected (A37)
+    backend: cow-snapshot             # qcow2 | dm-thin | zfs-clone (Phase 9); overlayfs (sysbox/runc)
     path: /home/assistant
   - type: user-data
     backend: s3
@@ -85,14 +88,18 @@ mounts:
 | 2 | None directly; provider learns mount specs but Docker still binds local fs |
 | 3 | MinIO into Compose; `S3_*` config; FUSE sidecar pattern; squashfs skill blobs |
 | 4 | Per-session STS tokens replace static S3 creds |
-| 5 | K8s provider uses PVCs (RWO) for Tier 3 opt-in persistence; FUSE pattern carried to pods |
+| 5 | K8s provider keeps Tier 3 ephemeral (tmpfs / overlayfs on sysbox); no PVC for sandbox session workspace ([A37](../antipatterns.md#a37--pvc-for-sandbox-session-workspace)); FUSE pattern carried to pods |
 | 8 | virtio-fs replaces FUSE on kata-ch (faster, kernel-level) |
+| 9 | Tier 3 = CoW snapshot of golden rootfs (qcow2 / dm-thin / ZFS) on Kata templates; ext4 `resuid=nobody` per-VM ceiling; sealed `squashfs` disks for binaries / system skills ([`research/19`](../research/19-anthropic-firecracker-microvm-internals-observed.md)) |
 
 ## Explicit non-goals
 
 - **No RWX (ReadWriteMany).** Single-writer patterns only. Avoids EFS/Filestore complexity and consistency surprises.
 - **No proprietary CSI drivers.** S3-compatible API only.
 - **No custom storage gateway.** Use existing FUSE / virtio-fs / CSI building blocks.
+- **No PVC for the sandbox session workspace (Tier 3).** Locked decision — see [A37](../antipatterns.md#a37--pvc-for-sandbox-session-workspace). CoW snapshot at the storage layer replaces it. PVC remains the right primitive for stateful platform services (PostgreSQL, Redis, Prometheus, etcd) — none of which our sandbox runtime hosts.
+- **No S3 credentials inside the sandbox guest.** Tier 4 Phase 4 target end-state: guest carries a `filesystem_id` session token, broker / storage proxy holds S3 keys server-side ([`research/19` §4](../research/19-anthropic-firecracker-microvm-internals-observed.md#layer-4--credentials-identity-and-the-no-s3-keys-in-the-guest-rule)).
+- **No skill hot-reload.** Skills materialize at provisioning, are immutable for the lifetime of the VM ([`research/19` §5](../research/19-anthropic-firecracker-microvm-internals-observed.md#layer-5--skills-as-a-provisioning-time-concern-not-a-runtime-one)).
 
 ## Source
 

--- a/docs/future-architecture/research/16-anthropic-production-sandbox-observed.md
+++ b/docs/future-architecture/research/16-anthropic-production-sandbox-observed.md
@@ -6,7 +6,9 @@
 > Source: empirical observation from inside a live Anthropic Claude sandbox session, 2026-05.
 > Distinct from [`13-anthropic-sandbox-runtime.md`](./13-anthropic-sandbox-runtime.md) which covers the open-source local sandbox (`anthropic-experimental/sandbox-runtime`, bubblewrap-based). This file documents the **production hosted environment** — closed, but observable from the inside.
 >
-> Status: **observation, not yet decision-grade.** Locks in only one downstream choice (rclone baseline for Tier 4 — see [`../architecture/06-storage.md`](../architecture/06-storage.md)). All other implications stay open until Phase 3 / Phase 7 / Phase 8 research.
+> **Companion deep dive:** [`19-anthropic-firecracker-microvm-internals-observed.md`](./19-anthropic-firecracker-microvm-internals-observed.md). This file is the high-level summary; #19 is the layer-by-layer transcript with every supporting datum, locked decisions (incl. "no PVC for sandbox session workspace" — [A37](../antipatterns.md#a37--pvc-for-sandbox-session-workspace)), and a reproduction recipe.
+>
+> Status: **observation, not yet decision-grade.** Locks in only one downstream choice (rclone baseline for Tier 4 — see [`../architecture/06-storage.md`](../architecture/06-storage.md)). All other implications stay open until Phase 3 / Phase 7 / Phase 8 research. See #19 for additional locked decisions.
 
 ## 1. Runtime — Firecracker microVM, NOT k8s
 

--- a/docs/future-architecture/research/19-anthropic-firecracker-microvm-internals-observed.md
+++ b/docs/future-architecture/research/19-anthropic-firecracker-microvm-internals-observed.md
@@ -1,0 +1,362 @@
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+<!-- Copyright (c) 2025 Open Computer Use Contributors -->
+
+# 19 — Anthropic Firecracker microVM internals (deep dive, observed)
+
+> Source: live-VM walk inside an Anthropic Claude production sandbox session, 2026-05-17, all evidence collected from inside the guest with shell tools (`cat /proc/cmdline`, `lsblk`, `mount`, `ps -ef`, `findmnt`, `stat`, `sha256sum`, `uptime -s` vs directory Birth times).
+>
+> Companion to [`16-anthropic-production-sandbox-observed.md`](./16-anthropic-production-sandbox-observed.md). #16 stays the high-level summary; this file is the **layer-by-layer transcript** with every datum that supports the picture, so we can replicate it later without re-running the experiment.
+>
+> Status: **decision-grade.** Locks one new decision (no PVC for sandbox session workspace — Tier 3 is CoW snapshot, not RWO PVC; see [`../architecture/06-storage.md`](../architecture/06-storage.md) and antipattern [A37](../antipatterns.md#a37--pvc-for-sandbox-session-workspace)). All other implications carry forward as inputs to Phase 3, Phase 5, Phase 7, Phase 9 research.
+
+## Locked decisions emerging from this observation
+
+| # | Decision | Where locked |
+|---|---|---|
+| L1 | **No PVC for sandbox session workspace (Tier 3).** Use CoW snapshot of a golden rootfs (qcow2 backing files / dm-thin / ZFS-clone), not RWO PVC. PVC is rejected for the agent session workspace tier in all templates. | [`../architecture/06-storage.md`](../architecture/06-storage.md) Tier 3 + [A37](../antipatterns.md#a37--pvc-for-sandbox-session-workspace) |
+| L2 | **Sealed read-only system disks** (binaries, system skills) ship as `squashfs` on dedicated block devices, not as layers inside the rootfs. | [`../architecture/06-storage.md`](../architecture/06-storage.md) Tier 1 / Tier 2 |
+| L3 | **No S3 credentials inside the guest.** Storage-side auth: the guest carries only a `filesystem_id` session token; the storage proxy outside the VM maps `filesystem_id → bucket prefix` and holds the S3 creds. | [`../architecture/07-security.md`](../architecture/07-security.md) Tier-4 credential boundary |
+
+All other items in this file are research inputs, not amendments to existing ADRs.
+
+---
+
+## Layer 1 — Hypervisor and init
+
+### 1.1 Firecracker microVM, custom Go init, no systemd
+
+Kernel cmdline (verbatim, line-broken for readability):
+
+```text
+rdinit=/process_api --firecracker-init --addr 0.0.0.0:2024
+  --max-ws-buffer-size 32768 --block-local-connections
+console=ttyS0 reboot=k panic=1 nomodule random.trust_cpu=1
+  ipv6.disable=1 swiotlb=noforce init_on_free=1
+```
+
+- **VMM = Firecracker.** The `--firecracker-init` flag is unambiguous (confirms [#16 §1](./16-anthropic-production-sandbox-observed.md)).
+- **PID 1 = `/process_api`,** a custom Go binary, invoked via kernel `rdinit=` so it runs **directly off the initramfs ramdisk**, bypassing any `init` / `systemd` / `sysvinit` stage entirely.
+- `process_api` is the everything-init: mounts the squashfs disks, spawns and supervises `rclone-filestore`, serves a control-plane WebSocket on `0.0.0.0:2024`, reaps zombies, runs the agent's exec loop.
+- No containerd, no runc, no Kubernetes, no Docker. Bare Firecracker VM.
+
+Process census inside the live VM: ~56 processes total, **two user-space**:
+
+| PID | Process | Role |
+|---|---|---|
+| 1 | `process_api` | Init, control-plane WS, supervisor, exec |
+| 489 | `rclone-filestore` (custom rclone fork, `multimount` subcommand) | All four FUSE mounts in one process |
+
+The rest are kernel threads.
+
+### 1.2 Kernel hardening flags (each justified)
+
+| Flag | Effect | Why |
+|---|---|---|
+| `rdinit=/process_api` | Skip `/sbin/init`, run custom binary | Removes systemd attack surface; deterministic boot |
+| `--firecracker-init` (binary flag) | `process_api` knows it's PID 1 inside FC | Branches mount/setup behavior |
+| `--addr 0.0.0.0:2024` | Control-plane WS bind | TCP, not vsock — see [#16 §2](./16-anthropic-production-sandbox-observed.md) |
+| `--max-ws-buffer-size 32768` | Bound WS frame size | DoS mitigation |
+| `--block-local-connections` | Drop guest-to-guest local syscalls on control path | Internal lockdown — guest code can't talk to the control plane port |
+| `console=ttyS0` | Serial console (Firecracker only exposes ttyS0) | Standard FC |
+| `reboot=k panic=1` | Reboot via keyboard reset; panic = exit immediately | FC reboot model — panic = VM dies, host respawns |
+| `nomodule` | Disable post-boot kernel module loading | Locks attack surface — even root can't `insmod` |
+| `random.trust_cpu=1` | RDRAND counted as seeded entropy | Skip slow entropy gather; fine inside FC where RDRAND is virtualized |
+| `ipv6.disable=1` | No IPv6 stack | Smaller surface, single egress path to manage |
+| `swiotlb=noforce` | Skip software IOTLB bounce buffer | Perf — FC presents native virtio, no need for swiotlb |
+| `init_on_free=1` | Zero pages on `kfree` | Prevents info-leak across freed allocations (CVE class) |
+
+**Takeaway for us.** Every flag is intentional; copying them in our Phase 9 Kata/CH template defaults is cheap and gives meaningful hardening. See [A37](../antipatterns.md) and the cross-link to [`research/05-firecracker.md`](./05-firecracker.md).
+
+---
+
+## Layer 2 — Block devices: four disks, three classes of mutability
+
+```text
+NAME  MAJ:MIN  SIZE   RO  TYPE      MOUNTPOINT             ROLE
+vda   254:0    256G   rw  ext4      /                      ephemeral rootfs, CoW-snapshot of golden image
+vdb   254:16   9.4M   ro  squashfs  /opt/rclone            sealed rclone-filestore binary
+vdc   254:32   656K   ro  squashfs  /mnt/skills/public     Anthropic-built system skills
+vdd   254:48   5.3M   ro  squashfs  /mnt/skills/examples   example skills
+```
+
+### 2.1 Why four disks, not one layered image
+
+One read-write disk for ephemeral session state; three sealed read-only `squashfs` blocks for **everything that must be tamper-evident at boot.** Different classes of data → different disks with different mutability:
+
+- **Binaries and system skills are version-pinned artifacts**, shipped independently of rootfs. Updating rclone or the public skill set does not require rebuilding the golden rootfs. They are also bit-identical across every session that uses the same template version.
+- **Even guest root cannot mutate them at runtime** — they're `ro` at the block layer, not just at the mount layer. `mount -o remount,rw` does nothing.
+- **An RCE inside the guest cannot swap out `rclone-filestore` or a system skill,** because the underlying block device refuses writes. This is the strongest possible host-side guarantee without crypto.
+
+### 2.2 The ext4 reserved-blocks quota trick
+
+`vda` is a 256 GiB ext4, but `df` inside the guest reports only ~10 GiB free for the agent user. The mount line shows the mechanism:
+
+```text
+/dev/vda on / type ext4 (rw,...,resuid=65534,resgid=65534,...)
+```
+
+- ext4 `resuid` / `resgid` reserves a fraction of free blocks for **a specific uid/gid only.** Default is `root` (uid 0).
+- Anthropic sets `resuid=65534,resgid=65534` (`nobody:nogroup`) — a uid that no real process runs as. The reserved blocks are effectively claimable by **no-one**, so the agent (running as `claude`, uid 999) hits ENOSPC at ~10 GiB despite a 256 GiB volume.
+- This gives **per-VM quota at near-zero runtime cost** — no `quota` daemon, no XFS project quotas, no LVM thin volume. Just ext4 tunables baked at provisioning time.
+
+**Takeaway for us.** Cheap per-session-soft-cap pattern for our Phase 9 microVM templates. Useful early Phase 5 as well (k8s ephemeral-storage limits are weaker). Document but ship later (no Phase-3 priority).
+
+### 2.3 Rootfs as CoW snapshot — the PVC-replacement pattern ⭐
+
+`vda` is 256 GiB but it is not 256 GiB of allocated storage. It's an ext4 filesystem **on a CoW snapshot of a golden rootfs image**. Evidence:
+
+- Directory Birth time on `/root`, `/home/claude`, `/tmp` matches the golden-image build date, not VM boot — these directories are inherited from the snapshot, not created fresh.
+- `uptime -s` says boot was ~35 min before this observation; many directory Birth times are days older. CoW.
+- The 256 GiB is the **maximum** the rootfs can grow to (sparse), not the actual provisioned storage.
+
+The host-side implementation is `qcow2` backing files (Firecracker supports this), or `dm-thin` snapshots, or ZFS clone — observation cannot tell which. What it can tell:
+
+> **The session workspace is a per-VM CoW snapshot of a shared template, not a per-session persistent volume.** Per-session ext4 deltas live on the snapshot; when the session ends, the delta is discarded and the golden image untouched.
+
+This is the technical answer to "do we need PVC for `/home/assistant`?" — **no**. CoW snapshot at the storage layer (qcow2 / dm-thin / ZFS) supplies the same "every session starts from a clean template" guarantee with zero state across sessions, no RWX problems, no garbage collection, no per-tenant claim management.
+
+**Cross-link.** This locks [A37](../antipatterns.md#a37--pvc-for-sandbox-session-workspace) and the Tier 3 wording in [`06-storage.md`](../architecture/06-storage.md).
+
+---
+
+## Layer 3 — FUSE mounts for persistent state (rclone multimount)
+
+```text
+fuse.rclone → /mnt/user-data/uploads        ro    vfs-cache-time 1s
+fuse.rclone → /mnt/user-data/outputs        rw    vfs-cache-time 3600s
+fuse.rclone → /mnt/user-data/tool_results   ro    vfs-cache-time 3s
+fuse.rclone → /mnt/transcripts              ro    vfs-cache-time 10s
+```
+
+All four mounts are served by **one** process — `rclone-filestore` (PID 489) running a `multimount` subcommand. The `multimount` subcommand does not exist in upstream `rclone` — Anthropic forked rclone and added it.
+
+From the binary's own `--help` (extracted inside the guest):
+
+> Designed for Firecracker containers where a single init script manages all mounts. Uses go-fuse/v2 with DirectMount (no fusermount subprocess) to avoid chroot deadlocks. Once every mount is ready, a ready_file is touched to signal the init script.
+
+Three deliberate engineering choices baked into `multimount`:
+
+1. **`go-fuse/v2` with DirectMount** — bypasses the setuid `fusermount` helper. Smaller TCB; no setuid binary inside the guest at all.
+2. **`ready_file` synchronization** — `process_api` blocks on the `ready_file` touch before declaring the VM ready to accept agent traffic. Eliminates the "container started but mounts not ready" race that plagues normal FUSE deployments.
+3. **One process, all mounts** — single SIGTERM tears down all four cleanly; memory footprint one rclone process, not four.
+
+### 3.1 Per-mount VFS cache TTL — semantics-driven
+
+The TTLs are chosen per-mount based on writer/reader patterns:
+
+| Mount | TTL | Pattern |
+|---|---|---|
+| `uploads/` (ro) | 1 s | User writes from outside; agent needs to see new uploads near-immediately |
+| `outputs/` (rw) | **3600 s** | Agent is the sole writer — local cache is authoritative for the session |
+| `tool_results/` (ro) | 3 s | Control plane writes; agent reads soon after |
+| `transcripts/` (ro) | 10 s | Updated occasionally; bounded staleness OK |
+
+Pattern: **read-heavy + multi-writer ⇒ short TTL; write-heavy + single-writer ⇒ long TTL.** This is a portable design rule for any FUSE-over-object-store layout, not Anthropic-specific.
+
+**Takeaway for us.** Folds into the Tier 4 Phase 3 research:
+- Multimount in one process — defer. Upstream `rclone mount` × N is fine until we hit boot-time bottlenecks.
+- DirectMount — only matters once we go FUSE-in-guest on Kata. Today we mount on the host / sidecar, so the setuid helper isn't in the threat model.
+- TTL-per-semantic table — adopt verbatim into the Tier 4 mount spec.
+- `ready_file` pattern — adopt at Phase 7 (guest agent boots only after mounts ready).
+
+---
+
+## Layer 4 — Credentials, identity, and the "no S3 keys in the guest" rule
+
+The rclone mount config inside the guest (representative):
+
+```json
+{
+  "filesystem_id": "claude_chat_01Ss4WPSeLtHEPZ1q3qBrjt7",
+  "source": "/uploads",
+  "destination": "/mnt/user-data/uploads",
+  "readonly": true,
+  "vfs_cache_mode": "full",
+  "vfs_cache_max_size": "1G",
+  "cache_duration_s": 1.0,
+  "uid": 999,
+  "gid": 1000
+}
+```
+
+What is **not** in this config — and not anywhere else in the guest:
+
+- No S3 `access_key_id`.
+- No S3 `secret_access_key`.
+- No STS token.
+- No bucket name.
+- No S3 endpoint URL.
+- No IAM role ARN.
+
+The only thing in the guest is a **session token** (`filesystem_id`). The guest's `rclone-filestore` calls out to a **storage proxy server outside the VM**, which holds the actual S3 credentials and maps `filesystem_id → S3 bucket prefix` server-side.
+
+### 4.1 Security boundary
+
+| Compromise scenario | Blast radius |
+|---|---|
+| Guest RCE | Attacker has access to their own `filesystem_id` prefix only. No S3 keys to steal. No way to reach another session's data — auth happens server-side by `filesystem_id`. |
+| Single `filesystem_id` leak | Attacker can read/write that one session's prefix. Cannot enumerate others; cannot get long-lived S3 creds. |
+| S3 credential leak | Impossible from the guest layer — they don't exist in the guest. |
+
+This is the **strongest available** boundary short of E2EE on every object. It's how we want our Tier-4 to behave by Phase 4 (secret broker).
+
+**Cross-link.** Compatible with our Phase 4 plan (STS tokens) but stricter: even STS tokens are absent from the guest in Anthropic's model. Worth folding into Phase 4 research as a target end-state — see [`17-anthropic-claude-code-remote-env-observed.md`](./17-anthropic-claude-code-remote-env-observed.md) §3 (FD-passing) for the same hardening philosophy applied to a different secret class.
+
+---
+
+## Layer 5 — Skills as a provisioning-time concern, not a runtime one
+
+Three classes of skills, three delivery mechanisms:
+
+```text
+/mnt/skills/public      → squashfs ro on vdc     Anthropic-built, immutable per template version
+/mnt/skills/examples    → squashfs ro on vdd     example skills, immutable per template version
+/mnt/skills/user        → ext4 rw on /vda        per-user skills, baked into rootfs at provisioning
+```
+
+User skills are **injected into rootfs at provisioning time**, not pulled at runtime. Evidence by comparing the same skill file across two VMs spawned for the same chat user a few minutes apart:
+
+| | VM A (older session) | VM B (fresh session, same user) |
+|---|---|---|
+| `sha256sum /mnt/skills/user/foo/SKILL.md` | `419bb48f…` | `9534653f…` |
+| "v2" marker in file | absent | present at line 8 |
+
+Same source-of-truth (S3 / database), different snapshots inside each VM. The source updated between A and B; B picked up the change at provisioning, A did not, **even though both VMs are still alive at the same time.**
+
+### 5.1 Why this is the right design
+
+- **Determinism.** An agent mid-task cannot get code modified out from under it. Every tool exec in a single VM runs against the same skill snapshot.
+- **No runtime invalidation surface.** No `inotify` watch, no version checks per tool call, no hot-reload race.
+- **Auditability.** Every session has a fixed skill-snapshot fingerprint — recordable in audit logs.
+- **Security.** A skill cannot be modified mid-execution by another tenant or a compromised control plane component; the bytes that run are the bytes the VM was provisioned with.
+
+**Takeaway for us.** When Phase 3 lands squashfs skills, **adopt the bake-at-provisioning model for user skills too,** not just Anthropic's "system" ones. No runtime hot-reload of skills. This is consistent with our Phase 3 acceptance ("Sandbox image no longer carries `/usr/local/share/skills/` baked in") — the skills come from S3 squashfs blobs, but they're materialized **once per VM at boot**, not watched for updates during the session.
+
+---
+
+## Layer 6 — VM lifecycle: pause/resume between messages
+
+VMs are **not kept alive between user messages.** They are paused and resumed via Firecracker snapshot/restore. Evidence:
+
+| Signal | Value | What it means |
+|---|---|---|
+| `uptime -s` | `2026-05-17 14:39:51` | Kernel boot |
+| `stat /home/claude` Birth | `2026-05-17 12:08:21` | rootfs was built earlier — golden image |
+| Wall clock at observation | `2026-05-17 15:15:01` | ~35 min into uptime, but most directories older |
+| Empty `dmesg` since uptime+5s | no warm-running noise | VM was resumed from snapshot mid-execution; little post-boot activity |
+
+The control plane orchestrates this — VM resume on first user message arrival, pause after agent's reply lands, snapshot the dirty pages, hand the VM back to the warm-pool. Cold sessions ≥ N minutes old are torn down completely; the FUSE mounts re-bind to the same S3 prefix the next time the chat is opened, so the user's workspace returns even if the VM didn't.
+
+### 6.1 Full lifecycle (reconstructed from evidence)
+
+```text
+1. User opens a new chat
+   └─ control plane clones golden-rootfs.img → my-vm.img (CoW snapshot at storage layer)
+   └─ injects /mnt/skills/user/* into rootfs (from S3 / DB source-of-truth at this instant)
+   └─ injects container_info.json (session_id, limits)
+   └─ Firecracker start --drive my-vm.img --kernel vmlinuz...
+
+2. Boot
+   └─ kernel cmdline → rdinit=/process_api → PID 1
+   └─ process_api mounts vdb (rclone bin), vdc (skills public), vdd (skills examples)
+   └─ process_api starts rclone-filestore multimount → touches ready_file when 4 mounts up
+   └─ process_api signals control plane: ready
+
+3. User sends a message
+   └─ control plane resumes VM (FC snapshot restore, ~100ms) — or cold-boots if needed
+   └─ agent runs: writes to /home/claude (ext4 delta on vda), reads/writes /mnt/user-data/* (FUSE → S3)
+   └─ control plane pauses VM after reply (FC snapshot)
+
+4. Chat idle / closed
+   └─ Firecracker SIGTERM → process_api → rclone graceful umount → exit
+   └─ my-vm.img CoW delta discarded
+   └─ S3 prefix remains for restore
+
+5. User returns to chat (even days later)
+   └─ control plane provisions a NEW VM with the SAME session_id (filesystem_id)
+   └─ FUSE-mount re-binds to the existing S3 prefix
+   └─ workspace re-appears — but skills may be updated (provisioned fresh)
+```
+
+**Takeaway for us.** This is the right cost model for our Phase 9 templates: VMs are not long-running; they're paused/resumed on the order of message latency. Snapshotting is the architecture, not an optimization. Folds into Phase 10 (snapshot/restore) as the canonical pattern.
+
+---
+
+## Final mental model — storage by data class
+
+| Data class | Examples | Storage | Lifecycle | Delivery |
+|---|---|---|---|---|
+| **System binaries** | `rclone-filestore`, agent runtime | `squashfs` on a dedicated `ro` disk | versioned artifact | bake into VM image (sealed disk) |
+| **System skills** | `/mnt/skills/public`, `/mnt/skills/examples` | `squashfs` on dedicated `ro` disks | per template version, immutable | sealed disks, bit-identical across sessions |
+| **User customization** | `/mnt/skills/user`, dotfiles | `ext4` on rootfs | per-user mutable | **inject at provisioning** (not runtime) |
+| **Session workspace** | `/home/claude`, `/tmp`, scratch | `ext4` on rootfs (CoW delta) | ephemeral, dies with VM | **CoW snapshot of golden rootfs** |
+| **Persistent state** | uploads, outputs, tool_results | S3 via FUSE | per session, survives VM | runtime FUSE mount, server-side auth |
+| **Identity** | `session_id` | `container_info.json` | per session | inject at provisioning |
+
+**Where PVC fits in this picture: it does not.** Every row above has a better answer than RWO PVC:
+
+- Ephemeral workspace → CoW snapshot at the storage layer is cheaper, faster, and gives stronger reset-on-spawn guarantees than a wiped-on-claim PVC. No claim controller, no quota controller, no GC.
+- Persistent state → S3 with server-side auth is stronger than a PVC reused across sessions (auth boundary, no GC), and trivially multi-region.
+- System binaries / skills → sealed `squashfs` is stronger than a PVC (immutable, not just "shouldn't change").
+
+PVC remains the right answer for **classical workloads** that our sandbox runtime does not host: PostgreSQL, Redis, Prometheus, etcd. For agent sandboxes specifically, it's the wrong primitive. See [A37](../antipatterns.md#a37--pvc-for-sandbox-session-workspace).
+
+---
+
+## Implications and where they land in the roadmap
+
+| Layer in this file | Roadmap target | What feeds in |
+|---|---|---|
+| 1 — Firecracker init, kernel cmdline | [Phase 9](../roadmap.md#phase-9) (Kata + CH) and Phase 7 (guest agent) | Adopt kernel hardening flag set as template default. Agent PID-1 design copies `process_api` shape — single Go binary, supervises children, exposes control-plane WS. |
+| 2 — Multi-disk squashfs + CoW rootfs | [Phase 3](../roadmap.md#phase-3) (storage MVP) and Phase 9 | Squashfs for system binaries / skills lands at Phase 3. CoW rootfs (qcow2 backing) lands at Phase 9 as the per-VM disk. Reject PVC for Tier 3 now ([A37](../antipatterns.md#a37--pvc-for-sandbox-session-workspace)). |
+| 3 — rclone multimount, VFS TTLs | [Phase 3](../roadmap.md#phase-3) | Adopt TTL-per-semantic table verbatim. Defer multimount fork; ship one `rclone` process per mount until measured boot bottleneck. Adopt `ready_file` synchronization pattern at Phase 7. |
+| 4 — No S3 creds in guest | [Phase 4](../roadmap.md#phase-4) (secret broker) | Target end-state: guest carries `filesystem_id` only, broker holds S3 creds server-side. Stronger than the Phase 4 STS-token-in-guest baseline. Folds into Phase 4 research as the stretch goal. |
+| 5 — Skills bake-at-provisioning | [Phase 3](../roadmap.md#phase-3) | When squashfs skills land, materialize at provisioning, not runtime. No hot-reload. |
+| 6 — VM pause/resume | [Phase 10](../roadmap.md#phase-10) | Snapshot/restore is the lifecycle, not an optimization. Phase 10 acceptance must include pause/resume across messages, not just cold start. |
+
+---
+
+## What to copy verbatim from Anthropic's design
+
+When the corresponding phase ships, take these patterns as-is:
+
+1. **Firecracker microVM + custom Go init via `rdinit=`.** No systemd, no Docker, no containerd inside the guest. — Phase 7 + Phase 9.
+2. **Multi-disk layout: ext4 rootfs + sealed `squashfs` for system binaries and system skills.** — Phase 3 (skills disk) + Phase 9 (binaries disk).
+3. **CoW snapshot rootfs** via `qcow2` backing files / `dm-thin` / ZFS clone. Storage-level CoW, **NOT** overlayfs inside the guest. — Phase 9.
+4. **Two-tier rclone.** Custom multimount inside the VM, `rclone serve` outside the VM. No S3 keys in the guest. — Phase 4 stretch.
+5. **`filesystem_id` session-token auth.** Guest carries only the token; storage proxy maps token → bucket prefix. — Phase 4 stretch.
+6. **Skills materialized at provisioning, not runtime.** No hot-reload. — Phase 3.
+7. **ext4 `resuid=nobody,resgid=nobody` for cheap per-VM quota.** — Phase 9 (template default).
+8. **VM pause/resume via FC snapshots** between user messages; warm-pool of paused VMs, not running ones. — Phase 10.
+
+## What to simplify on day one (not copy)
+
+- **Do not fork rclone yet.** Use `rclone serve webdav` outside + `rclone mount` inside. Add `multimount` only when start-up time hurts. — Phase 3.
+- **Do not write a custom Go init yet.** Use `tini` / `dumb-init` + a shell script. Custom Go `process_api` arrives only when the shell glue runs out. — Phase 7.
+- **Do not chase ext4 reserved-blocks quota in Phase 3 / 5.** A 10 GiB disk volume gives the same UX. The trick lands in Phase 9 with the Kata templates. — Phase 9.
+
+## What NOT to copy
+
+- **No FUSE-in-guest before Kata / Firecracker.** On `containerd` + `runc`, FUSE-in-guest requires `--privileged`, which voids isolation. Until Phase 9, mount FUSE on the host or in a sidecar (CSI w/ FUSE-on-node). — Phase 5–8.
+- **No overlayfs inside the guest as the workspace layer.** Storage-level CoW (qcow2 / ZFS / dm-thin) is strictly better in every dimension except operator simplicity. The operator cost is paid once at the runtime layer; the benefit accrues to every VM. — Phase 9.
+
+---
+
+## How to reproduce these observations
+
+If we ever want to redo the live-VM walk (e.g., to capture new flags after an Anthropic infrastructure update), the commands are:
+
+```bash
+cat /proc/cmdline                      # kernel cmdline → Firecracker + flags
+ps -ef                                  # find PID 1 = /process_api
+lsblk -o NAME,MAJ:MIN,SIZE,RO,TYPE,MOUNTPOINT   # 4-disk layout
+findmnt -A                              # mount-by-mount with options (TTLs, resuid)
+mount | grep -E '(ext4|squashfs|fuse)'  # cross-check
+cat /tmp/rclone-mount-config.json       # rclone session-token config
+sha256sum /mnt/skills/user/foo/SKILL.md # skill fingerprint
+uptime -s                               # boot time
+stat /                                  # Birth time on rootfs → CoW evidence
+/opt/rclone/rclone-filestore --help     # discover multimount + flags
+```
+
+Run inside any live session within the first minute (some paths get touched later). Save outputs verbatim into a new `research/NN-anthropic-*-observed.md` next time — comparison across snapshots is how we caught the skills-at-provisioning rule (§5.1).


### PR DESCRIPTION
Description retired during the initial-public-release history consolidation. The canonical content lives in docs/architecture/ at the current tip.