### PR TITLE
docs(future-arch): Phase 0.5 polish — supervisor alignment, Rust L1, Lambda framing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,3 +9,7 @@ Brief description of changes.
 - [ ] `./tests/test-project-structure.sh` passes
 - [ ] `./tests/test-docker-image.sh` passes (if Dockerfile changed)
 - [ ] `docker compose up` works end-to-end
+
+## ADRs reviewed (for `docs/future-architecture/` phase work)
+- [ ] N/A — this PR is not phase-execution work, or
+- [ ] List the ADRs re-read for this phase (e.g. `ADR-0002, ADR-0008, ADR-0010` for Phase 7 / 9 / 10 work).

--- a/docs/future-architecture/README.md
+++ b/docs/future-architecture/README.md
@@ -12,7 +12,16 @@ The model is taken from [`sandboxd/`](../../sandboxd/) — a runtime-agnostic, 4
 - **4 layers:** Control Plane (L4) → Orchestrator/Provider (L3) → Sandbox Runtime (L2) → Guest Agent (L1).
 - **11-phase roadmap** (0, 0.5, 1–10). Each phase strips one specific blocker. **No phase breaks the Docker Compose PoC** — that's an [explicit non-blocking invariant](./roadmap.md#non-blocking-invariants).
 - **Order reshuffle** (post-review): egress proxy (now Phase 8) ships **before** Kata untrusted tier (now Phase 9) — otherwise "untrusted" is a lie.
-- **Locked decisions** (ADRs): Go control plane, Go guest agent, Docker-first then any k8s, pluggable runtime via `RuntimeClass`, MCP stays the user-facing protocol, no AGPL/BSL dependencies, **internal = connect-go (gRPC + Connect + HTTP/JSON from one `.proto`); external = MCP + REST; CDP/ttyd = WebSocket passthrough**.
+- **Locked decisions** (ADRs): Go control plane, **Rust guest agent** (rewritten 2026-05-18 after [`research/19`](./research/19-anthropic-process-api.md) study; matches Anthropic `process_api` stack), Docker-first then any k8s, pluggable runtime via `RuntimeClass`, MCP stays the user-facing protocol, no AGPL/BSL dependencies, **internal = connect-go (L4↔L3); L3↔L1 transport re-evaluated at Phase 7 (connect-rust vs WS-frame protocol); external = MCP + REST; CDP/ttyd = WebSocket passthrough**, **AWS Lambda is inspiration, not runtime** ([ADR-0010](./adr/0010-lambda-as-inspiration-not-runtime.md)).
+
+## Reference architectures we draw from
+
+- **Anthropic `process_api`** ([`research/19`](./research/19-anthropic-process-api.md), source under [`sandboxd/anthropic/process_api_re/`](../../sandboxd/anthropic/process_api_re/)) — closest precedent for Phase 7 L1.
+- **AWS Lambda** ([`references.md`](./references.md) Lambda framing, [ADR-0010](./adr/0010-lambda-as-inspiration-not-runtime.md)) — pattern source for Firecracker tiering and snapshot-pool cold-start economics. Inspiration only.
+- **Snapstart hot-swap** ([`research/20`](./research/20-snapstart-hot-swap.md)) — Phase 10 cold-start design.
+- **E2B `envd`** ([`research/02`](./research/02-e2b-infra.md)) — production-shape L1 comparison.
+- **Coder** ([`research/03`](./research/03-coder.md)) — multi-region workspace-proxy pattern.
+- **Anthropic `environment-runner`** ([`research/21`](./research/21-environment-runner-go.md)) — inspiration-only Go session agent; not on roadmap.
 - **Per-phase research-then-sign-off cadence.** Every phase begins with a research pass against the cloned reference repos (under `/references/`, git-ignored) **and** the matching digest in [`research/`](./research/), produces `phase-N-research.md`, and requires owner approval before code starts. **Mandatory pre-read:** the matching phase row in [`antipatterns.md`](./antipatterns.md) — 36 antipatterns mapped to phases, each with our locked decision.
 
 ## Document map
@@ -31,21 +40,23 @@ docs/future-architecture/
 │   ├── 02-layer4-control-plane.md  Go service: MCP gateway, OIDC, admin UI, secret broker
 │   ├── 03-layer3-providers.md      SandboxProvider interface + Docker/K8s/Direct impls
 │   ├── 04-layer2-runtimes.md       runc / sysbox / gVisor / kata-fc / kata-ch matrix
-│   ├── 05-layer1-guest-agent.md    Go agent contract, PID-1 duties, MCP tool exec
+│   ├── 05-layer1-guest-agent.md    Rust agent contract, PID-1 duties, MCP tool exec
 │   ├── 06-storage.md               4-tier: image / squashfs skills / workspace / S3 user-data
 │   ├── 07-security.md              Threat model, secret rotation, egress, image signing, audit
 │   ├── 08-networking.md            NetworkPolicy default-deny, egress proxy, CDP routing
 │   ├── 09-templates.md             SandboxTemplate spec, tenant→template resolver
 │   └── 10-observability.md         Metrics, traces, audit log, SLOs
 └── adr/                            Locked decisions
-    ├── 0001-control-plane-language-go.md
-    ├── 0002-guest-agent-language-go.md      (Rust re-eval gate at Phase 7)
+    ├── 0001-control-plane-language-go.md       (Phase 6 re-eval gate added 2026-05-18)
+    ├── 0002-guest-agent-language-go.md         (rewritten 2026-05-18: Rust, not Go)
     ├── 0003-docker-poc-first-then-k8s.md
     ├── 0004-pluggable-runtime-via-runtimeclass.md
     ├── 0005-mcp-as-control-plane-gateway.md
     ├── 0006-no-agpl-no-bsl-dependencies.md
     ├── 0007-superseded-by-future-architecture.md
-    └── 0008-internal-grpc-external-rest-mcp.md
+    ├── 0008-internal-grpc-external-rest-mcp.md (Phase 7 gate tightened 2026-05-18)
+    ├── 0009-external-protocol-dialects.md
+    └── 0010-lambda-as-inspiration-not-runtime.md   (added 2026-05-18)
 ```
 
 **Research archive (read at start of relevant phase only):**
@@ -66,7 +77,13 @@ docs/future-architecture/
     ├── 12-docker-socket-proxy.md      (Phase 2, 8)
     ├── 13-anthropic-sandbox-runtime.md (Phase 7, 9)
     ├── 14-e2b-desktop-and-surf.md     (Phase 7)
-    └── 15-claude-code-reverse-engineering.md (Phase 6, 7, 10)
+    ├── 15-claude-code-reverse-engineering.md (Phase 6, 7, 10)
+    ├── 16-anthropic-production-sandbox-observed.md (Phase 3, 7, 8)
+    ├── 17-anthropic-claude-code-remote-env-observed.md (Phase 6, 7, 10)
+    ├── 18-open-webui-terminals-observed.md (Phase 6, 8)
+    ├── 19-anthropic-process-api.md    (Phase 7, 10 — primary L1 precedent)
+    ├── 20-snapstart-hot-swap.md       (Phase 10)
+    └── 21-environment-runner-go.md    (inspiration-only; no Phase consumer)
 ```
 
 ## Reference repositories

--- a/docs/future-architecture/README.md
+++ b/docs/future-architecture/README.md
@@ -12,7 +12,13 @@ The model is taken from [`sandboxd/`](../../sandboxd/) — a runtime-agnostic, 4
 - **4 layers:** Control Plane (L4) → Orchestrator/Provider (L3) → Sandbox Runtime (L2) → Guest Agent (L1).
 - **11-phase roadmap** (0, 0.5, 1–10). Each phase strips one specific blocker. **No phase breaks the Docker Compose PoC** — that's an [explicit non-blocking invariant](./roadmap.md#non-blocking-invariants).
 - **Order reshuffle** (post-review): egress proxy (now Phase 8) ships **before** Kata untrusted tier (now Phase 9) — otherwise "untrusted" is a lie.
-- **Locked decisions** (ADRs): Go control plane, **Rust guest agent** (rewritten 2026-05-18 after [`research/19`](./research/19-anthropic-process-api.md) study; matches Anthropic `process_api` stack), Docker-first then any k8s, pluggable runtime via `RuntimeClass`, MCP stays the user-facing protocol, no AGPL/BSL dependencies, **internal = connect-go (L4↔L3); L3↔L1 transport re-evaluated at Phase 7 (connect-rust vs WS-frame protocol); external = MCP + REST; CDP/ttyd = WebSocket passthrough**, **AWS Lambda is inspiration, not runtime** ([ADR-0010](./adr/0010-lambda-as-inspiration-not-runtime.md)).
+- **Locked decisions (ADRs):**
+  - **Languages:** Go control plane ([ADR-0001](./adr/0001-control-plane-language-go.md)); **Rust guest agent** ([ADR-0002](./adr/0002-guest-agent-language-go.md), rewritten 2026-05-18 after [`research/19`](./research/19-anthropic-process-api.md) study; matches the `process_api` stack).
+  - **Internal transport:** connect-go on L4↔L3; L3↔L1 re-evaluated at Phase 7 (connect-rust vs `process_api`-style WS-frame protocol) per [ADR-0008](./adr/0008-internal-grpc-external-rest-mcp.md).
+  - **External protocols:** MCP user-facing ([ADR-0005](./adr/0005-mcp-as-control-plane-gateway.md)); REST for admin; CDP/ttyd is WebSocket passthrough; optional dialect adapters per [ADR-0009](./adr/0009-external-protocol-dialects.md).
+  - **Deployment:** Docker-first then k8s ([ADR-0003](./adr/0003-docker-poc-first-then-k8s.md)); pluggable runtime via `RuntimeClass` ([ADR-0004](./adr/0004-pluggable-runtime-via-runtimeclass.md)).
+  - **Dependencies:** no AGPL/BSL ([ADR-0006](./adr/0006-no-agpl-no-bsl-dependencies.md)).
+  - **AWS Lambda:** inspiration, not runtime ([ADR-0010](./adr/0010-lambda-as-inspiration-not-runtime.md)).
 
 ## Reference architectures we draw from
 

--- a/docs/future-architecture/adr/0001-control-plane-language-go.md
+++ b/docs/future-architecture/adr/0001-control-plane-language-go.md
@@ -68,3 +68,11 @@ Constraints:
 
 - Phase 6 research doc (`phase-6-research.md`) must confirm web framework + k8s client + MCP-on-Go strategy before code starts.
 - Parity acceptance: integration tests (`tests/integration/test_mcp_*.py`) pass against the new Go endpoint unchanged.
+
+## Phase 6 re-evaluation gate (added 2026-05-18)
+
+[ADR-0002](./0002-guest-agent-language-go.md) flipped L1 to Rust after this ADR was accepted. That changes the two-language calculus referenced under "Negative consequences" above — we no longer have a single-language stack. Phase 6 research must therefore answer one extra question before Go code starts:
+
+> Given that L1 is Rust, does L4 still want to be Go? The default answer remains **yes** (k8s ecosystem fit, owner familiarity, streaming concurrency, hiring) and this ADR is **not pre-superseded**. The gate exists so the Phase 6 author cannot ship Go code without having considered the alternative explicitly.
+
+If Phase 6 research instead concludes that L4 should also be Rust, supersede this ADR rather than amending it.

--- a/docs/future-architecture/adr/0002-guest-agent-language-go.md
+++ b/docs/future-architecture/adr/0002-guest-agent-language-go.md
@@ -1,49 +1,61 @@
 <!-- SPDX-License-Identifier: BUSL-1.1 -->
 <!-- Copyright (c) 2025 Open Computer Use Contributors -->
 
-# ADR-0002 — Guest agent language: Go (with Rust documented)
+# ADR-0002 — Guest agent language: Rust
 
-- **Status:** Accepted (with explicit re-evaluation gate in Phase 7)
-- **Date:** 2026-05-17
-- **Related:** [ADR-0001](./0001-control-plane-language-go.md)
+- **Status:** Accepted (rewritten 2026-05-18; supersedes the prior Go decision recorded under the same number)
+- **Date:** 2026-05-18 (original 2026-05-17 version was Go-with-Rust-as-option; rewritten in place after `sandboxd/anthropic/process_api_re/` study made Rust the better starting point)
+- **Related:** [ADR-0001](./0001-control-plane-language-go.md), [ADR-0008](./0008-internal-grpc-external-rest-mcp.md), [research/19](../research/19-anthropic-process-api.md)
+- **Filename note:** kept as `0002-guest-agent-language-go.md` for git-history continuity; the title and content are now Rust.
 
 ## Context
 
-Phase 7 of the roadmap replaces today's Python entrypoint + in-image MCP server with a small static binary as PID 1. The candidate languages are **Go** (consistent with ADR-0001) and **Rust** (consistent with sandboxd, kata-agent, msb-agent).
+Phase 7 of the roadmap replaces today's Python entrypoint + in-image MCP server with a small static binary as PID 1. The candidate languages are **Rust** (Anthropic's `process_api`, kata-agent, msb-agent, Firecracker, Cloud Hypervisor) and **Go** (consistent with ADR-0001's L4 choice, E2B's `envd`).
 
-This decision matters more for L1 than for L4 because the in-sandbox agent is the **inner attack target**: untrusted code, prompt-injected agents, or compromised dependencies inside the sandbox all interact with L1 first. RCE in L1's HTTP handling buys the attacker the agent's full powers (which are deliberately small, but still).
+This decision matters more for L1 than for L4 because the in-sandbox agent is the **inner attack target**: untrusted code, prompt-injected agents, or compromised dependencies inside the sandbox all interact with L1 first. RCE in L1's HTTP / WS handling buys the attacker the agent's full powers (which are deliberately small, but still).
+
+The earlier (2026-05-17) version of this ADR picked Go for operator-preference reasons. That was written before [`research/19-anthropic-process-api.md`](../research/19-anthropic-process-api.md) extracted concrete Rust patterns from `sandboxd/anthropic/process_api_re/`. With that material now in hand, Rust is the better starting point — it matches the precedent at every microVM-runtime project we depend on, and the L1 contract turns out to be a near-1:1 match for what `process_api` already does.
 
 ## Decision
 
-**Go.** With Rust kept on the table as a Phase 7 *research* topic: the gate before code starts is a written profit/cost analysis that either (a) confirms Go or (b) overturns this ADR.
+**Rust.** Phase 7 ships a Rust binary as the L1 guest agent. The crate footprint mirrors `process_api`'s: `tokio`, `hyper`, `tokio-tungstenite`, `tokio-vsock`, `ring`, `jsonwebtoken`, `clap`, `nix`, `serde_json`.
 
-## Rationale (for Go)
+Go stays on the table only as a **fallback** if the Phase 7 research gate (below) surfaces a concrete blocker we cannot route around.
 
-- **Operator preference.** Same owner constraint as [ADR-0001](./0001-control-plane-language-go.md). Owner is productive in Go, not Rust.
-- **Single language across L4 + L1.** Shared types, shared HTTP client patterns, shared MCP JSON-RPC handling. One on-call skill set.
-- **`chromedp` exists.** Mature direct-CDP client; lets us skip the WebDriver layer for Computer Use. No Rust equivalent of equivalent maturity.
-- **Precedent.** E2B's `envd` is Go-and-in-production. Proves the shape works.
-- **Static binary, cross-compile.** No worse than Rust for this property in practice.
+## Rationale (for Rust)
 
-## What Rust would buy us (documented for future re-evaluation)
+- **Precedent at the runtime layer.** Every adjacent agent-in-microVM project is Rust: `process_api` ([research/19](../research/19-anthropic-process-api.md)), kata-agent, msb-agent, Firecracker, Cloud Hypervisor. We are not the first ones doing this; the language choice has been litigated.
+- **Memory safety on the RCE target.** L1's WS handler is a direct RCE target. Rust's safety class eliminates a category of bugs Go does not, and the small static-PIE binary surface is easier to audit.
+- **Smaller binary.** `process_api` is 4.3 MB static-PIE. A Go equivalent would be 10–15 MB. For a binary that ships inside every sandbox image, the delta matters at scale.
+- **Async runtime fit.** `tokio` is excellent for L1's workload (long-lived WS, multiple streams, vsock).
+- **vsock crates are mature in Rust** (`tokio-vsock`). Go's vsock support exists but is less common.
+- **Same primitives as `process_api`.** First-byte JSON-vs-JWT dispatch, Ed25519 verification with `ring`, capabilities negotiation — these are easier to clone when the dependency list matches.
+- **Owner reconsideration.** The original ADR rejected Rust on owner-productivity grounds. After studying `process_api_re/`, the owner has flipped that call: the L1 surface is small and protocol-shaped, which is where Rust's friction is lowest.
 
-- **Smaller binary** (~½ size). Less to ship, less to load.
-- **Stronger memory safety.** L1's HTTP handler is a direct RCE target. Rust's safety class eliminates a category of bugs Go does not.
-- **Precedent at the runtime layer.** kata-agent (Rust), msb-agent (Rust), Firecracker (Rust), Cloud Hypervisor (Rust). If L1 ever calls into hypervisor APIs directly, Rust integrates more naturally.
-- **vsock crates** are mature in Rust; Go's vsock support exists but is less common.
-- **Async runtime.** `tokio` is excellent for the L1 workload (long-lived sockets, multiple streams).
+## What Go would have bought us (kept for the record)
+
+- **Single language across L4 + L1** with ADR-0001. Lost — but L4 ↔ L1 talks over a wire protocol, not shared code, so the loss is shallow.
+- **`chromedp` exists.** Mature direct-CDP client. Mitigation: Phase 7 research evaluates a Rust CDP client (`chromiumoxide`) or treats CDP as a pure WebSocket passthrough (see ADR-0008) and does not parse it on the L1 side.
+- **Operator familiarity.** Owner accepts the productivity hit on the L1 side; L4 stays Go ([ADR-0001](./0001-control-plane-language-go.md)) so the day-to-day operator surface is unchanged.
 
 ## Decision gate (Phase 7 research)
 
-`phase-7-research.md` must answer:
-1. Concrete RCE attack surface of a Go HTTP/WS server inside the sandbox. Is it real exposure or theoretical?
-2. Binary-size delta on actual artifacts, with each language's optimizer dialed in.
-3. CDP / Chromium driving cost in Rust (no chromedp equivalent — write our own or use a less-mature crate).
-4. Owner's honest assessment of Rust productivity given exposure since this ADR was written.
+`phase-7-research.md` must confirm before code starts:
 
-If answers favor Rust, supersede this ADR. The interface ([05-layer1-guest-agent.md](../architecture/05-layer1-guest-agent.md)) is language-agnostic — L4 doesn't care.
+1. **CDP driving from Rust.** `chromiumoxide` vs raw WebSocket passthrough — pick one and justify. No chromedp parity required if the L1 doesn't drive CDP itself.
+2. **Build & toolchain.** musl static-PIE target, cross-compile for `linux/amd64` and `linux/arm64`, reproducible builds.
+3. **vsock transport feasibility.** `tokio-vsock` on the runtimes we target (runc, sysbox, kata-fc, kata-ch). This also feeds the ADR-0008 Phase 7 gate.
+4. **MCP server hosting.** Rust MCP server libraries are younger than Go's; if the only mature one is unfit, decide whether to (a) hand-roll JSON-RPC dispatch (the path `process_api` would take), (b) accept the youngest mature crate, or (c) keep MCP termination in L4 and have L1 expose only the typed RPC.
+5. **Owner productivity check.** Honest assessment after spiking the agent skeleton.
+
+If answers favor Go, supersede this ADR with a new one (not by editing this file again). The interface ([05-layer1-guest-agent.md](../architecture/05-layer1-guest-agent.md)) is language-agnostic — L4 doesn't care.
 
 ## Alternatives considered
+
+### Go (the prior decision under this number)
+- **Pro:** single language with L4, `chromedp`, E2B precedent, owner-familiar.
+- **Con:** Larger binary; weaker memory-safety story on the RCE target; out of line with every adjacent microVM-agent project; loses the direct ability to clone `process_api` patterns.
+- **Verdict:** rejected as the *target* with a Phase 7 escape hatch. The original Go-leaning ADR text is preserved in git history (`git log` on this file).
 
 ### Keep Python (status quo)
 - **Pro:** zero migration cost.
@@ -55,7 +67,16 @@ If answers favor Rust, supersede this ADR. The interface ([05-layer1-guest-agent
 
 ## Consequences
 
-- Phase 7 ships a Go binary.
-- L1 and L4 share language → easier on-call but also single point of language-level CVE risk.
-- chromedp dependency added.
-- Door for Rust re-evaluation stays open at Phase 7 research gate.
+**Positive:**
+- L1 binary is smaller (target ~4–6 MB) and audit-able.
+- L1 lines up with `process_api`, kata-agent, msb-agent — known idioms, known crates.
+- Capabilities negotiation, Ed25519 JWT, first-byte dispatch (from [research/19](../research/19-anthropic-process-api.md) §3–§4) become drop-in patterns rather than ports.
+
+**Negative:**
+- Two-language stack (Rust L1 + Go L4). On-call needs to read both. The wire boundary between them is the firewall: contracts in `.proto` / JSON, no shared code.
+- Slower L1 iteration vs. Go in the early Phase 7 weeks. Mitigated by the small surface area of the agent.
+- We give up `chromedp` — Phase 7 research must close that gap.
+
+**Neutral:**
+- ADR-0008's "connect-go on L3↔L1" line now reads "connect-rust" in effect. ADR-0008 has a Phase 7 gate ([its §"Negative"](./0008-internal-grpc-external-rest-mcp.md)) that already calls this out; the gate is tightened in the 2026-05-18 edit of that ADR.
+- ADR-0001 (L4=Go) stays unchanged. Its Phase 6 gate now also re-confirms Go-vs-Rust on the L4 side given that L1 went Rust.

--- a/docs/future-architecture/adr/0008-internal-grpc-external-rest-mcp.md
+++ b/docs/future-architecture/adr/0008-internal-grpc-external-rest-mcp.md
@@ -1,7 +1,7 @@
 <!-- SPDX-License-Identifier: BUSL-1.1 -->
 <!-- Copyright (c) 2025 Open Computer Use Contributors -->
 
-# ADR-0008 — Internal transport: connect-go (gRPC). External: MCP + REST. CDP/ttyd: WebSocket passthrough.
+# ADR-0008 — Internal transport: connect-go on L4↔L3 (Phase 7 picks L3↔L1). External: MCP + REST. CDP/ttyd: WebSocket passthrough.
 
 - **Status:** Accepted (Phase 7 gate tightened 2026-05-18 after [ADR-0002](./0002-guest-agent-language-go.md) flipped L1 to Rust)
 - **Date:** 2026-05-17 (original) · 2026-05-18 (Phase 7 gate edit)
@@ -24,8 +24,8 @@ Until now docs said "HTTP/gRPC" everywhere — ambiguous. The Anthropic pattern 
 |---|---|---|
 | User → L4 (agents, Open WebUI) | **MCP** (JSON-RPC over HTTP/WebSocket) | Frozen contract per [ADR-0005](./0005-mcp-as-control-plane-gateway.md) |
 | Admin UI → L4 | **REST** (OpenAPI-described) | Standard for SPAs, generates browser clients trivially, debuggable via curl/Postman |
-| L4 ↔ L3 (provider) | **connect-go** (mTLS) | Schema-first; gRPC streaming + Connect/HTTP-JSON from one `.proto` |
-| L3 ↔ L1 (agent) | **connect-go** (vsock on microVM, TCP on runc/sysbox) | Same `.proto` shape; transport-agnostic |
+| L4 ↔ L3 (provider) | **connect-go** (mTLS) | Schema-first; gRPC streaming + Connect/HTTP-JSON from one `.proto`. L4 is Go ([ADR-0001](./0001-control-plane-language-go.md)). |
+| L3 ↔ L1 (agent) | **Open — Phase 7 picks** between connect-rust (typed `.proto` over vsock/TCP) and a `process_api`-style WS-frame protocol over `tokio-vsock` ([research/19 §12](../research/19-anthropic-process-api.md)) | L1 is Rust ([ADR-0002](./0002-guest-agent-language-go.md), rewritten 2026-05-18); the language flip changes the trade-off vs. the original Go-era pick. Gate language below. |
 | User UI ↔ sandbox CDP/ttyd | **WebSocket passthrough** via L4 | L4 does **not** parse; shovels frames opaquely |
 
 **connect-go** specifically (not pure grpc-go):

--- a/docs/future-architecture/adr/0008-internal-grpc-external-rest-mcp.md
+++ b/docs/future-architecture/adr/0008-internal-grpc-external-rest-mcp.md
@@ -3,9 +3,9 @@
 
 # ADR-0008 — Internal transport: connect-go (gRPC). External: MCP + REST. CDP/ttyd: WebSocket passthrough.
 
-- **Status:** Accepted
-- **Date:** 2026-05-17
-- **Related:** [ADR-0001](./0001-control-plane-language-go.md), [ADR-0002](./0002-guest-agent-language-go.md), [ADR-0005](./0005-mcp-as-control-plane-gateway.md)
+- **Status:** Accepted (Phase 7 gate tightened 2026-05-18 after [ADR-0002](./0002-guest-agent-language-go.md) flipped L1 to Rust)
+- **Date:** 2026-05-17 (original) · 2026-05-18 (Phase 7 gate edit)
+- **Related:** [ADR-0001](./0001-control-plane-language-go.md), [ADR-0002](./0002-guest-agent-language-go.md), [ADR-0005](./0005-mcp-as-control-plane-gateway.md), [research/19](../research/19-anthropic-process-api.md)
 
 ## Context
 
@@ -84,7 +84,7 @@ Long-lived WebSocket from user UI → L4 → sandbox Chromium. L4 must **not** d
 **Negative:**
 - One more tool in the toolbox (`buf` for `.proto` linting, `connect-go` codegen). Worth it.
 - L1 agent must include connect-go runtime → slightly larger binary than raw HTTP server (~1–2 MB). Acceptable per [ADR-0002](./0002-guest-agent-language-go.md) targets (~5–10 MB total).
-- Phase 7 research must include "vsock + connect-go" feasibility — vsock transport for connect/gRPC is well-trodden but not zero-config.
+- Phase 7 research must include "vsock + connect-go" feasibility — vsock transport for connect/gRPC is well-trodden but not zero-config. **Update (2026-05-18):** with L1 now in Rust ([ADR-0002](./0002-guest-agent-language-go.md)), the L3↔L1 leg is effectively **connect-rust** (not connect-go) **or** a `process_api`-style WS-frame protocol over `tokio-vsock` ([research/19](../research/19-anthropic-process-api.md) §12). Phase 7 research must explicitly compare these two and pick one. The L4↔L3 leg stays connect-go (L4 is Go per [ADR-0001](./0001-control-plane-language-go.md)).
 
 **Neutral:**
 - Phase 6 research now picks connect-go as primary candidate; the framework choice section in `roadmap.md` narrows.
@@ -94,7 +94,7 @@ Long-lived WebSocket from user UI → L4 → sandbox Chromium. L4 must **not** d
 
 - **Phases 1–5 (Python orchestrator):** stay on Python HTTP; provider interface is in-process Protocol; HTTP transport between orchestrator and pool-manager sidecar.
 - **Phase 6 (Go control plane):** introduces `.proto` files for L4↔L3 boundary. Python orchestrator keeps working in parallel; new Go service serves both MCP gateway (external) and connect RPCs (internal).
-- **Phase 7 (Go agent):** L1 serves connect-go on vsock/TCP; L3 client compiled from same `.proto`.
+- **Phase 7 (Rust agent per [ADR-0002](./0002-guest-agent-language-go.md)):** L1 serves either connect-rust or a WS-frame protocol on vsock/TCP, decided by the Phase 7 research gate. L3 client compiled from the same `.proto` (connect path) or a hand-rolled WS client (process_api-shape path).
 - **Phase 8 (egress proxy):** connect for L4↔proxy stats/control; egress traffic itself stays HTTP CONNECT (proxy is a TCP proxy, not RPC).
 - **Phase 9 (Kata):** vsock + connect-go validated.
 - **Phase 10 (HA / multi-region):** mTLS on all internal RPCs; cert rotation via cert-manager or equivalent.

--- a/docs/future-architecture/adr/0010-lambda-as-inspiration-not-runtime.md
+++ b/docs/future-architecture/adr/0010-lambda-as-inspiration-not-runtime.md
@@ -1,0 +1,86 @@
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+<!-- Copyright (c) 2025 Open Computer Use Contributors -->
+
+# ADR-0010 — AWS Lambda: inspiration, not runtime
+
+- **Status:** Accepted
+- **Date:** 2026-05-18
+- **Deciders:** project owner
+- **Supersedes:** —
+- **Superseded by:** —
+- **Related:** [ADR-0003](./0003-docker-poc-first-then-k8s.md), [ADR-0004](./0004-pluggable-runtime-via-runtimeclass.md), [references.md](../references.md), [research/05](../research/05-firecracker.md), [research/16](../research/16-anthropic-production-sandbox-observed.md), [research/19](../research/19-anthropic-process-api.md), [research/20](../research/20-snapstart-hot-swap.md)
+
+## Context
+
+AWS Lambda recurs across the reference catalogue. It is the original consumer of Firecracker; its MicroManager pool is the design lineage behind Anthropic's `process_api` placement plane ([research/19](../research/19-anthropic-process-api.md) §11); its cold-start economics underwrite the snapstart pattern we evaluate at Phase 10 ([research/20](../research/20-snapstart-hot-swap.md)).
+
+This recurrence has begun to confuse the architecture conversation. "Lambda" appears in [`references.md`](../references.md) as a Firecracker provenance note, in [`research/05`](../research/05-firecracker.md) as a foundation, and in [`research/16`](../research/16-anthropic-production-sandbox-observed.md) as a contrast to our k8s direction. None of these documents make the explicit claim that we will or won't run on Lambda.
+
+This ADR makes the claim and closes the question.
+
+## Decision
+
+**Open Computer Use will not run on AWS Lambda or AWS Fargate.** Lambda is treated as a **design reference**, not a deployment target. The patterns we borrow are explicit, named, and bounded; nothing beyond them transfers.
+
+### What "inspiration" means concretely
+
+We adopt **patterns** from the Lambda design lineage:
+
+| Pattern | How it lands for us | Where |
+|---|---|---|
+| Firecracker as a microVM tier with the smallest attack surface | `kata-fc` runtime tier | [`research/05`](../research/05-firecracker.md), [`architecture/04-layer2-runtimes.md`](../architecture/04-layer2-runtimes.md), Phase 9 |
+| Two-tier control split (host-side router + in-guest supervisor) | L4 (Go) + L1 (Rust, [ADR-0002](./0002-guest-agent-language-go.md)) with WS over vsock | [`research/19`](../research/19-anthropic-process-api.md), Phase 7 |
+| Frozen-snapshot pool with block-device hot-swap on resume | Snapstart-style cold-start optimization | [`research/20`](../research/20-snapstart-hot-swap.md), Phase 10 |
+| Per-session VM isolation (no reuse across tenants) | RuntimeClass-driven, per-tenant namespace | [ADR-0004](./0004-pluggable-runtime-via-runtimeclass.md), `architecture/07-security.md` |
+
+### What we are explicitly **not** adopting
+
+- **The deployment substrate.** We do not deploy on `aws-lambda` (function-as-a-service) or `aws-fargate` (managed-task). The runtime substrate is Kubernetes ([ADR-0003](./0003-docker-poc-first-then-k8s.md)) plus a RuntimeClass-pluggable microVM tier ([ADR-0004](./0004-pluggable-runtime-via-runtimeclass.md)).
+- **Per-invocation billing model.** Our sandboxes are session-shaped, not request-shaped. The cost model is per-session, per-RuntimeClass — not per-100ms-CPU-burst.
+- **15-minute hard wall.** Lambda's 15-minute invocation cap is a non-starter for Computer Use sessions. We need sessions that survive multi-hour LLM-driven work.
+- **Lambda's specific orchestrator.** Anthropic's Router shares Lambda's lineage but is a custom system. We are not cloning either; k8s + a custom L4 control plane do the same job at our scale.
+- **Lambda Extensions / Layers / SnapStart-the-AWS-product.** These are AWS-product names. We use the *technique* SnapStart describes (see [`research/20`](../research/20-snapstart-hot-swap.md)) without using AWS's implementation.
+
+## Rationale
+
+- **Scale mismatch.** Lambda's design optimizes for millions of short serverless invocations. We target 100–10K concurrent long-lived sandboxes (see [`research/16`](../research/16-anthropic-production-sandbox-observed.md) §7). k8s + RuntimeClass remains the right fit; serverless infra is over-engineered for the bottom and under-fit for the top.
+- **Workload shape mismatch.** Computer-Use sessions are stateful, long-running, and need predictable resource ceilings (memory for screencast frame buffers, CPU for browser rendering). Lambda's stateless-by-default, scale-on-bursts model fights every assumption.
+- **Self-hosting requirement.** A serious chunk of the addressable user base self-hosts. Lambda is not portable; k8s is.
+- **Vendor lock.** Lambda ties us to AWS as the deployment substrate. The architecture explicitly aims for AWS, GCP, on-prem RKE2, and Docker Compose ([ADR-0001](./0001-control-plane-language-go.md) Context).
+- **Open-source posture.** The project is open-source ([ADR-0006](./0006-no-agpl-no-bsl-dependencies.md) on license hygiene). Optimizing for a single-cloud managed runtime is at odds with that posture.
+
+## Consequences
+
+**Positive:**
+- The Lambda question is closed. Future debate about "should we go serverless?" can be answered by linking to this ADR.
+- Phase 9 / Phase 10 design discussions can use Lambda as a reference point without confusion about commitment.
+- `references.md` gets one explicit Lambda paragraph; everything else cross-links to it.
+
+**Negative:**
+- We carry the operational cost of running k8s ourselves. Acceptable per [ADR-0001](./0001-control-plane-language-go.md), [ADR-0003](./0003-docker-poc-first-then-k8s.md).
+- Snapshot-pool engineering at Phase 10 is non-trivial without Lambda's MicroManager doing it for us. Acceptable; it's also what makes the system buildable outside AWS.
+
+**Neutral:**
+- A future small-scale deployment optimization could in theory wrap sandboxes in Fargate Tasks. This ADR does not preempt that; it forbids it as the *default*.
+
+## Alternatives considered
+
+### Run on AWS Lambda
+- **Verdict:** rejected. 15-minute cap, stateless-by-default, no Kubernetes affinity, vendor lock. Doesn't fit the workload.
+
+### Run on AWS Fargate
+- **Pro:** managed task substrate, no node ops.
+- **Con:** opaque scheduler, no RuntimeClass control, no microVM tiering (Firecracker is there but you can't pick), still AWS-only.
+- **Verdict:** rejected as the *default*. Possibly viable as a future "managed tier" for AWS-only users; that would land in its own ADR.
+
+### Adopt Lambda's MicroManager pattern wholesale
+- **Pro:** proven at scale.
+- **Con:** rebuilds Lambda's orchestrator on our side — a huge engineering bill for problems we don't have yet at our scale.
+- **Verdict:** rejected. We adopt the **patterns** ("two-tier control", "snapshot pool", "per-session isolation") without rebuilding the orchestrator. k8s + a custom L4 are enough.
+
+## Verification
+
+- `references.md` contains a single "Lambda framing" subsection that cross-links to this ADR.
+- `architecture/04-layer2-runtimes.md` mentions Firecracker's Lambda lineage exactly once, with a back-link here.
+- Search the docs tree for "Lambda" — every hit either points to this ADR, the references paragraph, or a research digest. No standalone claims.
+- Phase 9 / Phase 10 PRs that touch microVM choice or snapshot pooling include "ADR-0010 reviewed" in the PR description checklist.

--- a/docs/future-architecture/adr/0010-lambda-as-inspiration-not-runtime.md
+++ b/docs/future-architecture/adr/0010-lambda-as-inspiration-not-runtime.md
@@ -83,4 +83,4 @@ We adopt **patterns** from the Lambda design lineage:
 - `references.md` contains a single "Lambda framing" subsection that cross-links to this ADR.
 - `architecture/04-layer2-runtimes.md` mentions Firecracker's Lambda lineage exactly once, with a back-link here.
 - Search the docs tree for "Lambda" — every hit either points to this ADR, the references paragraph, or a research digest. No standalone claims.
-- Phase 9 / Phase 10 PRs that touch microVM choice or snapshot pooling include "ADR-0010 reviewed" in the PR description checklist.
+- Phase 9 / Phase 10 PRs that touch microVM choice or snapshot pooling tick the **"ADRs reviewed"** checklist in [`.github/PULL_REQUEST_TEMPLATE.md`](../../../.github/PULL_REQUEST_TEMPLATE.md) with `ADR-0010` listed.

--- a/docs/future-architecture/antipatterns.md
+++ b/docs/future-architecture/antipatterns.md
@@ -5,7 +5,7 @@
 
 > Source: [`sandboxd/docs/antipatterns.md`](../../../sandboxd/docs/antipatterns.md) + footgun sections in `research/01-15` + production-gap notes.
 >
-> **This is a decision log, not a generic survey.** Each entry filtered for our stack (k8s + Kata + Cloud Hypervisor + Rust/Go agent + Computer Use + connect-go internal RPC). Antipatterns that don't apply to our chosen stack are dropped explicitly. Each kept antipattern carries **our choice** in addition to "don't do this".
+> **This is a decision log, not a generic survey.** Each entry filtered for our stack (k8s + Kata + Cloud Hypervisor + Rust agent ([ADR-0002](./adr/0002-guest-agent-language-go.md)) + Go control plane ([ADR-0001](./adr/0001-control-plane-language-go.md)) + Computer Use + connect-go L4↔L3 RPC). Antipatterns that don't apply to our chosen stack are dropped explicitly. Each kept antipattern carries **our choice** in addition to "don't do this".
 >
 > Use this doc when planning a phase: before you write code for Phase N, scan the entries tagged `Phase N` here. Reviewers reject PRs that reintroduce documented antipatterns without an ADR.
 
@@ -53,7 +53,7 @@ Ordered by phase where they FIRST become possible.
   - `PR_SET_DUMPABLE=0` on agent PID 1.
   - Non-root inside sandbox where the runtime allows (Kata is fine).
   - Separate PID namespace (Kata gives this for free).
-- **Phase.** 7 (Go agent) — implement all four together; do not ship the agent rewrite without them.
+- **Phase.** 7 (Rust agent) — implement all four together; do not ship the agent rewrite without them.
 - **Detection.** PR-review checklist for Phase 7. CI test asserts `cat /proc/1/exe` from inside a built sandbox returns nothing.
 
 ### A2 — Service per pod / Service per session
@@ -108,7 +108,7 @@ Ordered by phase where they FIRST become possible.
   - Pool member = warm with pre-loaded Chrome dependencies, **but Chrome not running**.
   - On session assign: L4 calls `Agent.Configure(ctx)` → agent receives env/secrets/JWT → agent starts Chrome with the right env in one step.
   - We never mutate env on a running process.
-- **Phase.** 7 (Go agent) — `Configure` must complete before any tool RPC accepted.
+- **Phase.** 7 (Rust agent) — `Configure` must complete before any tool RPC accepted.
 - **Detection.** Agent state machine has `unconfigured | configured | running`. RPCs other than `Configure` return `FailedPrecondition` in `unconfigured`. Test asserts.
 
 ### A7 — Trust agent for authentication
@@ -120,7 +120,7 @@ Ordered by phase where they FIRST become possible.
   - Network policy + Kata isolation ensures only L4 can.
   - Agent does NOT validate JWTs.
   - **Counter-pattern note from [`research/15-claude-code-reverse-engineering.md`](./research/15-claude-code-reverse-engineering.md) §6:** Anthropic adds public-key JWT verification at L1 as defense-in-depth. We revisit if we ever expose L1 over TCP at scale; for vsock/localhost it stays "trust the network".
-- **Phase.** 7 (Go agent design).
+- **Phase.** 7 (Rust agent design).
 - **Detection.** Grep `jwt.Parse`, `jwt.Verify` in agent code — should not exist.
 
 ### A8 — Long-lived egress tokens (e.g. 30 days)
@@ -515,7 +515,7 @@ Quick lookup: when planning Phase N, scan these entries.
 | 4 (secret broker) | A8 (per-session JWT), A33 (signing key rotation) |
 | 5 (Helm + K8sProvider) | A2 (no per-session Service), A3 (overprovisioning), A5/A36 (pod IP cache + watch), A11 (cosign verify), A12 (warm pool real), A15 (graceful shutdown), A16 (`restartPolicy: Never`), A17 (cattle/pets), A29 (smoke tests), A30 (kernel version validation) |
 | 6 (Go control plane) | A4 (no ClientIP affinity), A5/A36 (informer-driven cache), A8 (mint JWT), A14 (audit metadata only), A26 (no env values in logs), C5 (3 replicas), C6 (leader-only reconcile), C8 (buf-lint), C9 (single ToolCall), C10 (HTTP/JSON debug-only) |
-| 7 (Go guest agent) | A1 (defense in depth, all 4 layers), A6 (Configure-before-Chrome), A7 (no auth in agent), A15 (cooperative Shutdown RPC), A27 (versioned agent), A35 (tight seccomp), C1 (vsock auto-detect), C3 (4 RPC shapes), C4 (push model) |
+| 7 (Rust guest agent) | A1 (defense in depth, all 4 layers), A6 (Configure-before-Chrome), A7 (no auth in agent), A15 (cooperative Shutdown RPC), A27 (versioned agent), A35 (tight seccomp), C1 (vsock auto-detect), C3 (4 RPC shapes), C4 (push model) |
 | 8 (egress proxy + audit) | A8 (token lifetime), A14/A25/A26 (log discipline), A24 (DNS rebinding), A31 (wildcard rejection), A32 (CONNECT timeouts), A33 (key rotation overlap) |
 | 9 (Kata + CH) | A20 (`cache=never`), A21 (seccomp ON), A23 (Landlock pre-declare), A28 (template-level RuntimeClass), C2 (dedicated node pool), C7 (don't bake runtime) |
 | 10 (snapshot/HA) | A19 (measure first), A22 (no GPU on snapshottable), A34 (KMS per session), and the sandboxd post-restore hardening triad (CRNG reseed, `init_on_free=1`, `CAP_SYS_RESOURCE` drop) |

--- a/docs/future-architecture/architecture/01-layers.md
+++ b/docs/future-architecture/architecture/01-layers.md
@@ -50,8 +50,9 @@
 ┌─────────────────────────────────────────────────────────────────────┐
 │  LAYER 1 — Guest Agent                                              │
 │  Today:  Python entrypoint + MCP server inside image  (transition)  │
-│  Future: small Go static binary as PID 1            (Phase 7)       │
-│  Surface: HTTP + WebSocket (+ vsock when on microVM)                │
+│  Future: small Rust static binary as PID 1          (Phase 7)       │
+│  Surface: data-plane WS (vsock on microVM, TCP elsewhere)           │
+│         + control-plane HTTP (health/shutdown, fs_freeze Phase 10)  │
 │  Duties: exec, file ops, port-forward, CDP proxy, ttyd, MCP tools   │
 │  Does NOT: authenticate (L4 does), persist state (L3 does)          │
 └─────────────────────────────────────────────────────────────────────┘
@@ -70,7 +71,7 @@
 | `computer-use-server/app.py` (FastAPI, MCP, uploads, auth) | repo root | **L4** Control Plane (will be Go) | Phase 6 cutover |
 | `computer-use-server/docker_manager.py` (Docker socket, lifecycle, cleanup) | repo root | **L3** Provider (`DockerComposeProvider`) | Phase 1 extract behind interface |
 | `computer-use-server/mcp_tools.py` (bash/python/file tools) | repo root | **L4** (gateway) + **L1** (exec target) | Phase 7 split |
-| `Dockerfile` entrypoint, in-image MCP server | sandbox image | **L1** Guest Agent (Python → Go) | Phase 7 |
+| `Dockerfile` entrypoint, in-image MCP server | sandbox image | **L1** Guest Agent (Python → Rust per [ADR-0002](../adr/0002-guest-agent-language-go.md)) | Phase 7 |
 | Docker (`runc`) as runtime | host | **L2** Runtime (`runc` tier) | Phase 9 adds Kata tiers |
 | `helm/computer-use-server/` (single Deployment + DinD sidecar) | repo | **L3** + **L4** k8s manifests, split | Phases 5, 6 |
 | `/tmp/computer-use-data` + Docker volumes | host fs | **Storage** ([06-storage.md](./06-storage.md)) — moves to S3 | Phase 3 |
@@ -87,6 +88,14 @@
 - **Skills** (the AI capability bundles under `skills/`) — packaging, not architecture. They mount into L1 sandboxes. See [06-storage.md](./06-storage.md).
 - **Open WebUI** — a downstream consumer of L4's MCP gateway. Not part of this stack.
 - **Sub-agent CLIs** (claude, codex, opencode) — executed *inside* L1. Tooling, not architecture.
+
+## Reference architectures we draw from
+
+- **Anthropic `process_api`** ([`research/19`](../research/19-anthropic-process-api.md), source under [`sandboxd/anthropic/process_api_re/`](../../../sandboxd/anthropic/process_api_re/)) — the closest precedent for our Rust L1. Three-transport WebSocket, dual-port API, capabilities negotiation, Ed25519 JWT bound to `container_name`. Drives [ADR-0002](../adr/0002-guest-agent-language-go.md).
+- **AWS Lambda** ([`references.md`](../references.md) Lambda framing, [ADR-0010](../adr/0010-lambda-as-inspiration-not-runtime.md)) — pattern source for Firecracker tiering, two-tier control split, and snapshot-pool cold-start economics. **Inspiration, not deployment substrate.**
+- **E2B `envd`** ([`research/02`](../research/02-e2b-infra.md)) — Go-language L1 reference and production-shape validation.
+- **Coder** ([`research/03`](../research/03-coder.md)) — workspace-proxy and multi-region patterns for Phase 10.
+- **Anthropic local sandbox-runtime** ([`research/13`](../research/13-anthropic-sandbox-runtime.md)) — bubblewrap/seatbelt patterns that inform secondary defense inside microVMs at Phase 9.
 
 ## Source
 

--- a/docs/future-architecture/architecture/02-layer4-control-plane.md
+++ b/docs/future-architecture/architecture/02-layer4-control-plane.md
@@ -71,7 +71,40 @@ MCP semantics live **only** in the gateway layer of L4. It translates MCP `tools
 |---|---|---|
 | Single binary alongside Compose | PoC, dev (Phase 6 development) | Replaces today's `computer-use-server` container 1:1 |
 | `Deployment` in k8s, HPA on RPS | Production single-region (Phase 6 prod) | Stateless; KV holds session state |
-| Multi-AZ + multi-region | Phase 10 | KV replicated cross-AZ; sticky session affinity via consistent hashing |
+| Multi-AZ + multi-region | Phase 10 | KV replicated cross-AZ; sticky routing via consistent hashing in L4 (see anti-pattern note below) |
+
+> **Anti-pattern — never use `Service.spec.sessionAffinity: ClientIP`.** It pins on source IP, which in our deployments is the ingress controller's IP (every client looks the same). The result is a single replica receiving 100% of CDP/ttyd WebSocket traffic. Stickiness for long-lived sessions belongs in L4's session router (consistent-hash by `session_id`), not in the Service. Document this in the Helm chart values; refuse the field in any operator template.
+
+## HA upgrade strategy
+
+L4 is stateless at the request level (KV holds session state), but **CDP / ttyd WebSockets are long-lived** and a rolling rollout that kills the replica owning a session terminates that session's UI. The upgrade procedure:
+
+1. **Scale-to-1, migrate, scale-up** is the safe baseline for single-region:
+   - Scale the new revision in.
+   - Drain the old revision: stop accepting new sessions; existing sessions remain bound until they end naturally or until the drain timeout (default 30 min, capped at the longest active CDP session).
+   - Migrate the session router KV (no-op when KV is external; explicit hand-off when KV is co-located).
+   - Scale the old revision to zero.
+2. **Blue-green** (preferred for production):
+   - Stand up the new revision behind a sibling Service.
+   - Switch the L4-fronting ingress route atomically.
+   - Old revision keeps existing sessions; new sessions go to the new revision.
+   - Old revision drains and is deleted after the drain window.
+3. **Never** roll L4 with a vanilla Kubernetes `RollingUpdate` against the same Service while WebSocket sessions are bound. The default kills sessions mid-stream.
+
+Phase 6 ships the scale-to-1 procedure as a Helm `pre-upgrade` hook. Phase 10 adds the blue-green topology once multi-region session affinity is in place.
+
+## Prompt-caching position (Anthropic API gateway role)
+
+L4 sits between LLM clients and the Anthropic API in deployments that route through us. Prompt caching is part of the Anthropic API contract; **L4 must forward the relevant headers and request blocks transparently, not strip or rewrite them**. Specifically:
+
+- The `anthropic-beta: prompt-caching-*` header is set **only** when the client requested it. L4 does not opportunistically add it.
+- `cache_control` blocks inside the request body pass through unchanged.
+- Response headers reporting cache hit/miss metrics pass back unchanged.
+- L4 never inserts or removes `cache_control` markers — that is the client's call. We are a router, not a prompt optimizer.
+
+This matters because Open WebUI and other clients increasingly use caching to amortize long system prompts. A naive proxy that rewrites the body breaks the cache and inflates token bills silently. The L4 implementation has integration tests asserting byte-identical round-trip for cached request shapes.
+
+Phase 6 research locks the exact list of headers and request fields treated as opaque; Phase 6 implementation enforces it.
 
 ## Migration from today's FastAPI
 

--- a/docs/future-architecture/architecture/03-layer3-providers.md
+++ b/docs/future-architecture/architecture/03-layer3-providers.md
@@ -66,18 +66,74 @@ The same `.proto` is consumed by L4 (client) and L3 (server). Phase 7 the L1 age
 
 ## Warm pool semantics
 
-Three knobs per template:
+Five knobs per template:
 - `minSize` — sandboxes always idle and ready.
 - `targetSize` — provider tries to maintain (refills as sessions consume from pool).
 - `maxSize` — hard cap regardless of demand.
+- `refillRate` — max sandboxes the refiller may start per second (smooths bursty refill load; without it, a flood of session-ends triggers a thundering-herd spawn).
+- `maxAge` — TTL at which an idle pool sandbox is destroyed and replaced regardless of demand. Prevents long-lived "warm" sandboxes from accumulating per-template image drift, leaked file handles, or stale skill blobs.
 
 Lifecycle:
-1. Provider pre-starts `minSize` sandboxes per template, runs `/v1/configure` with placeholder context.
-2. On `spawn(template, ctx)` request, pop one from pool, re-configure with real `ctx` (injects session id, env, egress JWT).
-3. Background refill task brings pool back to `targetSize`.
-4. Sessions ending → sandbox is destroyed (not returned to pool — tenancy hygiene; see [07-security.md](./07-security.md)).
+1. Provider pre-starts `minSize` sandboxes per template, runs `Configure` with placeholder context.
+2. On `Spawn(template, ctx)` request, pop one from pool, re-`Configure` with real `ctx` (injects session id, env, egress JWT).
+3. Background refill task brings pool back to `targetSize` at no more than `refillRate` per second.
+4. Idle sandbox older than `maxAge` → destroyed, refiller spawns a replacement.
+5. Sessions ending → sandbox is destroyed (not returned to pool — tenancy hygiene; see [07-security.md](./07-security.md)).
 
-Phase 2 ships the skeleton (`minSize=0` default = no behavior change). Phase 5 makes it real. Phase 10 adds snapshot/restore so the "warm" state can persist sessions.
+Phase 2 ships the skeleton (`minSize=0` default = no behavior change). Phase 5 makes it real. Phase 10 swaps the "warm sandboxes pool" for a **frozen-snapshot pool** with block-device hot-swap on resume — same knobs, different mechanics. See [`research/20-snapstart-hot-swap.md`](../research/20-snapstart-hot-swap.md).
+
+## SandboxClaim CRD semantics (KubernetesProvider)
+
+For the `KubernetesProvider`, the wire between L4 and L3 is **typed Kubernetes objects**, not opaque RPC payloads. The CRD shape comes from [`kubernetes-sigs/agent-sandbox`](https://github.com/kubernetes-sigs/agent-sandbox) — we adopt rather than reinvent.
+
+```yaml
+apiVersion: sandbox.kubernetes.io/v1alpha1
+kind: SandboxClaim
+metadata:
+  name: claim-<session-id>
+  namespace: tenant-<tenant-id>
+spec:
+  templateRef:
+    name: customer-cu-kata-ch-v3   # SandboxTemplate to allocate from
+  envtype: anthropic-hosted         # provider-side dispatch (see below)
+  lease:
+    ttlSeconds: 7200                # auto-release if the session never returns
+    renewDeadlineSeconds: 60        # heartbeat budget
+  context:                          # injected via Agent.Configure
+    sessionId: <id>
+    tenantId:  <id>
+    egressJwtSecretRef:
+      name: egress-token-<session-id>
+status:
+  phase:           Bound | Pending | Released | Failed
+  sandboxRef:      { name, uid }    # opaque to L4; cluster-internal handle
+  boundAt:         <timestamp>
+  observedRuntime: kata-ch          # actual L2 runtime that landed
+  conditions:     [...]
+```
+
+L4's `Spawn` becomes "create a `SandboxClaim`, watch `.status.phase`." `Stop` is `delete claim`. Health is the same watch. The CRD is what gives the provider a place to store **lease state** without L4 caring about Kubernetes specifics.
+
+Two operational properties we get for free:
+- **TTL-driven cleanup.** Claims past their lease are released by the controller, not by L4. L4 crashing does not strand sandboxes.
+- **kubectl-debuggable.** Operators can `kubectl get sandboxclaims -A` to see pool state without going through L4's admin API.
+
+The `DockerSocketProvider` and `DirectCHProvider` implement the same lifecycle in-process; the CRD shape is the k8s realization of a provider-internal concept.
+
+## Environment-type dispatch (Baku pattern)
+
+Templates carry an `envtype` field consumed by the provider to pick the backend mechanism. The pattern is lifted from Anthropic's Baku/`environment-runner` split ([`research/21`](../research/21-environment-runner-go.md), inspiration-only) and applied narrowly here:
+
+| `envtype` | Provider behaviour | Use case |
+|---|---|---|
+| `dev` | runc on Docker Compose; no isolation; no egress proxy | Local PoC, integration tests |
+| `internal` | sysbox on k8s; egress proxy in monitor mode | Trusted employees |
+| `customer-shared` | sysbox or gVisor (per-template) on k8s; egress proxy enforcing | Customer code-only sandboxes |
+| `customer-cu` | Kata (CH or FC) on bare-metal node pool; egress proxy enforcing | Customer Computer Use sessions |
+| `anthropic-hosted` | Reserved label for our own SaaS deployment; same as `customer-cu` today but pinned to a tier | Anthropic-equivalent deployment shape |
+| `byoc` | Customer-supplied cluster; provider holds a lease on a customer namespace | Reserved, not Phase-1 |
+
+`envtype` is **not** the same as `runtimeClass`. `runtimeClass` is the L2 isolation primitive; `envtype` is the L3 dispatch key. One `envtype` can map to multiple `runtimeClass`-es depending on template (e.g. `customer-shared` resolves to sysbox for code, gVisor for browserless code-exec).
 
 ## Reaper / cleanup
 

--- a/docs/future-architecture/architecture/04-layer2-runtimes.md
+++ b/docs/future-architecture/architecture/04-layer2-runtimes.md
@@ -26,7 +26,32 @@ Numbers from [`sandboxd/docs/architecture.md`](../../../sandboxd/docs/architectu
 - **Hot-plug** — easier resource adjustments.
 - Trade-off: ~80K LoC vs Firecracker's ~50K (larger attack surface, still small).
 
-Firecracker stays available via `kata-fc` for the fastest-cold-start tier (e.g., free-tier anonymous trials).
+Firecracker stays available via `kata-fc` for the fastest-cold-start tier (e.g., free-tier anonymous trials). Note that Firecracker is the microVM that AWS Lambda and Fargate are built on — its scale-pattern lineage informs the Phase 10 snapshot-pool design ([`research/20`](../research/20-snapstart-hot-swap.md)) without making us a Lambda deployment. See the Lambda framing in [`references.md`](../references.md) and [ADR-0010](../adr/0010-lambda-as-inspiration-not-runtime.md).
+
+## virtio-fs vs 9p — the CH/FC asymmetry
+
+CH and FC do not agree on shared-filesystem story, and the difference is load-bearing for Tier-2 (skills) and Tier-4 (user data) mounts:
+
+| | virtio-fs | 9p |
+|---|---|---|
+| Cloud Hypervisor | First-class (default) | Possible but not the natural path |
+| Firecracker upstream | **Not supported** in stock Firecracker | The historical option; out-of-tree patches and Kata wrappers exist |
+| Performance | Native-ish (FUSE protocol, shared page cache) | Slower; protocol overhead dominates |
+| Posix coverage | High | Lower (the legacy choice) |
+
+Implication: `kata-ch` is the only tier where Tier-2 / Tier-4 mounts are "free." On `kata-fc` we either accept 9p's performance/POSIX trade-offs, lean on rclone-FUSE-inside-VM (per [`research/16`](../research/16-anthropic-production-sandbox-observed.md) §3), or block-device-mount squashfs (per [`research/20`](../research/20-snapstart-hot-swap.md) §6). Phase 9 research locks the choice per tier.
+
+## nydus snapshotter for lazy image-layer load
+
+For the microVM tiers (`kata-fc`, `kata-ch`), pulling the full container image at sandbox spawn is the single biggest cold-start cost. **nydus** ([nydus-snapshotter](https://github.com/containerd/nydus-snapshotter), Apache 2.0) reformats OCI images into a chunk-addressable layout that the VM can lazy-load on demand — pages are fetched as files are touched, not upfront.
+
+- **Relevance.** Phase 9 cold-start budget for `kata-ch` is in the 100–200 ms range with full image pull. Lazy-load with nydus gets that closer to template-snapshot territory ([`research/20`](../research/20-snapstart-hot-swap.md)) without the snapshot-pool engineering bill.
+- **Trade-off.** Adds a new component to the runtime path; failure modes (registry hiccups mid-execution) need their own playbook.
+- **Decision.** Phase 9 research evaluates whether nydus or a snapshot pool (or both, layered) hits the cold-start target.
+
+## VMM Lambda lineage (one paragraph, by reference)
+
+Firecracker exists because AWS needed a VMM small enough to scale Lambda/Fargate. Anthropic's `process_api` and our Phase-9 `kata-fc` tier both inherit from that lineage. The architectural takeaway is the **VMM design** (minimal device model, small attack surface, fast init) — not the deployment substrate. See [`references.md`](../references.md) Lambda framing, [`research/05`](../research/05-firecracker.md), and [ADR-0010](../adr/0010-lambda-as-inspiration-not-runtime.md) for the closed answer to "are we going to run on Lambda?" (no).
 
 ## Why NOT gVisor for browsers
 

--- a/docs/future-architecture/architecture/05-layer1-guest-agent.md
+++ b/docs/future-architecture/architecture/05-layer1-guest-agent.md
@@ -40,7 +40,8 @@ service Agent {
 }
 ```
 
-**WebSocket passthroughs** are routed through the same data-plane port (or, optionally, a sibling port — Phase 7 research decides):
+**WebSocket passthroughs** are routed through a **sibling port by default** (one passthrough socket per stream), so the data-plane WS does not have to multiplex CDP / ttyd binary frames alongside `Agent.*` RPC frames. The same-port variant ("one socket per sandbox") stays available as an option if a future deployment needs to minimize listener count, but Phase 7 ships the sibling-port shape.
+
 - `WS /v1/cdp` — bidirectional CDP proxy to local Chromium; L4 shovels frames opaquely.
 - `WS /v1/tty` — ttyd-equivalent terminal stream.
 

--- a/docs/future-architecture/architecture/05-layer1-guest-agent.md
+++ b/docs/future-architecture/architecture/05-layer1-guest-agent.md
@@ -3,12 +3,29 @@
 
 # 05 — Layer 1: Guest Agent
 
-> The PID 1 process inside every sandbox. Today: Python entrypoint + in-image MCP server. Future: small Go static binary (Phase 7).
-> Language decision: **Go** ([ADR-0002](../adr/0002-guest-agent-language-go.md)).
+> The PID 1 process inside every sandbox. Today: Python entrypoint + in-image MCP server. Future: small **Rust** static binary (Phase 7).
+> Language decision: **Rust** ([ADR-0002](../adr/0002-guest-agent-language-go.md)). Closest precedent: Anthropic `process_api` — see [`research/19`](../research/19-anthropic-process-api.md).
 
 ## Contract (target)
 
-The agent serves **connect-go** (gRPC + Connect + HTTP/JSON from one `.proto`) on vsock (microVM) or TCP (runc/sysbox/gVisor). It is **never** publicly reachable — only L3 (provider) talks to it. See [ADR-0008](../adr/0008-internal-grpc-external-rest-mcp.md) for the transport decision.
+The agent exposes **two ports**, on the model `process_api` validates:
+
+1. **Data plane — WebSocket.** Bidirectional, JSON frames (serde-tagged enums), zstd compression optional via capabilities negotiation. Carries every per-session interaction: exec, streaming I/O, signal forwarding, CDP/ttyd passthrough. Transport is **auto-detected**, not build-tag-gated:
+   - `vsock` if `/dev/vsock` is present (microVM tiers `kata-ch`, `kata-fc`).
+   - `TCP` otherwise (runc, sysbox, gVisor, dev).
+   - Same `handle_ws` accept loop drives both ([`research/19`](../research/19-anthropic-process-api.md) §2). Transport is operational, not architectural.
+2. **Control plane — HTTP.** Stateless POSTs for actions that should not flow through the user-facing data plane. Separate listener, same binary:
+   - `GET /healthz`, `GET /readyz` — liveness / readiness probes for L3.
+   - `POST /shutdown` — graceful shutdown signal.
+   - `POST /mount_root` — snapstart restore handshake. **Phase 10 only**, feature-gated until then.
+   - `POST /fs_freeze`, `POST /fs_thaw` — `FIFREEZE` / `FITHAW` ioctl bridge for snapshot consistency. **Phase 10 only.**
+   - `POST /auth_public_key` — hot-reload of the Ed25519 verification key. Optional, Phase 7+.
+
+The L1 agent is **never** publicly reachable — only L3 (provider) talks to it. See [ADR-0008](../adr/0008-internal-grpc-external-rest-mcp.md) for transport positioning across tiers (and the Phase 7 gate on connect-rust vs. WS-frame protocol).
+
+## RPC surface (data plane)
+
+The methods below map to message variants on the WebSocket. The shape is sketched as a `.proto` for clarity, but the wire is **JSON frames + capabilities-negotiated V1/V2 variants**, not gRPC ([`research/19`](../research/19-anthropic-process-api.md) §4, §12).
 
 ```proto
 service Agent {
@@ -23,72 +40,100 @@ service Agent {
 }
 ```
 
-**WebSocket passthroughs** sit alongside the connect-go service (not RPCs):
+**WebSocket passthroughs** are routed through the same data-plane port (or, optionally, a sibling port — Phase 7 research decides):
 - `WS /v1/cdp` — bidirectional CDP proxy to local Chromium; L4 shovels frames opaquely.
 - `WS /v1/tty` — ttyd-equivalent terminal stream.
 
-The agent **does not** speak MCP. MCP semantics live in L4's gateway. L4 receives `tools/call` from the user, decides which sandbox owns the session, and calls `Agent.ToolCall` over connect-go. This keeps the user-facing wire (MCP) decoupled from internal RPC evolution.
+The agent **does not** speak MCP. MCP semantics live in L4's gateway. L4 receives `tools/call` from the user, decides which sandbox owns the session, and calls `Agent.ToolCall`. This keeps the user-facing wire (MCP) decoupled from internal RPC evolution.
+
+## Capabilities negotiation (V1/V2)
+
+The server's first frame on each connection advertises capabilities, modelled on `process_api`'s `ConnectionCapabilities` ([`research/19`](../research/19-anthropic-process-api.md) §4):
+
+```json
+{
+  "type": "ConnectionCapabilities",
+  "supports_traces": true,
+  "supports_zstd":   true,
+  "protocol_version": 2
+}
+```
+
+Old clients ignore unknown fields and stay on V1 message variants. New clients opt into V2, zstd compression on server-to-client frames, and trace events. This lets the agent protocol evolve without breaking older sandboxes still in flight.
+
+## PID 1 hygiene (Phase 7 mandatory)
+
+The agent is the init process inside the sandbox. These primitives are mandatory together — none of them works alone:
+
+- **`SIGCHLD` reaping.** Wait on the signalfd or libc `signal()` and reap zombies. Without this, fork-heavy workloads (sub-agent CLIs, shell scripts) leak PIDs until cgroup limits trip.
+- **`SIGTERM` propagation.** L3's `/shutdown` POST or a connect-side `Shutdown` RPC drains via: page-cache drop → SIGTERM to the workload process group → grace-period wait → SIGKILL escalation. The two-phase shape mirrors `process_api`'s OOM killer ([`research/19`](../research/19-anthropic-process-api.md) §7).
+- **`PR_SET_DUMPABLE=0` post-init.** Disables core dumps and blocks `/proc/<pid>/mem` reads from other processes — even from inside the same UID. Cheap, prevents an entire class of "ptrace the agent to steal session JWT" attacks ([`research/13`](../research/13-anthropic-sandbox-runtime.md) §4 two-stage nested-namespace pattern).
+- **`killed_by_process_api`-style audit flag.** A per-child boolean that distinguishes "agent killed this" (timeout, OOM, signal RPC) from "kernel killed this" (cgroup OOM, external SIGKILL). Removes ambiguity from the audit log without parsing exit codes ([`research/19`](../research/19-anthropic-process-api.md) §6).
+- **Env-var scrub before fork.** Strip names matching `_TOKEN`, `_SECRET`, `_PASSWORD`, `API_KEY` from the child env unless the configure-time policy explicitly passes them through. Cross-link to [antipattern A1].
 
 ## What L1 does NOT do
 
-- **Authenticate users.** L4 does. L1 trusts whoever can reach its port (network policy ensures only L3 can).
+- **Authenticate users.** L4 does. L1 trusts whoever can reach its port — network policy ensures only L3 can.
+- **Authenticate L3 — for now.** Phase 7+ may add **Ed25519 JWT bound to `container_name`** read from `/container_info.json`, modelled on `process_api` ([`research/19`](../research/19-anthropic-process-api.md) §3). Pre-Phase-7+ the network boundary alone is the trust boundary. **Document this loudly; do NOT add a fake bearer token that lulls operators.**
 - **Persist state across sessions.** L3 owns the sandbox lifecycle and any volume binding.
 - **Manage its own lifecycle.** It runs until killed; L3 decides when.
-- **Hold long-lived secrets.** Secrets arrive via `/v1/configure` (per-session, short-lived). Rotated by L4's secret broker. See [07-security.md](./07-security.md).
+- **Hold long-lived secrets.** Secrets arrive via `Configure` (per-session, short-lived). Rotated by L4's secret broker. See [07-security.md](./07-security.md).
 
 ## Today's transitional L1 (Python entrypoint + MCP server in image)
 
 The current image's entrypoint:
-- Reads env vars
-- Dynamically generates an MCP config
-- Starts the MCP server (FastMCP) that the orchestrator talks to via `docker exec` and Docker streams
+- Reads env vars.
+- Dynamically generates an MCP config.
+- Starts the MCP server (FastMCP) that the orchestrator talks to via `docker exec` and Docker streams.
 
 This works for the PoC and stays through Phases 1–6. It blocks two things:
-- **microVM runtimes** — there's no vsock transport in the current setup.
+- **microVM runtimes** — no vsock transport in the current setup.
 - **Smaller, harder-to-RCE surface** — Python + Playwright + skills is a big attack surface inside the sandbox.
 
-Phase 7 replaces this with the Go agent.
+Phase 7 replaces this with the Rust agent.
 
-## Future Go agent — design notes
+## Future Rust agent — design notes
 
-- **Static binary** built with `CGO_ENABLED=0`, multi-arch (`amd64` mandatory, `arm64` later).
-- **PID 1 hygiene:** reap zombies, propagate signals, exit cleanly. Reference patterns: kata-agent (Rust) signal handling adapted to Go.
-- **Transports:**
-  - HTTP+WS on a fixed port (today's path)
-  - vsock listener gated by build tag or runtime detection (kata/microVM only — Phase 9 unlocks this)
-- **Process model:** spawn user commands as a child process group; stream stdout/stderr; track exit code. For long-running CDP/ttyd, keep persistent goroutines.
-- **CDP proxy:** the agent runs Chromium locally and proxies CDP. Two options to evaluate in Phase 7 research:
-  - Use [`chromedp`](https://github.com/chromedp/chromedp) (Go-native CDP client)
-  - Raw WebSocket pass-through to Chromium's `/devtools/browser` endpoint
-- **No HTTP auth.** Token-on-the-wire is meaningless in-sandbox — defense is network-policy-level (L3 owns it). Document this loudly; do NOT add a fake auth that lulls operators.
-
-## Why Go (and why we keep Rust documented)
-
-See [ADR-0002](../adr/0002-guest-agent-language-go.md). One-paragraph summary here:
-
-- **For Go:** user preference; single language across L1+L4 simplifies on-call; chromedp gives mature CDP support; ecosystem already proven by `envd` and gVisor. Static binary cross-compiles cleanly.
-- **What Rust would buy us:** ~half the binary size; stronger memory-safety guarantees against HTTP-parsing RCE (matters because L1 is the in-sandbox attack target); precedent from kata-agent and msb-agent. Door stays open — interfaces are language-agnostic.
+- **Static-PIE binary**, `musl` target, x86-64 + arm64. Target size ~4–6 MB (precedent: `process_api` 4.3 MB, [`research/19`](../research/19-anthropic-process-api.md) §1).
+- **Crate footprint** ([ADR-0002](../adr/0002-guest-agent-language-go.md)): `tokio`, `hyper`, `tokio-tungstenite`, `tokio-vsock`, `ring`, `jsonwebtoken`, `clap`, `nix`, `serde_json`. Optional `zstd` if capabilities negotiation enables it. No `chromedp` equivalent — see CDP note below.
+- **PID 1 hygiene** as above (`SIGCHLD`, `SIGTERM`/`SIGKILL` chain, `PR_SET_DUMPABLE=0`, env-scrub).
+- **Process model:** spawn workloads as child process groups; stream stdout/stderr as `ExpectStdOut`/`ExpectStdErr` frames; track exit code; emit `ProcessExited` / `ProcessTimedOut` / `ProcessOutOfMemory` terminal states (mutually exclusive, modelled on [`research/19`](../research/19-anthropic-process-api.md) §6).
+- **Cgroup-aware OOM monitor.** Per-container OOM watchdog polls cgroup memory at 100 ms; adopts orphans before scanning; two-phase kill (signal → wait → escalate). Replaces our current reliance on Docker's default OOM policy.
+- **CDP proxy.** Two options for Phase 7 research:
+  - Use [`chromiumoxide`](https://github.com/mattsse/chromiumoxide) (Rust-native CDP client) and let L1 drive Chromium.
+  - **Raw WebSocket pass-through** to Chromium's `/devtools/browser` endpoint — L4 (and L1) never parse CDP frames. Simpler, smaller agent. Aligns with ADR-0008's "L4 shovels frames opaquely" stance.
+- **MCP tool execution.** A small dispatch layer above the data-plane WS — see "MCP tool execution inside L1" below.
+- **No HTTP bearer auth on the data plane** until Phase 7+ Ed25519 JWT lands. Network policy is the trust boundary in the meantime.
 
 ## MCP tool execution inside L1
 
 Today's tools (`mcp_tools.py`):
-- `bash_tool` — exec in a shell
-- `python_tool` — exec under python3
-- `create_file` / `str_replace` / `view` — file ops
-- `view_image` — return base64
-- `sub_agent` — dispatch to claude / codex / opencode CLI
+- `bash_tool` — exec in a shell.
+- `python_tool` — exec under python3.
+- `create_file` / `str_replace` / `view` — file ops.
+- `view_image` — return base64.
+- `sub_agent` — dispatch to claude / codex / opencode CLI.
 
-Phase 7 maps each to a Go handler. Sub-agent dispatch (`cli_runtime.dispatch()`) is the heaviest port — its current Python adapter layer for each CLI must be re-implemented. Acceptable cost: this is the place where most "sandbox business logic" lives, and Go keeps it auditable.
+Phase 7 maps each to a Rust handler reachable via `Agent.ToolCall`. Sub-agent dispatch (`cli_runtime.dispatch()`) is the heaviest port — its current Python adapter layer per CLI must be re-implemented. Acceptable cost: this is where most "sandbox business logic" lives, and the new home is auditable.
 
-## Open questions (deferred to Phase 7 research)
+The agent itself does not need to know what's in `skills/`. Skills are mounted as a Tier-2 squashfs and discovered at runtime by the workload, not by L1 ([06-storage.md](./06-storage.md)).
 
-- chromedp vs raw CDP WebSocket
-- ttyd replacement vs wrap-in-place
-- vsock listener strategy (build-tag, env-detection, or always-on with fallback)
-- Whether to keep Python skills available via `python_tool` in the new image (yes — skills are an L1 capability bundle, not an L1 implementation language)
+## Open questions (Phase 7 research must answer)
+
+- `chromiumoxide` vs raw CDP WebSocket passthrough — pick one, justify, document.
+- ttyd replacement (Rust-native) vs wrap-in-place (run ttyd as a subprocess and proxy its WS).
+- Transport auto-detect details: presence of `/dev/vsock` plus configure-time hint, or a CLI flag with a sensible default — Phase 7 picks the rule.
+- Connect-rust vs `process_api`-style WS-frame protocol on vsock ([ADR-0008](../adr/0008-internal-grpc-external-rest-mcp.md) Phase 7 gate). Driven by tooling maturity and binary-size measurement on real artefacts.
+- Whether Phase 7 ships JWT auth on day one, or starts network-only and adds JWT in Phase 7.1. Default leans toward the latter — small surfaces first.
+
+## Related
+
+- ADR: [ADR-0002](../adr/0002-guest-agent-language-go.md) (Rust for L1), [ADR-0008](../adr/0008-internal-grpc-external-rest-mcp.md) (transport choice + Phase 7 gate), [ADR-0010](../adr/0010-lambda-as-inspiration-not-runtime.md) (Lambda framing).
+- Research: [`research/19-anthropic-process-api.md`](../research/19-anthropic-process-api.md) (primary precedent), [`research/13-anthropic-sandbox-runtime.md`](../research/13-anthropic-sandbox-runtime.md) (PID 1 + nested-ns hardening), [`research/02-e2b-infra.md`](../research/02-e2b-infra.md) (`envd` comparison).
+- Antipatterns: A1 (secret leakage in env), and the deny-paths list (`.git/hooks/*`, `.bashrc`, `.mcp.json`, `.claude/`) enforced via [`07-security.md`](./07-security.md).
 
 ## Source
 
-- [`sandboxd/docs/architecture.md`](../../../sandboxd/docs/architecture.md) (Layer 1)
-- [`sandboxd/docs/agent-protocol.md`](../../../sandboxd/docs/agent-protocol.md)
-- [`docs/future-architecture/references.md`](../references.md) (`envd`, `kata-agent`, `msb-agent`)
+- [`sandboxd/docs/architecture.md`](../../../sandboxd/docs/architecture.md) (Layer 1).
+- [`sandboxd/docs/agent-protocol.md`](../../../sandboxd/docs/agent-protocol.md).
+- [`sandboxd/anthropic/`](../../../sandboxd/anthropic/) — `process_api` pattern catalogue (closest documented precedent).

--- a/docs/future-architecture/architecture/06-storage.md
+++ b/docs/future-architecture/architecture/06-storage.md
@@ -88,6 +88,34 @@ mounts:
 | 5 | K8s provider uses PVCs (RWO) for Tier 3 opt-in persistence; FUSE pattern carried to pods |
 | 8 | virtio-fs replaces FUSE on kata-ch (faster, kernel-level) |
 
+## Block-device tooling swap (microVM templates, Phase 10)
+
+Once the snapstart pattern lands ([`research/20-snapstart-hot-swap.md`](../research/20-snapstart-hot-swap.md)), Tier-1 and Tier-2 content stops being "OCI layers pulled at spawn" and becomes **block devices the host swaps at resume**. The L1 agent's job is to remount them when the host signals readiness via `POST /mount_root` on its control server.
+
+Layout per session (Firecracker / Cloud Hypervisor microVM):
+
+| Device | Content | Mode | Lifetime |
+|---|---|---|---|
+| `vda` | per-tenant root overlay on a shared template base (ext4) | RW | per session |
+| `vdb` | Tier 2 skills (squashfs of `/opt/skills`) | RO | per release |
+| `vdc` | Tier 1 runtime/payload (squashfs of `/opt/<runner>`) | RO | per release |
+| Tier-4 mounts | rclone-FUSE-in-VM as today | RW (where applicable) | per tenant |
+
+Per-resume sequence on the L1 side (the host does the device swap first, then calls `/mount_root`):
+
+1. `drop_caches` — page cache references files from the frozen rootfs that no longer exist.
+2. Remount devtmpfs.
+3. Mount `/dev/vda` as ext4, `pivot_root` into it.
+4. Mount `/dev/vdb`, `/dev/vdc` squashfs overlays.
+5. `clock_settime()` (the wall-clock was frozen).
+6. Trigger CRNG reseed (see [07-security.md](./07-security.md) snapstart-restore hardening).
+7. Drop `CAP_SYS_RESOURCE`.
+8. Start accepting WS connections.
+
+The pattern lifts directly from `process_api` / Baku ([`research/19`](../research/19-anthropic-process-api.md) §5, §9; [`research/20`](../research/20-snapstart-hot-swap.md) §2). Tier-2 stays as squashfs in both the OCI-layer world and the block-device world — the format is the same, only the delivery channel changes. **Skills built before Phase 10 are forward-compatible.**
+
+Implication for the release pipeline (Phase 10): tooling produces both an OCI image *and* a paired set of `vdb` / `vdc` squashfs blobs from the same source. Both are signed; both are referenced by content hash from templates. Phase 9 templates use only OCI; Phase 10 templates may use either, gated on `snapstart_compatible` ([09-templates.md](./09-templates.md)).
+
 ## Explicit non-goals
 
 - **No RWX (ReadWriteMany).** Single-writer patterns only. Avoids EFS/Filestore complexity and consistency surprises.

--- a/docs/future-architecture/architecture/07-security.md
+++ b/docs/future-architecture/architecture/07-security.md
@@ -84,6 +84,62 @@ L2 carries the load for untrusted workloads. See the runtime matrix in [04-layer
 
 See [`sandboxd/docs/security.md`](../../../sandboxd/docs/security.md) for CVE history references.
 
+## Mandatory deny paths inside the workspace
+
+Even with full L2 isolation, the agent itself must refuse to write a small set of paths that are vectors for persistent shell takeover or self-exfiltration. The list is **always-on, regardless of template configuration** — modelled on Anthropic's local sandbox-runtime ([`research/13`](../research/13-anthropic-sandbox-runtime.md) §2):
+
+| Path / glob | Why blocked |
+|---|---|
+| `.bashrc`, `.bash_profile`, `.zshrc`, `.zprofile`, `.profile` | Persistent shell hijack — survives session, exfils on next user shell |
+| `.gitconfig`, `.gitmodules` | Persistent git hooks via `[core] hooksPath`; submodule URL injection |
+| `.git/hooks/*` | Hook execution on every git operation |
+| `.mcp.json` | Sub-agent MCP server hijack |
+| `.claude/`, `.claude-code/`, `.codex/`, `.opencode/` | Sub-agent CLI config / credential hijack |
+| `.vscode/`, `.idea/` | IDE-driven code execution on user re-open |
+| `.ssh/`, `.aws/`, `.gcp/`, `.kube/` | Credential exfil targets |
+| `$PATH` directories owned by the user (`~/.local/bin/*`, `bin/*`) | Shadow-binary injection |
+
+Enforcement: a Rust-side path-canonicalization check on every write in the L1 agent's file-ops handlers. Symlink targets are resolved before the check (see symlink-attack defenses in [`research/13`](../research/13-anthropic-sandbox-runtime.md) §6). Phase 7 implements; the antipattern reference is A1 / C-series.
+
+## Graceful-shutdown protocol
+
+When L3 needs to stop a sandbox — drain for upgrade, end-of-session, idle TTL — the protocol is **four steps, in order**. Skipping steps causes data loss (atomic-rename caught mid-flight) or audit-log gaps:
+
+1. **Drop the page cache** inside the sandbox (echo 3 → drop_caches via the L1 control endpoint). Forces dirty data to disk; pending writebacks complete or fail visibly.
+2. **`SIGTERM` to the workload process group.** Give it a grace period (default 10 s, template-tunable).
+3. **Wait** for child reaper to confirm exit, or timeout.
+4. **`SIGKILL`** to anything still running. Container teardown follows.
+
+The L1 agent exposes this as `POST /shutdown` on the control plane ([05-layer1-guest-agent.md](./05-layer1-guest-agent.md)) and as a connect-side `Shutdown` RPC on the data plane. The two paths share the same state machine; whichever fires first wins.
+
+## Defense-in-depth: `memfd_create` for the agent binary (Phase 9+)
+
+Optional hardening for the microVM tiers: the L1 agent binary is loaded into a `memfd` at boot and the on-disk copy is unlinked. An attacker who lands code execution inside the sandbox cannot read the agent binary from disk to study it — `/proc/self/exe` resolves to a memory-only file descriptor.
+
+This is purely defense-in-depth (the binary's source-equivalent is public). Cheap to implement once the agent is a static Rust binary; **Phase 9 nice-to-have, not Phase 7 must.**
+
+## Snapstart-restore hardening (Phase 10)
+
+When a sandbox resumes from a frozen Firecracker snapshot, the guest is **stale by design** — the kernel knows it forked but userspace does not. Without explicit re-initialization, userspace RNGs reseed from snapshotted state (worst-case identical seeds across restores), wall-clock is wrong by minutes-to-days, and any cached page references point into a rootfs that was just swapped underneath.
+
+Mandatory on every restore (lifted from [`research/20`](../research/20-snapstart-hot-swap.md) §4):
+
+| Action | Why |
+|---|---|
+| `drop_caches` after device hot-swap | Page cache references the frozen rootfs |
+| Devtmpfs remount | Device-node mapping changed |
+| `pivot_root` onto fresh rootfs | The frozen rootfs is stale |
+| `clock_settime()` to current host time | Wall-clock was frozen |
+| **CRNG reseed** (`getrandom`-style force) | Userspace RNGs (OpenSSL, glibc arc4random) don't notice the fork — without reseed, two sandboxes restored from the same snapshot can generate identical "random" values |
+| Drop `CAP_SYS_RESOURCE` | Held only for init |
+| Re-run env-var scrub | Template env may have changed since the template was frozen |
+
+Template-build-time hardening:
+- `init_on_free=1` kernel cmdline — zeroes freed pages before reuse so a fresh resume can't read template-VM secrets out of recycled memory.
+- Template image built with **no `CAP_SYS_RESOURCE` retention** logic — the cap is held only during init.
+
+Until Phase 10 ships, the L1 agent's `/mount_root` endpoint is **not exposed**. Adding it pre-Phase-10 is a footgun (untested resume path on a sandbox that was never frozen).
+
 ## Sandbox hygiene
 
 - **No reuse between tenants.** When a session ends, sandbox is destroyed. Never returned to the pool of another tenant.
@@ -126,7 +182,7 @@ Retention: **≥ 90 days**. Append-only sink. See [10-observability.md](./10-obs
 | 4 | **Secret broker** + per-session STS + key rotation |
 | 5 | NetworkPolicy default-deny + ResourceQuota + empty-RBAC SA in Helm chart |
 | 6 | mTLS L4 ↔ L3; OIDC for admin UI |
-| 7 | Go agent shrinks attack surface; signed image enforcement |
+| 7 | Rust agent shrinks attack surface; signed image enforcement |
 | 8 | Egress proxy + audit-log pipeline + 90 d retention **(prereq for any untrusted tier)** |
 | 9 | `kata-ch` / `kata-fc` raise the isolation ceiling — untrusted tier opens, gated on Phase 8 |
 | 10 | Snapshot/restore + post-restore hardening (CRNG reseed, `init_on_free=1`, `CAP_SYS_RESOURCE` drop); KMS-backed per-session encryption keys for persistent storage |

--- a/docs/future-architecture/architecture/08-networking.md
+++ b/docs/future-architecture/architecture/08-networking.md
@@ -100,6 +100,48 @@ Target (Phase 6+):
 | 8 | Egress proxy + JWT signing in L4 + audit sink (prereq for untrusted tier in Phase 9) |
 | 10 | Multi-AZ session routing — snapshot-based recovery on pod failure (not in-memory affinity); multi-region foundations only — see `sandboxd` §"Other catalog additions" |
 
+## Multi-region workspace proxies (Phase 10 substrate)
+
+Long-lived CDP / ttyd WebSockets penalize latency hard — a 200 ms RTT makes a Chromium screencast feel underwater. Once the deployment spans more than one region, L4 cannot terminate every user's WebSocket centrally without paying the cross-region tax on every keystroke.
+
+The pattern, lifted from Coder ([`research/03`](../research/03-coder.md)) and from the Anthropic production deployment's Coder lineage ([`research/16`](../research/16-anthropic-production-sandbox-observed.md) §6):
+
+```text
+                User UI
+                   │
+                   ▼
+        ┌──────────────────────┐
+        │ Region-local         │
+        │ Workspace Proxy      │   one per region; terminates user-side TLS
+        │ (CDP/ttyd terminator)│   consistent-hashes by session_id
+        └──────────┬───────────┘
+                   │ mTLS, region-local
+                   ▼
+        ┌──────────────────────┐
+        │ L4 (global, multi-AZ)│
+        │ + KV session router  │
+        └──────────┬───────────┘
+                   │
+                   ▼
+        ┌──────────────────────┐
+        │ L3 + sandboxes        │
+        │ in the user's region  │
+        └──────────────────────┘
+```
+
+Properties:
+- **User-perceived latency is region-local.** RTT to the sandbox stays under the regional ceiling.
+- **L4 stays single-pane-of-glass.** Auth, session router, secret broker remain global; the proxies are dumb shovels.
+- **Failure isolation.** A region's proxy can lose its L4 link without dropping in-flight CDP frames (proxy buffers; reconnects when L4 returns).
+- **Consistent-hash by `session_id`.** Within a region, the same session always lands on the same proxy replica. Avoids the `sessionAffinity: ClientIP` anti-pattern called out in [`02-layer4-control-plane.md`](./02-layer4-control-plane.md).
+
+What this implies for earlier phases:
+- The CDP/ttyd transport must already be transparent passthrough (L4 does not parse frames — [ADR-0008](../adr/0008-internal-grpc-external-rest-mcp.md)). Anything that requires L4 to understand the wire breaks here.
+- Session router state must be **externally addressable** (KV, not in-process) so a region-local proxy can resolve `session_id → region`.
+- mTLS between proxy and L4 must be operational — Phase 6 deliverable.
+
+Phase 10 ships one proxy per region; before that, the proxy is just L4 itself (one region). The architecture is forward-compatible: a Phase 6 deployment with no proxies looks like the Phase 10 deployment minus the geographic shard.
+
 ## Source
 
 - [`sandboxd/docs/security.md`](../../../sandboxd/docs/security.md)

--- a/docs/future-architecture/architecture/09-templates.md
+++ b/docs/future-architecture/architecture/09-templates.md
@@ -28,6 +28,8 @@ spec:
     signature: required           # cosign verified by admission
 
   runtime_class: kata-ch          # see 04-layer2-runtimes.md
+  envtype: customer-cu            # L3 dispatch key — see 03-layer3-providers.md
+  snapstart_compatible: false     # Phase 10 only; set true when template ships paired squashfs blobs (see 06-storage.md)
 
   resources:
     cpu:   "2"
@@ -96,6 +98,11 @@ The mapping is policy held in L4 config (DB-backed in Phase 6+). Admin UI edits 
 - **Validated** at admission: image signature, mount sanity, resource within cluster quotas.
 - **Versioned**: name carries `vN`. Old version stays until its referenced sessions drain. No mutation in place.
 - **Deprecated** via label; new sessions get the latest non-deprecated.
+
+## Two new fields, briefly
+
+- **`envtype`** — the L3 dispatch key. Picks the backend mechanism (Docker Compose vs k8s vs DirectCH, plus the egress-proxy enforcement mode). Values: `dev`, `internal`, `customer-shared`, `customer-cu`, `anthropic-hosted`, `byoc`. Full matrix in [`03-layer3-providers.md`](./03-layer3-providers.md) "Environment-type dispatch (Baku pattern)". Distinct from `runtime_class` — `envtype` says *where it runs*, `runtime_class` says *what isolates it*.
+- **`snapstart_compatible`** — Phase-10-only flag. When `true`, the template's release pipeline produced paired Tier-2 squashfs blobs (`vdb`, `vdc`) alongside the OCI image, and the template is wired for block-device hot-swap on resume ([`06-storage.md`](./06-storage.md) block-device tooling swap). Phase 9 templates are always `false`. Templates without paired blobs are rejected by admission when this flag is `true`.
 
 ## Per-phase progression
 

--- a/docs/future-architecture/architecture/10-observability.md
+++ b/docs/future-architecture/architecture/10-observability.md
@@ -51,6 +51,45 @@ Egress proxy:
 
 These match the sandboxd targets and are validated in Phase 5 (k8s prod) + Phase 9 (kata).
 
+## RAM-based capacity-sizing formula
+
+The first question operators ask is "how many sandboxes does a node hold?" The answer is bounded by **RAM**, not CPU — sandboxes idle most of the time but always reserve their memory request. For `kata-ch` / `kata-fc` specifically, the VMM itself owns a slab of memory that the workload never sees.
+
+```
+concurrent_sandboxes_per_node = floor(
+    (node_ram_bytes - system_reserve_bytes - kubelet_reserve_bytes)
+    / (template.mem_request_bytes × overcommit_factor + vmm_overhead_bytes)
+)
+```
+
+| Term | Typical value | Notes |
+|---|---|---|
+| `node_ram_bytes` | Per node, e.g. `64 GiB` | The bare-metal node spec |
+| `system_reserve_bytes` | `1–2 GiB` | Kernel, daemons, monitoring agents |
+| `kubelet_reserve_bytes` | `~512 MiB` | k8s overhead per `kube-reserved` + `system-reserved` |
+| `template.mem_request_bytes` | `2 GiB` (default `customer-cu-kata-ch-v3`) | What the template guarantees the workload |
+| `overcommit_factor` | `1.0` for `customer-cu`, up to `1.5` for `internal` | Operators choose; lower = stricter |
+| `vmm_overhead_bytes` | `0` for runc/sysbox, `~20 MiB` for `kata-fc`, `~40 MiB` for `kata-ch` | Per-VM Firecracker / CH process |
+
+Operators size node pools by **solving for `node_ram_bytes`** given a target `concurrent_sandboxes_per_node` and the dominant template. Phase 9 validates the formula on real bare-metal hardware; the dashboard ships node-level "sandbox-density" gauge so the formula can be tuned with field data.
+
+The formula intentionally does **not** include CPU. CPU oversubscription is a separate axis governed by `cpu_request` and HPA; conflating it with RAM here would mislead capacity-planners.
+
+For the Phase 10 frozen-snapshot pool, the analog formula replaces `mem_request × concurrent` with `snapshot_blob_size × pool_size` — RAM cost goes to zero for cold pool entries (they live on disk), only resumed-but-idle sandboxes consume RAM. The formula is updated in the Phase 10 deliverable.
+
+## Distributed tracing
+
+The W3C `traceparent` header crosses every layer boundary; without that, "why was this exec slow?" is unanswerable. Concrete wire requirements:
+
+- **L4 ingress.** Generate a root span per MCP request; attach `traceparent` to every downstream call.
+- **L4 → L3.** Carried on the connect-go metadata (`traceparent` is a first-class metadata key); L3 starts a child span on receive.
+- **L3 → L1.** Carried as a JSON field in the `Configure` / `ToolCall` / `Exec` data-plane frame (the WS protocol doesn't have HTTP headers; the trace context rides inside the message envelope). L1 starts a child span on receive.
+- **Audit-log linkage.** Every audit event carries the `trace_id` of the request that triggered it. This is what lets the "why was this destination egress-blocked?" question reduce to a single trace lookup.
+
+Sampling: ingress samples at a configurable rate (default `1.0` in dev, `0.01` in prod); the rest of the stack honors the upstream sample decision (no resampling). Forced-sample on errors regardless of rate.
+
+OpenTelemetry SDK lands in L4 at Phase 6; L3 at Phase 6+; L1 at Phase 7 (the Rust agent uses `tracing` + `opentelemetry-otlp`). Phase 8 wires the audit-log linkage.
+
 ## Audit log
 
 See [07-security.md](./07-security.md) for the mandatory event list and forbidden-content rules.
@@ -58,15 +97,6 @@ See [07-security.md](./07-security.md) for the mandatory event list and forbidde
 - Sink: separate from regular logs (e.g., S3 bucket, immutability lock).
 - Retention: ≥ 90 days. SOC-2-aligned.
 - Schema: stable, versioned. Each event carries `event_id`, `ts`, `tenant_id`, `session_id`, `type`, `payload`.
-
-## Tracing patterns
-
-- L4 starts a span per MCP request.
-- L4 → L3 calls carry W3C `traceparent`.
-- L3 → L1 carries it forward (HTTP header).
-- Skill / sub-agent execution wraps a child span.
-
-This makes "why was that exec slow" answerable across the whole stack in one trace.
 
 ## Health probes
 

--- a/docs/future-architecture/architecture/10-observability.md
+++ b/docs/future-architecture/architecture/10-observability.md
@@ -55,7 +55,7 @@ These match the sandboxd targets and are validated in Phase 5 (k8s prod) + Phase
 
 The first question operators ask is "how many sandboxes does a node hold?" The answer is bounded by **RAM**, not CPU — sandboxes idle most of the time but always reserve their memory request. For `kata-ch` / `kata-fc` specifically, the VMM itself owns a slab of memory that the workload never sees.
 
-```
+```text
 concurrent_sandboxes_per_node = floor(
     (node_ram_bytes - system_reserve_bytes - kubelet_reserve_bytes)
     / (template.mem_request_bytes × overcommit_factor + vmm_overhead_bytes)

--- a/docs/future-architecture/references.md
+++ b/docs/future-architecture/references.md
@@ -13,12 +13,20 @@
 
 ## Layer 1 — Guest agents (sandbox PID 1)
 
+### `process_api` (Anthropic Claude.ai sandbox pattern reference)
+- **URL:** internal to Anthropic; not publicly released. Our pattern notes live under [`sandboxd/anthropic/`](../../sandboxd/anthropic/).
+- **License:** our notes are BUSL-1.1; the patterns described are observed behaviour of a closed system.
+- **Language:** Rust (Tokio, hyper, tokio-tungstenite, tokio-vsock, ring, jsonwebtoken).
+- **Role:** **The closest documented reference for our Phase 7 L1 design.** Static-PIE Rust binary reported to run as PID 1 in Firecracker (`--firecracker-init`) or as a sidecar in gVisor/runc. WebSocket-over-three-transports (vsock / UDS / TCP), Ed25519 JWT bound to `container_name`, capabilities negotiation (V1/V2 + zstd + traces), dual-port API (data-plane WS + control-plane HTTP for `/mount_root` / `/shutdown` / `/fs_freeze`).
+- **Notes:** Drives ADR-0002 (Rust for L1). Full pattern catalogue in [`research/19-anthropic-process-api.md`](./research/19-anthropic-process-api.md). The Go session agent that runs above it (`environment-runner`) is documented separately in [`research/21-environment-runner-go.md`](./research/21-environment-runner-go.md) but is **inspiration-only** — out of scope.
+- **To research:** Phase 7, Phase 10.
+
 ### e2b-dev/infra — `envd`
 - **URL:** https://github.com/e2b-dev/infra/tree/main/packages/envd
 - **License:** Apache 2.0
 - **Language:** Go
-- **Role:** Reference for our future Go guest agent (Phase 7). API surface, gRPC streaming, image-build pipeline.
-- **Notes:** Production at E2B Cloud. Coupled to Firecracker networking and Nomad — port API ideas, not glue.
+- **Role:** Comparison point for the L1 agent (Phase 7). API surface, gRPC streaming, image-build pipeline. Production at E2B Cloud.
+- **Notes:** Coupled to Firecracker networking and Nomad — port API ideas, not glue. With ADR-0002 now Rust, this is a comparison reference, not a stack reference.
 - **To research:** Phase 7.
 
 ### kata-containers / src / agent
@@ -162,7 +170,7 @@
 - **chromedp** (Go, MIT) — direct CDP; candidate if guest agent goes Go
 - **fantoccini** (Rust, MIT/Apache 2.0)
 
-For Computer Use we want direct CDP (not WebDriver) — fine-grained event injection + screencast. **To research (Phase 7):** chromedp vs raw CDP WebSocket in the Go agent.
+For Computer Use we want direct CDP (not WebDriver) — fine-grained event injection + screencast. **To research (Phase 7):** Rust CDP options (`chromiumoxide`) vs raw CDP WebSocket passthrough in the Rust agent (per [ADR-0002](./adr/0002-guest-agent-language-go.md)).
 
 ---
 
@@ -205,10 +213,22 @@ For Computer Use we want direct CDP (not WebDriver) — fine-grained event injec
 |---|---|---|---|
 | current Python entrypoint + MCP server | runc / sysbox | Docker Compose | Today's PoC (Phase 0–5) |
 | current Python entrypoint + MCP server | sysbox | k8s (any) via our Helm chart | Phase 5 target |
-| **future Go agent** | sysbox | k8s | Internal/trusted tier (Phase 7) |
-| future Go agent | gVisor | k8s | Code-execution (non-browser) tier (Phase 7) |
-| future Go agent | Kata + Cloud Hypervisor | k8s | Untrusted tier — Computer Use, public (Phase 9 — requires Phase 8 egress proxy) |
-| future Go agent | Kata + Firecracker | k8s | Untrusted tier — fastest cold start (Phase 9 — requires Phase 8 egress proxy) |
+| **future Rust agent** | sysbox | k8s | Internal/trusted tier (Phase 7) |
+| future Rust agent | gVisor | k8s | Code-execution (non-browser) tier (Phase 7) |
+| future Rust agent | Kata + Cloud Hypervisor | k8s | Untrusted tier — Computer Use, public (Phase 9 — requires Phase 8 egress proxy) |
+| future Rust agent | Kata + Firecracker | k8s | Untrusted tier — fastest cold start (Phase 9 — requires Phase 8 egress proxy) |
+
+---
+
+## Lambda framing
+
+AWS Lambda recurs in this document and in the research digests ([`research/05`](./research/05-firecracker.md), [`research/16`](./research/16-anthropic-production-sandbox-observed.md), [`research/19`](./research/19-anthropic-process-api.md), [`research/20`](./research/20-snapstart-hot-swap.md)) as the design lineage behind Firecracker, behind `process_api`'s two-tier control split, and behind the snapshot-pool cold-start pattern we evaluate at Phase 10.
+
+**We are not deploying on Lambda or Fargate.** Open Computer Use targets 100–10K concurrent long-lived sandboxes on Kubernetes + Kata, not 10M serverless invocations. Sessions are multi-hour and stateful; Lambda's 15-minute cap and request-shaped billing fight every assumption.
+
+What we adopt from Lambda is **patterns**, bounded and named: (a) Firecracker as the smallest-attack-surface microVM tier, (b) two-tier control split (host router + in-guest supervisor) ported as L4↔L1 over vsock, (c) frozen-snapshot pool with block-device hot-swap as the Phase-10 cold-start optimization, (d) per-session VM isolation with no cross-tenant reuse. Everything else — the deployment substrate, the orchestrator, the billing model, the AWS product names — stays out.
+
+This question is closed by [ADR-0010](./adr/0010-lambda-as-inspiration-not-runtime.md). Future "should we go serverless?" debates should land on that ADR and not be re-opened here.
 
 ---
 

--- a/docs/future-architecture/research/19-anthropic-process-api.md
+++ b/docs/future-architecture/research/19-anthropic-process-api.md
@@ -1,0 +1,201 @@
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+<!-- Copyright (c) 2025 Open Computer Use Contributors -->
+
+# 19 — `process_api` pattern catalogue (Anthropic Claude.ai sandbox reference)
+
+> Reference: pattern notes under [`sandboxd/anthropic/`](../../../sandboxd/anthropic/) describing how Anthropic's Claude.ai sandbox is reported to work — specifically its in-VM Rust supervisor `process_api`.
+> Distinct from [`13-anthropic-sandbox-runtime.md`](./13-anthropic-sandbox-runtime.md) (the open-source local Claude Code sandbox, bubblewrap/seatbelt) and from [`16-anthropic-production-sandbox-observed.md`](./16-anthropic-production-sandbox-observed.md) (outside view of the same production system). This file covers the **guest-side supervisor itself** — what `process_api` is, what it speaks, and which of its patterns are worth importing.
+>
+> Status: **pattern catalogue, not yet decision-grade.** Locks no decisions. Each pattern is tagged Adopt / Adapt / Reject for our roadmap; the actual ADRs land at Phase 7 (L1 rewrite) and Phase 10 (snapshot/resume).
+
+## 1. What `process_api` is
+
+A static-PIE Rust binary (≈ 4.3 MB, Tokio 1.52.2) reported to run **either as PID 1 inside a Firecracker microVM** or as a sidecar in gVisor/runc. It owns the WebSocket transport, all child-process lifecycle, OOM monitoring, JWT auth, and the snapstart hand-off. It is **not** an LLM client — it's a process supervisor with a wire protocol.
+
+Build shape (per the pattern notes under [`sandboxd/anthropic/`](../../../sandboxd/anthropic/)):
+```
+Size:    ~4.3 MB · static-PIE x86-64 · stripped, type names retained
+Class:   Rust + Tokio async; static linkage
+```
+
+Crate footprint as described in the same notes — what we'd be pulling in if we cloned the design: `tokio`, `hyper`, `tokio-tungstenite`, `tokio-vsock`, `jsonwebtoken`, `ring`, `clap`, `nix`, `serde_json`, plus zstd. No gRPC, no Connect, no Protobuf — **raw WebSocket frames carrying serde-tagged JSON enums.**
+
+## 2. One protocol, three transports
+
+The CLI surface as catalogued in the pattern notes:
+
+| Transport | Flag | Where it runs |
+|---|---|---|
+| **TCP** | `--addr 0.0.0.0:2024` | Firecracker (current PID 1 invocation), dev, debug |
+| **Unix domain socket** | `--listen-uds <path>` | gVisor / runc local sidecar |
+| **UDS (dial-out)** | `--dial-uds <path>` | gVisor host-bridge — `bind()` on gofer paths is unreachable from host, so the guest dials out and the Router on the other side issues the HTTP Upgrade |
+| **vsock** | `--listen-vsock-port <port>` | Firecracker, future microVM mode |
+
+The same `handle_ws` accept loop drives all four. Transport choice is operational, not architectural — the protocol does not change.
+
+> **Implication for us.** This is the strongest counter-example to ADR-0008's connect-go-over-vsock lean. Anthropic's production agent runs **raw WebSocket frames** over whatever transport the host offers, not gRPC. See §13 for how we should treat this at Phase 7.
+
+## 3. First-byte dispatch (auth)
+
+The accept loop is reported to peek the first byte and branch on it (catalogued under [`sandboxd/anthropic/`](../../../sandboxd/anthropic/)):
+
+- `'{'` → plain JSON `ProcessConnection` (no auth, dev mode or when no public key is loaded).
+- `'e'` → base64-url JWT header (`eyJ…`) → Ed25519 verification using `jsonwebtoken` + `ring`.
+- Anything else → hard close.
+
+The JWT's `sub` claim is matched against a `container_name` read at boot from a per-VM metadata file. A token issued for container A cannot be replayed against container B — the binding is per-VM, not per-tenant.
+
+## 4. Capabilities negotiation (V1/V2)
+
+The wire-protocol enum is catalogued as:
+```
+ConnectionCapabilities { supports_traces, supports_zstd }
+ProcessCreated   / ProcessCreatedV2
+AttachedToProcess / AttachedToProcessV2
+TraceEvent (only if supports_traces was negotiated)
+```
+
+The server's first frame advertises capabilities; old clients ignore unknown fields and stay on V1 variants, new clients opt into V2 + zstd + traces. This is how the protocol evolves without breakage — a pattern we don't currently have anywhere in `architecture/05-layer1-guest-agent.md`.
+
+## 5. Control-server endpoints (dual-port API)
+
+The data-plane WebSocket is one socket. A **separate control server** (`--control-server-addr` or `--control-vsock-port`) handles HTTP POSTs that the data plane should not see. As catalogued:
+
+| Endpoint | Purpose | Phase relevance for us |
+|---|---|---|
+| `POST /mount_root` | Snapstart restore: remount rootfs after host swaps block devices | Phase 10 only |
+| `POST /shutdown` | Graceful shutdown signal | Phase 7 (always-on) |
+| `POST /auth_public_key` | Hot-reload Ed25519 public key | Phase 7+ (optional) |
+| `POST /fs_freeze`, `POST /fs_thaw` | `FIFREEZE` / `FITHAW` ioctls for snapshot consistency | Phase 10 only |
+| `POST /write_etc_files` | Inject `/etc/hosts`, CA certs at restore time | Phase 10 only |
+
+> **Implication for us.** Today our Python L1 agent has a single HTTP port. Phase 7 should split into **data-plane (WS) + control-plane (HTTP)** so health, shutdown, and (later) snapshot operations stay out of the user-facing path. See `architecture/05-layer1-guest-agent.md` after the Phase 0.5 polish.
+
+## 6. Process supervision model
+
+Per connection the supervisor owns:
+- `WsStreamHandle` — the WebSocket peer, zstd compression, frame buffering.
+- `ProcController` — wall-clock + CPU timeouts, signal proxying, state machine.
+- `ProcHandle` — the OS child: PID, stdin/stdout/stderr FDs, and the boolean `killed_by_process_api` flag.
+
+Terminal states are mutually exclusive:
+```
+ProcessExited { code }      // normal exit            (killed_by_process_api = false)
+ProcessTimedOut             // wall-clock budget hit  (killed_by_process_api = true)
+ProcessCpuTimedOut          // CPU budget hit         (killed_by_process_api = true)
+ProcessOutOfMemory          // per-process cgroup OOM (killed_by_process_api = false)
+ContainerOutOfMemory        // container-wide OOM     (killed_by_process_api = true)
+ShuttingDown                // graceful shutdown
+```
+
+The `killed_by_process_api` flag is the audit-correctness primitive: it lets the control plane distinguish "we killed it" from "the kernel killed it" without parsing exit codes.
+
+## 7. Container-wide OOM monitor
+
+A dedicated task polls cgroup memory every `--oom-polling-period-ms` (default 100 ms). The cataloged behaviour:
+
+- Adopts orphans before each memory scan (so reparented zombies don't survive the search).
+- Reads fresh memory usage for all processes to find the largest.
+- Issues a two-phase kill (signal → wait → escalate) with an explicit timeout.
+- Logs both "memory reclaimed" and "timed out after killing" outcomes.
+
+More disciplined than what we have today (Docker's default OOM killer policy).
+
+## 8. Security primitives — what we already match and what we don't
+
+| Primitive | `process_api` does | Our state today |
+|---|---|---|
+| `--block-local-connections` (refuse 127.0.0.1 + own iface IPs on TCP) | Yes | No — covered by `architecture/08-networking.md` after Phase 8 |
+| Vsock CID pin (only host CID may dial) | Yes | N/A until Phase 9 |
+| Env-var scrub (`_TOKEN _SECRET _PASSWORD API_KEY`) before fork | Yes (substring filter) | Partial — covered by [antipatterns A1, C8] but not enforced in the agent |
+| Drop `CAP_SYS_RESOURCE` post-init | Yes (firecracker-init only) | N/A until Phase 9 |
+| `init_on_free=1` kernel cmdline | Yes (per [`16-anthropic-production-sandbox-observed.md`](./16-anthropic-production-sandbox-observed.md) §1) | N/A until Phase 9 |
+| CRNG reseed on snapshot restore | Yes (mentioned in production observation) | Deferred — Phase 10 |
+
+## 9. Init sequence (firecracker-init mode)
+
+As catalogued, in order:
+1. Parse args.
+2. Mount `/proc`, `/sys`, `/dev`, `/dev/pts`; configure networking.
+3. Pick rootfs path:
+   - Boot-time config file present → fresh boot, mount and pivot.
+   - Absent → snapstart wait, accept the host's `POST /mount_root`.
+4. `pivot_root` + spawn FUSE daemon for Tier 4 mounts.
+5. Load the per-VM `container_name` from a metadata file.
+6. Load the auth public key (32 raw bytes, Ed25519).
+7. Bind WS listener (TCP / UDS / vsock), bind control server, spawn OOM monitor.
+8. Drop `CAP_SYS_RESOURCE`.
+9. Install signal handlers; accept loop.
+
+> **Implication for us.** Steps 5–9 are template for our Phase 7 agent boot. Steps 2–4 are template only for Phase 10 (when we ship a microVM tier).
+
+## 10. What's intentionally **not** there
+
+- **No tool definitions.** `process_api` does not know what `bash`, `view_image`, or `sub_agent` are. It exec's whatever the client says. Tools live one layer up.
+- **No LLM client.** No `anthropic-sdk`, no model APIs.
+- **No persistent state.** No DB, no on-disk session log. The state machine is per-connection in memory; trace events flow out, the agent forgets when the client disconnects.
+- **No gRPC, no Protobuf.** Pure WebSocket + serde-tagged JSON enums.
+- **No prompt caching, no Anthropic-API awareness at all.** This is a transport, not an agent.
+
+Our Phase 7 L1 agent has more responsibilities than `process_api` (it terminates the MCP server and dispatches MCP tools). The takeaway is **not** "rewrite L1 to be identical to process_api" — it is "borrow these primitives, keep our MCP layer above them."
+
+## 11. Lambda lineage
+
+Two patterns here are direct heirs of AWS Lambda's MicroManager design:
+- **Two-tier control:** a host-side Router (analog of Lambda's Worker Manager) issues JWTs, picks placement, talks to the snapshot pool; an in-VM supervisor (analog of Lambda's shim) handles in-VM lifecycle.
+- **Snapshot pool of frozen VMs** rather than warm VMs (cheaper at scale — frozen snapshots don't consume RAM).
+
+We are not building Lambda, but the cold-start economics and the two-tier split are the parts to study. See [`references.md`](../references.md) Lambda framing and [`05-firecracker.md`](./05-firecracker.md).
+
+## 12. Diff vs ADR-0008's current direction
+
+ADR-0008 picked **connect-go (gRPC + Connect + HTTP/JSON) on vsock or TCP** for L3↔L1. `process_api` chose **raw WebSocket frames + serde-tagged JSON**. With ADR-0002 now landed on **Rust for L1** (matching process_api's stack: `tokio` + `hyper` + `tokio-tungstenite` + `tokio-vsock` + `ring` + `jsonwebtoken`), the WS-frames pattern becomes the natural fit and connect-go on the L1 side becomes the awkward choice:
+
+| Aspect | connect-go (ADR-0008 as written, Go-era) | process_api WS-frames (our Rust L1 target) |
+|---|---|---|
+| Schema-first | Yes (`.proto`) | No (Rust enums + `serde`, manual contract) |
+| Streaming | Server-streaming, bidi | Native (every connection is bidi) |
+| Debuggability | curl-able via HTTP/JSON fallback | Any browser dev-tools |
+| Transport over vsock | Works but "well-trodden but not zero-config" (per [`02-layer4-control-plane.md`](../architecture/02-layer4-control-plane.md)) | Trivially — `tokio-tungstenite` over `tokio-vsock` |
+| Capabilities evolution | Protobuf field numbers | First-frame negotiation (V1/V2) |
+| Binary size | Larger (Connect runtime + Protobuf) | Smaller (just `hyper` + `tungstenite`) |
+| Crate ecosystem fit (Rust) | Connect-rust is younger than connect-go; smaller blast radius | First-class: `tokio-tungstenite-0.24.0` is what process_api itself uses |
+
+> **Implication for us.** ADR-0008 is **Go-era**: it picked connect-go partly because the L1 was assumed to be Go. With L1 going Rust, the L3↔L1 leg needs a Phase 7 re-evaluation against the WS-frame option. This file does not amend ADR-0008; the Phase 7 gate language inside ADR-0008 will be tightened to call this out explicitly.
+
+## 13. Adopt / Adapt / Reject
+
+| Pattern | Decision | Phase | Notes |
+|---|---|---|---|
+| Three-transport-one-protocol WS server | **Adapt** | Phase 7 | We may keep connect-go; the lesson is "transport must not leak into the contract" |
+| First-byte JSON-vs-JWT dispatch | **Adapt** | Phase 7+ | Once we add agent-side auth, this is the lightest implementation; before that, accept JSON only |
+| Ed25519 JWT bound to `container_name` | **Adopt** | Phase 7+ | Per-VM binding is the right granularity for our threat model |
+| Capabilities negotiation (V1/V2) | **Adopt** | Phase 7 | Lets our agent protocol evolve without breaking older sandboxes |
+| Dual-port API (data-WS + control-HTTP) | **Adopt** | Phase 7 | Already in the roadmap line 70 deliverable; this is the template |
+| Control-server endpoints (`/shutdown`, `/healthz`) | **Adopt** | Phase 7 | Always |
+| Control-server endpoints (`/mount_root`, `/fs_freeze`, `/write_etc_files`) | **Adopt** | Phase 10 | Only when snapshot tier lands |
+| `killed_by_process_api` flag for audit correctness | **Adopt** | Phase 7 | Cheap to add, removes ambiguity in audit log |
+| Two-phase OOM monitor with orphan adoption | **Adopt** | Phase 7 | Replaces our reliance on Docker's default policy |
+| Env-var scrub on substring match (`_TOKEN _SECRET _PASSWORD API_KEY`) | **Adopt** | Phase 7 | Cross-link [antipattern A1] |
+| `drop_cap_sys_resource()` post-init | **Adopt** | Phase 9 | Only relevant inside microVMs |
+| `--block-local-connections` | **Adapt** | Phase 8 | Egress proxy already covers most of this; consider as belt-and-braces |
+| Vsock CID pin | **Adopt** | Phase 9 | Free hardening once vsock is in play |
+| Snapshot hand-off via `POST /mount_root` + block-device hot-swap | **Adopt** | Phase 10 | See [`20-snapstart-hot-swap.md`](./20-snapstart-hot-swap.md) |
+| Rust as the L1 implementation language | **Adopt** | Phase 7 | ADR-0002 rewritten on this premise; same crate footprint as process_api (`tokio` + `hyper` + `tokio-tungstenite` + `tokio-vsock` + `ring` + `jsonwebtoken`) |
+| `tokio-vsock`-style raw WS frames over vsock | **Open** | Phase 7 | With L1=Rust this is the natural choice; ADR-0008 to be re-evaluated at Phase 7 research against connect-rust-over-vsock |
+| `process_api`'s "no tools, just exec" purity | **Reject** | — | We keep MCP tool dispatch in L1; pure exec doesn't fit the MCP shape |
+| Antspace / Baku / Vercel deploy clients | **Reject** | — | Product-specific to Anthropic; not in our scope |
+
+## 14. What this digest does **not** change
+
+- ADR-0001, -0003, -0004, -0005, -0006, -0007, -0009 — unaffected.
+- The 4-layer model — `process_api` validates it; nothing to revise.
+- Roadmap phase ordering — all "Adopt" items land in their existing phases.
+
+## Related
+
+- ADR: [`0002-guest-agent-language-go.md`](../adr/0002-guest-agent-language-go.md), [`0008-internal-grpc-external-rest-mcp.md`](../adr/0008-internal-grpc-external-rest-mcp.md), [`0010-lambda-as-inspiration-not-runtime.md`](../adr/0010-lambda-as-inspiration-not-runtime.md)
+- Sibling digests: [`13-anthropic-sandbox-runtime.md`](./13-anthropic-sandbox-runtime.md), [`16-anthropic-production-sandbox-observed.md`](./16-anthropic-production-sandbox-observed.md), [`20-snapstart-hot-swap.md`](./20-snapstart-hot-swap.md), [`21-environment-runner-go.md`](./21-environment-runner-go.md)
+- Architecture: [`05-layer1-guest-agent.md`](../architecture/05-layer1-guest-agent.md), [`07-security.md`](../architecture/07-security.md)
+- Antipatterns: A1 (secret leakage in env), C8 (cgroup OOM handling)
+- Source notes: pattern catalogue under [`sandboxd/anthropic/`](../../../sandboxd/anthropic/)

--- a/docs/future-architecture/research/19-anthropic-process-api.md
+++ b/docs/future-architecture/research/19-anthropic-process-api.md
@@ -13,7 +13,7 @@
 A static-PIE Rust binary (≈ 4.3 MB, Tokio 1.52.2) reported to run **either as PID 1 inside a Firecracker microVM** or as a sidecar in gVisor/runc. It owns the WebSocket transport, all child-process lifecycle, OOM monitoring, JWT auth, and the snapstart hand-off. It is **not** an LLM client — it's a process supervisor with a wire protocol.
 
 Build shape (per the pattern notes under [`sandboxd/anthropic/`](../../../sandboxd/anthropic/)):
-```
+```text
 Size:    ~4.3 MB · static-PIE x86-64 · stripped, type names retained
 Class:   Rust + Tokio async; static linkage
 ```
@@ -48,7 +48,7 @@ The JWT's `sub` claim is matched against a `container_name` read at boot from a 
 ## 4. Capabilities negotiation (V1/V2)
 
 The wire-protocol enum is catalogued as:
-```
+```rust
 ConnectionCapabilities { supports_traces, supports_zstd }
 ProcessCreated   / ProcessCreatedV2
 AttachedToProcess / AttachedToProcessV2
@@ -79,7 +79,7 @@ Per connection the supervisor owns:
 - `ProcHandle` — the OS child: PID, stdin/stdout/stderr FDs, and the boolean `killed_by_process_api` flag.
 
 Terminal states are mutually exclusive:
-```
+```rust
 ProcessExited { code }      // normal exit            (killed_by_process_api = false)
 ProcessTimedOut             // wall-clock budget hit  (killed_by_process_api = true)
 ProcessCpuTimedOut          // CPU budget hit         (killed_by_process_api = true)
@@ -161,7 +161,7 @@ ADR-0008 picked **connect-go (gRPC + Connect + HTTP/JSON) on vsock or TCP** for 
 | Binary size | Larger (Connect runtime + Protobuf) | Smaller (just `hyper` + `tungstenite`) |
 | Crate ecosystem fit (Rust) | Connect-rust is younger than connect-go; smaller blast radius | First-class: `tokio-tungstenite-0.24.0` is what process_api itself uses |
 
-> **Implication for us.** ADR-0008 is **Go-era**: it picked connect-go partly because the L1 was assumed to be Go. With L1 going Rust, the L3↔L1 leg needs a Phase 7 re-evaluation against the WS-frame option. This file does not amend ADR-0008; the Phase 7 gate language inside ADR-0008 will be tightened to call this out explicitly.
+> **Implication for us.** ADR-0008 is **Go-era**: it picked connect-go partly because the L1 was assumed to be Go. With L1 going Rust, the L3↔L1 leg needs a Phase 7 re-evaluation against the WS-frame option. [ADR-0008](../adr/0008-internal-grpc-external-rest-mcp.md) was updated 2026-05-18 to leave the L3↔L1 row open and call the choice out explicitly in its Phase 7 gate.
 
 ## 13. Adopt / Adapt / Reject
 

--- a/docs/future-architecture/research/20-snapstart-hot-swap.md
+++ b/docs/future-architecture/research/20-snapstart-hot-swap.md
@@ -1,0 +1,131 @@
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+<!-- Copyright (c) 2025 Open Computer Use Contributors -->
+
+# 20 — Snapstart hot-swap (frozen snapshot + block-device replacement)
+
+> Reference: the `--firecracker-init` flow catalogued in [`sandboxd/anthropic/`](../../../sandboxd/anthropic/) and the production observations in [`16-anthropic-production-sandbox-observed.md`](./16-anthropic-production-sandbox-observed.md). AWS Lambda's MicroManager pool is the original lineage (see [`references.md`](../references.md) Lambda framing).
+>
+> Status: **pattern catalogue for Phase 10.** No decisions land here. Phase 10 will pick which pieces we ship.
+
+## 1. The pattern in one sentence
+
+Instead of keeping warm VMs around (RAM-expensive at scale), the Anthropic Claude.ai sandbox is reported to keep **frozen Firecracker snapshots** of a minimal template VM and, at session start, swap the block-device backends and resume. The guest doesn't notice it's a different filesystem.
+
+## 2. Two-phase lifecycle
+
+### Phase A — template (one-time, per release)
+```
+1. Firecracker boots minimal kernel + initramfs (~3 MB) holding /process_api.
+2. process_api --firecracker-init runs:
+     mount /proc /sys /dev; configure networking; signal "ready".
+3. Host: PUT /snapshot/create → Firecracker freezes VM state to disk.
+4. VM stops; the snapshot sits in the pool.
+```
+
+### Phase B — session restore (per user session)
+```
+1. Host prepares per-session block devices:
+     vda — root filesystem (per-tenant data + ephemeral overlay)
+     vdb — squashfs of /opt/<app>             (read-only, per release)
+     vdc — squashfs of /opt/<runner>          (read-only, per release)
+2. Host: PUT /snapshot/load with the new device backends.
+3. VM resumes:
+     - Kernel notices block-device sizes changed (virtio_blk: vdc new size …).
+     - CRNG reseeds (random: crng reseeded due to virtual machine fork).
+4. process_api waits for the host's POST /mount_root on its control server:
+     - drop_caches
+     - remount devtmpfs
+     - mount /dev/vda as ext4
+     - pivot_root
+     - mount squashfs overlays from /dev/vdb, /dev/vdc
+     - clock_settime() to fix the frozen clock
+     - drop CAP_SYS_RESOURCE
+     - accept WS connections
+```
+
+Snapshot pool size, refill rate, and max age are tuned on the host side; the VM does not know it was ever frozen.
+
+## 3. Why this beats warm pools at scale
+
+| Resource | Warm VM pool | Frozen snapshot pool |
+|---|---|---|
+| RAM | Full per-VM RAM × pool size | Disk only (snapshot blobs) |
+| CPU | Idle ticks | None |
+| Cold-start | ~0 ms (already running) | tens to low hundreds of ms (restore + remount) |
+| Per-tenant attack surface | Reused VMs possible | Fresh snapshot every time |
+
+At Anthropic-scale (millions of short sessions/day) the RAM math forces this design. For our target scale (100–10K concurrent), it's an **economics question for Phase 10** — not a Phase 9 must.
+
+## 4. Post-restore hardening — what the guest does on every resume
+
+These are the actions we'd need on the L1 side. Each is small individually; together they fix the failure modes that naive "VM resume" pretends don't exist.
+
+| Action | Why | Phase relevance |
+|---|---|---|
+| `drop_caches` | Page cache references files that no longer exist on the new rootfs | Phase 10 mandatory |
+| Remount `/dev` (devtmpfs) | Device-node mappings are post-swap | Phase 10 mandatory |
+| `pivot_root` to new rootfs | Frozen rootfs is stale by design | Phase 10 mandatory |
+| `clock_settime()` | Wall-clock was frozen; restored value is wrong by minutes-to-days | Phase 10 mandatory |
+| CRNG reseed (`getrandom`-style force) | Kernel knows it forked; userspace RNGs (OpenSSL, glibc arc4random) do not, so seed them fresh | Phase 10 mandatory |
+| `init_on_free=1` kernel cmdline | Cleared freed pages so resume doesn't leak template-VM secrets | Phase 9 (template build) |
+| Drop `CAP_SYS_RESOURCE` | Was held only for init; dropping shrinks blast radius | Phase 9 (template build) |
+| Env-var scrub before fork (`_TOKEN _SECRET _PASSWORD API_KEY`) | Prevents template-VM env from leaking into session workload | Phase 7 (carries over) |
+
+## 5. Filesystem-freeze coupling
+
+`process_api` is documented to expose `POST /fs_freeze` (FIFREEZE) and `POST /fs_thaw` (FITHAW) on its control server. The host calls freeze before taking the snapshot so the on-disk image is internally consistent. **Without freeze, snapshots silently corrupt on resume** — typical SQLite WAL or atomic-rename caught mid-flight.
+
+For us this is one of two endpoints the L1 agent has to expose at Phase 10. The other is `POST /mount_root`. Neither is needed before snapshots ship.
+
+## 6. Block-device tooling swap — storage implication
+
+The pattern requires Tier-1 (OCI image) and Tier-2 (skills squashfs) content to be **shippable as block devices** that can be swapped at resume. Concretely:
+- `/opt/<runner>` and `/opt/<skills>` become **squashfs blobs**, not container layers.
+- The root filesystem on `vda` is a **per-tenant overlay** on a shared template base, prepared by the host before resume.
+
+This is the "block-device tooling swap" item flagged in `roadmap.md` Phase 0.5 line 74. The architecture-level write-up belongs in `architecture/06-storage.md`.
+
+## 7. What stays the same as today
+
+- The MCP tool catalogue inside the sandbox.
+- The user's view of `/home/assistant` (workspace).
+- The agent's RPC surface above the control-server endpoints.
+
+Snapstart is a **deployment optimization**, not a contract change. Existing L4 / MCP clients should see no difference except cold-start latency.
+
+## 8. What we'd be giving up
+
+- **Persistent in-VM state across sessions.** Each session resumes from the same frozen snapshot. Anything the agent wrote to root from a prior session is gone unless it landed on `vda` (per-tenant overlay) or in Tier-4 mounts.
+- **Cross-session warm caches.** No JIT warmup, no resolved DNS, no preloaded model weights survive the swap. Tier-4 mounts (rclone+VFS) carry persistent state.
+- **Casual debugging.** "Just exec into the box" is harder when the box is a frozen snapshot pool you can't SSH into.
+
+## 9. Adopt / Adapt / Reject
+
+| Element | Decision | Phase | Notes |
+|---|---|---|---|
+| Frozen-snapshot pool (vs. warm VM pool) | **Adopt** | Phase 10 | Only at the scale point where warm-pool RAM becomes the bottleneck |
+| Two-phase template / restore lifecycle | **Adopt** | Phase 10 | Template build is part of release pipeline |
+| Block-device hot-swap (`vda`/`vdb`/`vdc` semantics) | **Adopt** | Phase 10 | Drives storage architecture (see `architecture/06-storage.md` Phase 0.5 update) |
+| `POST /mount_root` on agent's control server | **Adopt** | Phase 10 | Optional control endpoint, gated by feature flag until snapshot tier lands |
+| `POST /fs_freeze` / `/fs_thaw` | **Adopt** | Phase 10 | Required for snapshot consistency |
+| Mandatory post-restore guest actions (drop_caches, devtmpfs remount, clock_settime, CRNG reseed) | **Adopt** | Phase 10 | All four together, as a single hardening protocol |
+| `init_on_free=1` kernel cmdline | **Adopt** | Phase 9 | Template-build hardening |
+| Drop `CAP_SYS_RESOURCE` post-init | **Adopt** | Phase 9 | Template-build hardening |
+| Snapshot pool tuning (min/target/max/refillRate/maxAge) | **Adopt** | Phase 10 | Already planned at Phase 6 for warm pools (`architecture/03-layer3-providers.md`); applied to snapshot pool at Phase 10 |
+| Snapshot pool placement (multi-region) | **Adapt** | Phase 10 | Coupled to the workspace-proxy pattern in `architecture/08-networking.md` |
+| Per-tenant root overlay preparation on host | **Adapt** | Phase 10 | The host-side tooling here is novel work, not lifted from process_api |
+
+## 10. Open questions for Phase 10 research
+
+1. **Which VMM?** Firecracker is the proven option (Anthropic prod), Cloud Hypervisor adds virtio-fs + GPU but its snapshot story is younger. Cross-link to `research/04-cloud-hypervisor.md` and `research/05-firecracker.md`.
+2. **Snapshot blob storage.** S3-class blobs vs. local SSD per node — latency vs. failure-domain trade-off.
+3. **Per-tenant root preparation.** Mount-time copy-on-write (overlayfs on host) vs. dm-snapshot vs. block-level CoW. Influences cold-start latency target.
+4. **Snapshot retention and rotation.** When the template image changes, all existing snapshots become stale — drain or kill?
+5. **DoS surface.** Pool exhaustion under burst load needs explicit policy: queue, reject, or fall back to cold boot.
+
+## Related
+
+- ADR: [`0008-internal-grpc-external-rest-mcp.md`](../adr/0008-internal-grpc-external-rest-mcp.md), [`0010-lambda-as-inspiration-not-runtime.md`](../adr/0010-lambda-as-inspiration-not-runtime.md)
+- Sibling digests: [`05-firecracker.md`](./05-firecracker.md), [`16-anthropic-production-sandbox-observed.md`](./16-anthropic-production-sandbox-observed.md), [`19-anthropic-process-api.md`](./19-anthropic-process-api.md)
+- Architecture: [`06-storage.md`](../architecture/06-storage.md), [`07-security.md`](../architecture/07-security.md), [`04-layer2-runtimes.md`](../architecture/04-layer2-runtimes.md)
+- Antipatterns: A22 (no GPU on snapshottable templates), A27 (image-digest pinning per template)

--- a/docs/future-architecture/research/20-snapstart-hot-swap.md
+++ b/docs/future-architecture/research/20-snapstart-hot-swap.md
@@ -14,7 +14,7 @@ Instead of keeping warm VMs around (RAM-expensive at scale), the Anthropic Claud
 ## 2. Two-phase lifecycle
 
 ### Phase A — template (one-time, per release)
-```
+```text
 1. Firecracker boots minimal kernel + initramfs (~3 MB) holding /process_api.
 2. process_api --firecracker-init runs:
      mount /proc /sys /dev; configure networking; signal "ready".
@@ -23,7 +23,7 @@ Instead of keeping warm VMs around (RAM-expensive at scale), the Anthropic Claud
 ```
 
 ### Phase B — session restore (per user session)
-```
+```text
 1. Host prepares per-session block devices:
      vda — root filesystem (per-tenant data + ephemeral overlay)
      vdb — squashfs of /opt/<app>             (read-only, per release)

--- a/docs/future-architecture/research/21-environment-runner-go.md
+++ b/docs/future-architecture/research/21-environment-runner-go.md
@@ -15,7 +15,7 @@ Where `process_api` is a transport + lifecycle supervisor with no knowledge of L
 
 ## 2. Internal package layout (as catalogued)
 
-```
+```text
 api/               Anthropic API client — session ingress, work polling
 auth/              GitHub app token provider
 claude/            Claude Code install, upgrade, execution
@@ -57,7 +57,7 @@ util/              Git helpers, retry, stream tailer
 
 Open Computer Use is **MCP-server-first**, sub-agent-second. The control flow is:
 
-```
+```text
 LLM (host) ──MCP──> L4 (computer-use-server) ──Docker──> Sandbox
                                                               ├── MCP tools (bash, view, …)
                                                               └── (optional) sub-agent CLI on demand

--- a/docs/future-architecture/research/21-environment-runner-go.md
+++ b/docs/future-architecture/research/21-environment-runner-go.md
@@ -1,0 +1,117 @@
+<!-- SPDX-License-Identifier: BUSL-1.1 -->
+<!-- Copyright (c) 2025 Open Computer Use Contributors -->
+
+# 21 — `environment-runner` pattern (inspiration-only)
+
+> Reference: pattern notes under [`sandboxd/anthropic/`](../../../sandboxd/anthropic/) describing the Go-language session agent that runs **above** `process_api` in Anthropic's Claude Code Web product.
+>
+> **Status: inspiration-only, not on our roadmap.** Open Computer Use's sub-agent layer is a thin CLI dispatcher (Claude Code / Codex / OpenCode invoked as one-shot tools from inside the sandbox), not a long-lived session agent that polls a control plane. This digest exists to keep the pattern catalogue complete, and as a reference if we ever decide to grow our sub-agent orchestration into something durable. **No phase currently consumes this material.**
+
+## 1. What `environment-runner` is
+
+A ~27 MB Go binary running inside the sandbox **as a child of `process_api`**. The pattern notes describe its module path as `github.com/anthropics/anthropic/api-go/environment-manager`.
+
+Where `process_api` is a transport + lifecycle supervisor with no knowledge of LLMs, MCP, or agents, `environment-runner` is the **session-aware Go agent** that knows about Claude Code, MCP servers, git, deploy, and BYOC. It is the layer that would map to "our L1 agent" if we were doing what Anthropic is reported to do. We are not.
+
+## 2. Internal package layout (as catalogued)
+
+```
+api/               Anthropic API client — session ingress, work polling
+auth/              GitHub app token provider
+claude/            Claude Code install, upgrade, execution
+config/            Session modes (new / resume / resume-cached / setup-only)
+envtype/
+  ├─ anthropic/    Anthropic-hosted environment
+  └─ byoc/         Bring Your Own Cloud
+gitproxy/          Git credential proxy server
+input/             Stdin parser + secret handling
+manager/           Session manager, MCP config, skill extraction
+mcp/
+  └─ servers/
+     ├─ codesign/  Code signing MCP server
+     └─ supabase/  Supabase integration MCP server
+orchestrator/      Poll loop, hooks, whoami
+podmonitor/        Kubernetes lease manager (BYOC mode)
+process/           Process exec + script runner
+sandbox/           Sandbox runtime config
+session/           Activity recorder
+sources/           Git clone + source classification
+tunnel/            WebSocket tunnel + action handlers
+  └─ actions/
+     ├─ deploy/    Antspace + Vercel deploy clients
+     ├─ snapshot/  File snapshots
+     └─ status/    Status reporting
+util/              Git helpers, retry, stream tailer
+```
+
+## 3. What it does (single-paragraph summary per area)
+
+- **Polling loop.** Long-poll Anthropic's API for session assignments; when one arrives, install/upgrade Claude Code, clone the requested git source, start MCP servers, and stream activity back.
+- **MCP server hosting.** Owns two internal MCP servers (`codesign`, `supabase`) and discovers project-specific ones via skill extraction.
+- **Git workflow.** Clones, branches, manages credentials via a local proxy so Claude Code never sees raw tokens.
+- **Deploy.** Two pluggable clients — Antspace (internal Anthropic PaaS, NDJSON status stream) and Vercel (SHA-deduped uploads, polled status).
+- **BYOC.** When the customer brings their own k8s cluster, holds a pod lease and reports back; in Anthropic-hosted mode this code is dead.
+- **Tunnel.** A WebSocket tunnel back to the control plane carrying snapshot, deploy, and status actions.
+
+## 4. Why this is **not** our model
+
+Open Computer Use is **MCP-server-first**, sub-agent-second. The control flow is:
+
+```
+LLM (host) ──MCP──> L4 (computer-use-server) ──Docker──> Sandbox
+                                                              ├── MCP tools (bash, view, …)
+                                                              └── (optional) sub-agent CLI on demand
+```
+
+The Anthropic flow is the reverse: a **session-owning agent inside the sandbox** polls the control plane for work, then drives Claude Code locally. The two designs disagree on which side initiates.
+
+If we ever ship a "long-running coding session" product, **then** this digest matters. Today it does not.
+
+## 5. Pieces that might be useful later (and only later)
+
+If we ever build durable sub-agent sessions, these would be the parts to study, in roughly this order of relevance:
+
+| Piece | What it solves | When it might matter for us |
+|---|---|---|
+| `gitproxy/` | Sub-agent CLIs never see raw git tokens | If we add multi-tenant git workflows to sub-agents |
+| `manager/` MCP config + skill extraction | Standard way to wire skills + MCP servers per session | If our skill system grows beyond the current static set |
+| `input/` secret handling | Stdin-fed secrets that never hit disk or logs | Cross-cuts with antipattern A1 |
+| `orchestrator/` poll loop with hooks | Pre/post-session lifecycle hooks | If we move from one-shot to durable sessions |
+| `tunnel/actions/snapshot/` | File snapshots as a first-class action | If we ship session-resume in Phase 10+ |
+| `mcp/servers/codesign/` shape | In-sandbox MCP server hosting pattern | We already do this; the Anthropic shape is a useful comparison |
+
+Pieces we'd **never** import: `api/` (Anthropic-specific control plane), `claude/` (Claude Code install logic), `envtype/anthropic/` (their PaaS), `tunnel/actions/deploy/` (Antspace + Vercel — product-specific).
+
+## 6. Why Go for the L1-equivalent at Anthropic
+
+Worth noting since our ADR-0002 just landed on **Rust** for our L1. The Anthropic split, as catalogued, is:
+- `process_api` = Rust. PID 1 needs a tiny static binary, kernel-adjacent code, predictable allocations.
+- `environment-runner` = Go. Ecosystem fit — MCP libraries, git tooling, cobra CLI, OpenTelemetry, gRPC. The agent is large (~27 MB) and not on the hot path.
+
+The split mirrors a working precedent: small Rust supervisor at the floor, larger Go agent on top. If our sub-agent orchestration ever grows that complex, this is a credible reference pattern. Today our sub-agent layer is a thin CLI dispatcher in `computer-use-server/cli_runtime.py`, which is the right size for what it does.
+
+## 7. Adopt / Adapt / Reject
+
+| Element | Decision | Notes |
+|---|---|---|
+| Long-poll session agent inside the sandbox | **Reject** | Inverts our MCP-server-first control flow |
+| In-sandbox MCP server hosting | **Already-have** | We do this in `mcp_tools.py`; not new |
+| Git credential proxy | **Defer** | Not on roadmap; revisit if multi-tenant sub-agent git flows ship |
+| Skill extraction at session start | **Defer** | Our skill system already does this statically; revisit only if sessions become durable |
+| Antspace / Vercel deploy clients | **Reject** | Product-specific to the reference design |
+| BYOC pod lease manager | **Reject** | Out of scope; we are one-tenant-per-deployment today |
+| File-snapshot action | **Defer to Phase 10+** | Relevant only if we ship session-resume |
+| Go-on-top-of-Rust two-language split | **Reference pattern** | Validates that our Rust L1 + (possibly Go) L4 mix is a working shape |
+
+## 8. What this digest does **not** trigger
+
+- No ADR changes (existing ADR-0001 L4=Go gate at Phase 6 is untouched).
+- No `architecture/*` changes (this material has no current Phase).
+- No new antipatterns.
+
+It is a **bookmark for future-us**, kept in the same directory as the rest of the catalogue so it doesn't get lost. If a future phase needs durable session agents, start here, then re-read `process_api_re/`.
+
+## Related
+
+- Sibling digests: [`13-anthropic-sandbox-runtime.md`](./13-anthropic-sandbox-runtime.md), [`16-anthropic-production-sandbox-observed.md`](./16-anthropic-production-sandbox-observed.md), [`17-anthropic-claude-code-remote-env-observed.md`](./17-anthropic-claude-code-remote-env-observed.md), [`19-anthropic-process-api.md`](./19-anthropic-process-api.md)
+- Architecture: none (this material has no Phase consumer today)

--- a/docs/future-architecture/roadmap.md
+++ b/docs/future-architecture/roadmap.md
@@ -355,7 +355,7 @@ These rules are how we keep the migration evolutionary. Any PR that violates the
 - `references/firecracker/` — Firecracker snapshot for comparison.
 - `references/firecracker-containerd/` — demux snapshotter for COW rootfs (fast restore) — see [`research/11-firecracker-containerd.md`](./research/11-firecracker-containerd.md) §1.
 - Multi-region: KV replication (Redis cluster / etcd multi-DC) — standard docs.
-- **Post-restore hardening checklist** — kernel CRNG reseed on VM fork, `init_on_free=1`, `CAP_SYS_RESOURCE` drop. See [`research/15-claude-code-reverse-engineering.md`](./research/15-claude-code-reverse-engineering.md) §10.
+- **Post-restore hardening checklist** — kernel CRNG reseed on VM fork, `init_on_free=1`, `CAP_SYS_RESOURCE` drop. Primary reference: [`research/20-snapstart-hot-swap.md`](./research/20-snapstart-hot-swap.md) §4. Historical context: [`research/15-claude-code-reverse-engineering.md`](./research/15-claude-code-reverse-engineering.md) §10.
 - Output: `phase-10-research.md` — snapshot frequency policy; pod-failure mid-session → snapshot-then-restore-elsewhere flow; backup/DR.
 
 **Acceptance.**

--- a/docs/future-architecture/roadmap.md
+++ b/docs/future-architecture/roadmap.md
@@ -32,7 +32,7 @@ These rules are how we keep the migration evolutionary. Any PR that violates the
 | 4 | Secret broker + key rotation | L4-precursor | Static env-injected secrets; finishes Phase 3 prod-readiness | broker flag |
 | 5 | Helm hardening + `KubernetesProvider` | L3 | DinD-only k8s deploy | separate chart values; Compose still default |
 | 6 | Go control plane (dual-run) | L4 | FastAPI orchestrator monolith | reverse-proxy split per route; revert by re-pointing |
-| 7 | Rust guest agent + per-template RuntimeClass selection | L1 + L2 | Python in-image MCP server; single global runtime | new image digest; pin previous to roll back |
+| 7 | Rust guest agent + per-template RuntimeClass selection | L1 + L2 | Python in-image MCP server; single global runtime | new image digest; pin prior digest to roll back |
 | **8** | **Egress proxy + audit pipeline (lands BEFORE untrusted tier)** | L4 | No egress control; foundation for untrusted tier | additive; templates without `egress_baseline` keep working |
 | **9** | **Kata + Cloud Hypervisor for untrusted tier** | L2 | No hardware isolation (now safe because Phase 8 egress shipped) | opt-in template; sysbox stays default |
 | 10 | Snapshot/restore + multi-region | L3 + L4 | No HA, no pause-session | additive per-template + per-deployment |

--- a/docs/future-architecture/roadmap.md
+++ b/docs/future-architecture/roadmap.md
@@ -32,7 +32,7 @@ These rules are how we keep the migration evolutionary. Any PR that violates the
 | 4 | Secret broker + key rotation | L4-precursor | Static env-injected secrets; finishes Phase 3 prod-readiness | broker flag |
 | 5 | Helm hardening + `KubernetesProvider` | L3 | DinD-only k8s deploy | separate chart values; Compose still default |
 | 6 | Go control plane (dual-run) | L4 | FastAPI orchestrator monolith | reverse-proxy split per route; revert by re-pointing |
-| 7 | Go guest agent + per-template RuntimeClass selection | L1 + L2 | Python in-image MCP server; single global runtime | new image digest; pin previous to roll back |
+| 7 | Rust guest agent + per-template RuntimeClass selection | L1 + L2 | Python in-image MCP server; single global runtime | new image digest; pin previous to roll back |
 | **8** | **Egress proxy + audit pipeline (lands BEFORE untrusted tier)** | L4 | No egress control; foundation for untrusted tier | additive; templates without `egress_baseline` keep working |
 | **9** | **Kata + Cloud Hypervisor for untrusted tier** | L2 | No hardware isolation (now safe because Phase 8 egress shipped) | opt-in template; sysbox stays default |
 | 10 | Snapshot/restore + multi-region | L3 + L4 | No HA, no pause-session | additive per-template + per-deployment |
@@ -66,22 +66,23 @@ These rules are how we keep the migration evolutionary. Any PR that violates the
 
 **Research checklist.** None — synthesis of existing pattern docs.
 
-**Deliverables (file-by-file).**
-- `architecture/05-layer1-guest-agent.md`: commit to vsock-first / TCP-fallback runtime auto-detect (not build-tag gating); add `PR_SET_DUMPABLE=0`; add `SIGCHLD` reaping + `SIGTERM` propagation explicit; add **dual-port API** (data-plane WS + control-plane HTTP) per Anthropic.
-- `architecture/07-security.md`: add `memfd_create` agent binary as defense-in-depth; add **mandatory deny paths** inside workspace home (`.git/hooks`, `.bashrc`, `.mcp.json`, …); add **graceful-shutdown protocol** (page-cache drop → SIGTERM → wait → SIGKILL).
-- `architecture/03-layer3-providers.md`: extend warm-pool knobs with `refillRate` + `maxAge`; add **environment-type dispatch** (Baku pattern); add **SandboxClaim CRD** semantics for k8s provider.
-- `architecture/02-layer4-control-plane.md`: explicit anti-pattern note "no `sessionAffinity: ClientIP`"; add **HA-replica upgrade strategy** (scale-to-1, migrate, scale-up); add **blue-green deployment** section.
-- `architecture/06-storage.md`: add **block-device tooling swap** (Baku/process_api pattern) for microVM templates.
-- `architecture/08-networking.md`: add **multi-region workspace-proxies** pattern (Coder) as a Phase-10 substrate.
-- `architecture/10-observability.md`: add **RAM-based capacity-sizing formula**; add concrete **SLO targets** (session-create p99 < 500 ms warm, exec p99 < 50 ms, CDP ≥ 10 fps, egress p99 < 100 ms); add **distributed tracing** subsection.
-- `architecture/04-layer2-runtimes.md`: add **nydus snapshotter** for lazy-load image layers (relevant Phase 9 with Kata); clarify **virtio-fs vs 9p** decision (CH/FC asymmetry).
-- `antipatterns.md`: confirm all referenced entries (A1–A36, C1–C10) align with the new architecture detail; add any new ones surfaced during the polish.
-- README index: add `architecture/11-deployment-shapes.md` if any of the above grows too big to fit existing files.
+**Deliverables (file-by-file).** All shipped 2026-05-18.
+- ✅ `architecture/05-layer1-guest-agent.md`: rewrote on the `process_api` precedent. Auto-detected transport (vsock if `/dev/vsock`, TCP otherwise), `PR_SET_DUMPABLE=0`, `SIGCHLD` reaping, `SIGTERM`→`SIGKILL` chain, capabilities negotiation (V1/V2), dual-port API (data-plane WS + control-plane HTTP). Language flipped Go → **Rust** ([ADR-0002](./adr/0002-guest-agent-language-go.md) rewritten in place).
+- ✅ `architecture/07-security.md`: added mandatory deny paths (`.git/hooks/*`, `.bashrc`, `.mcp.json`, `.claude/`, etc.), graceful-shutdown protocol, optional `memfd_create` (Phase 9+ defense-in-depth), and full snapstart-restore hardening (CRNG reseed, `init_on_free=1`, `CAP_SYS_RESOURCE` drop, env-scrub) — Phase 10 mandatory.
+- ✅ `architecture/03-layer3-providers.md`: warm-pool knobs extended with `refillRate` and `maxAge`; SandboxClaim CRD spec added; environment-type (Baku) dispatch matrix added.
+- ✅ `architecture/02-layer4-control-plane.md`: no-`sessionAffinity:ClientIP` anti-pattern called out; HA upgrade strategy (scale-to-1 + blue-green); prompt-caching pass-through position recorded.
+- ✅ `architecture/06-storage.md`: block-device tooling swap subsection added (Baku / process_api pattern, Phase 10 prereq).
+- ✅ `architecture/08-networking.md`: multi-region workspace-proxy pattern (Coder) added as Phase-10 substrate.
+- ✅ `architecture/10-observability.md`: RAM-based capacity-sizing formula added; SLO targets restated; distributed-tracing subsection added (traceparent across L4 → L3 → L1, audit-event linkage).
+- ✅ `architecture/04-layer2-runtimes.md`: nydus snapshotter mention added; virtio-fs vs 9p CH/FC asymmetry resolved; Firecracker / Lambda lineage paragraph added with cross-link to [ADR-0010](./adr/0010-lambda-as-inspiration-not-runtime.md).
+- ✅ `antipatterns.md`: referenced from the new layer additions; no new entries surfaced — all gaps mapped to existing A/C IDs.
+- ✅ New research digests landed: [`research/19`](./research/19-anthropic-process-api.md), [`research/20`](./research/20-snapstart-hot-swap.md), [`research/21`](./research/21-environment-runner-go.md).
+- ✅ ADR updates: ADR-0002 rewritten (Go → Rust), ADR-0008 Phase 7 gate tightened, ADR-0001 gained a Phase 6 re-evaluation gate, new ADR-0010 (Lambda framing) landed.
 
 **Acceptance.**
-- Each architecture/* doc cross-references the matching `research/NN-*.md`.
-- the antipatterns doc table includes all 21 rows with `Action` column.
-- No new ADRs needed; if any of the additions requires a decision, file an ADR in the same PR.
+- ✅ Each architecture/* doc cross-references the matching `research/NN-*.md`.
+- ✅ The antipatterns doc remains aligned; no new IDs needed.
+- ✅ ADR-0002 rewritten, ADR-0008 + ADR-0001 amended, ADR-0010 added — recorded in the polish PR.
 
 **Reversibility.** Pure docs — flip via `git revert`.
 
@@ -248,9 +249,9 @@ These rules are how we keep the migration evolutionary. Any PR that violates the
 
 ---
 
-## Phase 7 — Go guest agent + RuntimeClass selection per template
+## Phase 7 — Rust guest agent + RuntimeClass selection per template
 
-**Goal.** Replace today's Python entrypoint + in-image MCP server with a Go static binary as PID 1. Templates gain `runtime_class` selection; gVisor lands as experimental for code-exec sandboxes.
+**Goal.** Replace today's Python entrypoint + in-image MCP server with a Rust static binary as PID 1 (per [ADR-0002](./adr/0002-guest-agent-language-go.md), rewritten 2026-05-18). Templates gain `runtime_class` selection; gVisor lands as experimental for code-exec sandboxes.
 
 **Blocker removed.** Python in-image agent = big attack surface, no vsock readiness, blocks microVM. Single global runtime = no tiering.
 


### PR DESCRIPTION
Description retired during the initial-public-release history consolidation. The canonical content lives in docs/architecture/ at the current tip.