### PR TITLE
chore(openwebui): bump base 0.9.2 -> 0.9.5 and refresh patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v0.9.5.0-rc.2 — bump Open WebUI base to 0.9.5 (2026-05-19)
+
+Minor release: Open WebUI base bumped from `0.9.2` → `0.9.5` (upstream shipped 0.9.3, 0.9.4, 0.9.5 on 2026-05-09). All eight patches re-audited against the new source tree — none became obsolete (upstream did not natively address any of the eight problem domains in 0.9.3–0.9.5). Frontend patches (`fix_artifacts_auto_show`, `fix_preview_url_detection`) applied to the bumped base without changes; four backend patches needed updated SEARCH/REPLACE anchors to track upstream refactors.
+
+### Changed
+
+- **`openwebui/Dockerfile`** — `ARG OPENWEBUI_VERSION=0.9.2` → `0.9.5`.
+- **`fix_tool_loop_errors` Mod 1 (tool_loop)** — upstream wrapped `convert_output_to_messages(output, raw=True)` into a multi-line call with the new `reasoning_format=get_reasoning_format(model)` kwarg (introduced for OR-aligned reasoning emission). SEARCH/REPLACE updated to match the multi-line shape at both call sites (stateful Responses API branch and Chat Completions branch).
+- **`fix_tool_loop_errors` Mod 2 (code_interp)** — upstream guarded the post-loop `title = await Chats.get_chat_title_by_id(metadata['chat_id'])` with a `channel:`-prefix check, turning the assignment into a multi-line parenthesized ternary. SEARCH/REPLACE updated to match.
+- **`fix_large_tool_results` Mod 3 (history)** — same `reasoning_format` refactor: upstream `process_messages_with_output(form_data.get('messages', []))` is now a multi-line call with `reasoning_format=get_reasoning_format(model)`. SEARCH/REPLACE updated to match.
+- **`fix_skip_embedding_chat_files` Patch 1 (early return for regular uploads)** — upstream inserted an `else: await _validate_collection_access([collection_name], user, access_type='write')` branch between `if collection_name is None:` and `if form_data.content:` (part of the v0.9.5 file-access enforcement, upstream PR #24524). SEARCH/REPLACE updated to preserve the new guard.
+
+### Verified
+
+- Backend dry-run: all six middleware/retrieval patches applied cleanly against a fresh `v0.9.5` source tree; resulting files parse with `ast.parse` (Python syntax intact).
+- Docker build: `docker build --platform linux/amd64 -t open-webui-ocu:0.9.5.0-rc.2 -f openwebui/Dockerfile openwebui/` succeeds end-to-end; all eight patches' hard-fail guards (`sys.exit(1)`) green.
+
+### Upstream behavior changes worth knowing
+
+- New default `AIOHTTP_CLIENT_ALLOW_REDIRECTS=False` blocks 3xx redirects in web fetch / tool servers / OAuth (we don't rely on redirects through `host.docker.internal`, no action).
+- `POST /api/v1/auth/signout` (was GET); `init.sh` does not call signout, no action.
+- New `IFRAME_CSP` env var controls iframe Content-Security-Policy (Artifacts panel uses iframes); leave default unless smoke test shows blank Artifacts.
+- Per-model `params` dict now stripped from non-write-access users in `models.py` GET responses; `init.sh` runs as admin, no action.
+
 ## v0.9.2.4 — fix xlsx upload hang on Open WebUI 0.9.x (2026-05-11)
 
 Patch release on top of v0.9.2.3 (Open WebUI base unchanged). Fixes a regression from the OWUI v0.8 → v0.9 base bump: the `fix_skip_embedding_chat_files` patch was written against the v0.8 sync database/storage signatures and quietly broke when OWUI made `Files.update_file_data_by_id`, `Storage.get_file`, and `Loader.load` async.

--- a/openwebui/Dockerfile
+++ b/openwebui/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BUSL-1.1
 # Copyright (c) 2025 Open Computer Use Contributors
-ARG OPENWEBUI_VERSION=0.9.2
+ARG OPENWEBUI_VERSION=0.9.5
 FROM ghcr.io/open-webui/open-webui:${OPENWEBUI_VERSION}
 
 # Copy all patches into the image
@@ -20,7 +20,7 @@ RUN python3 /tmp/patches/fix_preview_url_detection.py
 # Config: TOOL_RESULT_MAX_CHARS (default 50000), TOOL_RESULT_PREVIEW_CHARS (default 2000)
 RUN python3 /tmp/patches/fix_large_tool_results.py
 
-# Enabled backend patches (rewritten for v0.9.2 in Phase 6):
+# Enabled backend patches:
 #
 # fix_large_tool_args: Truncates oversized tool call arguments in HTML attributes
 # to prevent browser UI freeze on large tool outputs (>10KB).

--- a/openwebui/README.md
+++ b/openwebui/README.md
@@ -35,4 +35,4 @@ Applied at Docker build time. All are idempotent and non-breaking. The 4 patches
 | `fix_skip_embedding_chat_files` | Optional | Skips embedding for large uploads (>1MB) | Large uploads block the chat for minutes on extraction/embedding |
 | `fix_skip_rag_files_native_fc` | Optional | Skips RAG when `ai_computer_use` handles files directly | Extra RAG pipeline runs on every message even when unnecessary |
 
-Built strictly for Open WebUI 0.9.2 (this image's first 3 version segments match its target Open WebUI base).
+Built strictly for Open WebUI 0.9.5 (this image's first 3 version segments match its target Open WebUI base).

--- a/openwebui/patches/fix_artifacts_auto_show.py
+++ b/openwebui/patches/fix_artifacts_auto_show.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 # Copyright (c) 2025 Open Computer Use Contributors
 """
-Patch for Open WebUI 0.9.2: auto-open Artifacts panel
+Patch for Open WebUI 0.9.5: auto-open Artifacts panel
 
 Problem: If an HTML code block is inside a collapsed <details>, CodeBlock is not mounted ->
 onUpdate does not fire -> Artifacts panel does not open. Artifacts.svelte subscribe
@@ -432,7 +432,7 @@ if __name__ == "__main__":
         print(
             "ERROR: fix_artifacts_auto_show anchor not found in "
             f"{BUILD_CHUNKS_DIR}/*.js -- upstream may have refactored. "
-            "Check v0.9.2 source + update regex. "
+            "Check v0.9.5 source + update regex. "
             "Refusing to produce a silently-broken image.",
             file=sys.stderr,
         )

--- a/openwebui/patches/fix_attached_files_position.py
+++ b/openwebui/patches/fix_attached_files_position.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 # Copyright (c) 2025 Open Computer Use Contributors
 """
-Patch for Open WebUI 0.9.2: append <attached_files> instead of prepend.
+Patch for Open WebUI 0.9.5: append <attached_files> instead of prepend.
 
 Problem:
   add_file_context() prepends <attached_files> to the beginning of user message.

--- a/openwebui/patches/fix_large_tool_args.py
+++ b/openwebui/patches/fix_large_tool_args.py
@@ -134,7 +134,7 @@ def apply_patch():
     if occurrences != 2:
         print(
             f"ERROR: fix_large_tool_args expected 2 occurrences of OLD_ARGS f-string in "
-            f"serialize_output, found {occurrences}. v0.9.2 upstream may have restructured. "
+            f"serialize_output, found {occurrences}. v0.9.5 upstream may have restructured. "
             "Refusing to produce a silently-broken image.",
             file=sys.stderr,
         )

--- a/openwebui/patches/fix_large_tool_results.py
+++ b/openwebui/patches/fix_large_tool_results.py
@@ -25,7 +25,7 @@ Config env vars:
   ORCHESTRATOR_URL -- internal URL of computer-use-server for large-result uploads
 
 Must run AFTER fix_tool_loop_errors.py (Mod 2 targets its marker).
-Target: Open WebUI 0.9.2
+Target: Open WebUI 0.9.5
 """
 
 import os
@@ -194,13 +194,19 @@ REPLACE_TOOL_LOOP = (
 
 # Mod 3: Truncate historical tool messages loaded from DB
 SEARCH_HISTORY = (
-    "    form_data['messages'] = process_messages_with_output(form_data.get('messages', []))\n"
+    "    form_data['messages'] = process_messages_with_output(\n"
+    "        form_data.get('messages', []),\n"
+    "        reasoning_format=get_reasoning_format(model),\n"
+    "    )\n"
     "\n"
     "    system_message = get_system_message(form_data.get('messages', []))\n"
 )
 
 REPLACE_HISTORY = (
-    "    form_data['messages'] = process_messages_with_output(form_data.get('messages', []))\n"
+    "    form_data['messages'] = process_messages_with_output(\n"
+    "        form_data.get('messages', []),\n"
+    "        reasoning_format=get_reasoning_format(model),\n"
+    "    )\n"
     "    _truncate_tool_messages_in_history(form_data['messages'])  # LARGE_TOOL_RESULTS: trim old results\n"
     "\n"
     "    system_message = get_system_message(form_data.get('messages', []))\n"

--- a/openwebui/patches/fix_preview_url_detection.py
+++ b/openwebui/patches/fix_preview_url_detection.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 # Copyright (c) 2025 Open Computer Use Contributors
 """
-Patch for Open WebUI 0.9.2 (host-agnostic): automatic detection of file URLs in messages
+Patch for Open WebUI 0.9.5 (host-agnostic): automatic detection of file URLs in messages
 
 Problem: To show file preview in the Artifacts panel, we need to detect
 Computer Use Server file links in assistant messages and auto-open the
@@ -221,7 +221,7 @@ if __name__ == "__main__":
         print(
             "ERROR: fix_preview_url_detection anchor not found in "
             f"{BUILD_CHUNKS_DIR}/*.js -- getCodeBlockContents compiled shape changed. "
-            "Check v0.9.2 source + update CONST_DECL_PATTERN. "
+            "Check v0.9.5 source + update CONST_DECL_PATTERN. "
             "Refusing to produce a silently-broken image.",
             file=sys.stderr,
         )

--- a/openwebui/patches/fix_skip_embedding_chat_files.py
+++ b/openwebui/patches/fix_skip_embedding_chat_files.py
@@ -17,7 +17,7 @@ Solution:
 
 When adding a file to a knowledge base (collection_name is set), full processing works.
 
-Target: Open WebUI 0.9.2
+Target: Open WebUI 0.9.5
 """
 
 import os
@@ -31,14 +31,19 @@ NEW_PATCH_MARKER = "FIX_SKIP_EMBEDDING_CHAT_FILES"
 
 # === Patch 1: early return for regular uploads ===
 # v0.8.11-0.9.2 uses single quotes: f'file-{file.id}'
+# v0.9.5: added `else: await _validate_collection_access(...)` between the two if-blocks.
 
 SEARCH_PATTERN_1 = """            if collection_name is None:
                 collection_name = f'file-{file.id}'
+            else:
+                await _validate_collection_access([collection_name], user, access_type='write')
 
             if form_data.content:"""
 
 REPLACE_PATTERN_1 = """            if collection_name is None:
                 collection_name = f'file-{file.id}'
+            else:
+                await _validate_collection_access([collection_name], user, access_type='write')
 
             # PATCH: skip_processing_chat_files -- skip extraction + embedding; FIX_SKIP_EMBEDDING_CHAT_FILES
             # for large files (> 1 MB) during regular uploads (not KB).

--- a/openwebui/patches/fix_tool_loop_errors.py
+++ b/openwebui/patches/fix_tool_loop_errors.py
@@ -17,7 +17,7 @@ Problems solved:
 6. SSE parse errors logged at debug level only
 
 Applied at Docker build time. Works on ORIGINAL middleware.py (no dependencies).
-Target: Open WebUI 0.9.2 (output-based architecture, serialize_output, prior_output).
+Target: Open WebUI 0.9.5 (output-based architecture, serialize_output, prior_output).
 
 Fail-loud: ANY sub-anchor miss triggers sys.exit(1) with stderr ERROR — refuses
 to ship a partially-patched middleware.py. Idempotent: re-run prints ALREADY PATCHED.
@@ -59,10 +59,14 @@ SEARCH_TOOL_LOOP = """\
                             system_message = get_system_message(form_data['messages'])
                             new_form_data['messages'] = (
                                 [system_message] if system_message else []
-                            ) + convert_output_to_messages(output, raw=True)
+                            ) + convert_output_to_messages(
+                                output, raw=True, reasoning_format=get_reasoning_format(model)
+                            )
                             new_form_data['previous_response_id'] = last_response_id
                         else:
-                            tool_messages = convert_output_to_messages(output, raw=True)
+                            tool_messages = convert_output_to_messages(
+                                output, raw=True, reasoning_format=get_reasoning_format(model)
+                            )
 
                             # Chat Completions providers don't support multimodal
                             # tool messages.  Extract images into a user message.
@@ -148,10 +152,14 @@ REPLACE_TOOL_LOOP = (
     "                            system_message = get_system_message(form_data['messages'])\n"
     "                            new_form_data['messages'] = (\n"
     "                                [system_message] if system_message else []\n"
-    "                            ) + convert_output_to_messages(output, raw=True)\n"
+    "                            ) + convert_output_to_messages(\n"
+    "                                output, raw=True, reasoning_format=get_reasoning_format(model)\n"
+    "                            )\n"
     "                            new_form_data['previous_response_id'] = last_response_id\n"
     "                        else:\n"
-    "                            tool_messages = convert_output_to_messages(output, raw=True)\n"
+    "                            tool_messages = convert_output_to_messages(\n"
+    "                                output, raw=True, reasoning_format=get_reasoning_format(model)\n"
+    "                            )\n"
     "\n"
     "                            # Chat Completions providers don't support multimodal\n"
     "                            # tool messages.  Extract images into a user message.\n"
@@ -272,6 +280,7 @@ REPLACE_TOOL_LOOP = (
 # ============================================================
 # Mod 2: Code interpreter catch -> log.error + UI error display
 # v0.9.1: `title = await Chats.get_chat_title_by_id(...)` — async-ified
+# v0.9.3+: title wrapped in multi-line parenthesized ternary (channel: guard)
 # ============================================================
 SEARCH_CODE_INTERP = """\
                         except Exception as e:
@@ -283,7 +292,11 @@ SEARCH_CODE_INTERP = """\
                     if item.get('status') == 'in_progress':
                         item['status'] = 'completed'
 
-                title = await Chats.get_chat_title_by_id(metadata['chat_id'])"""
+                title = (
+                    await Chats.get_chat_title_by_id(metadata['chat_id'])
+                    if not metadata['chat_id'].startswith('channel:')
+                    else ''
+                )"""
 
 REPLACE_CODE_INTERP = (
     "                        except Exception as e:\n"
@@ -302,7 +315,11 @@ REPLACE_CODE_INTERP = (
     "                    if item.get('status') == 'in_progress':\n"
     "                        item['status'] = 'completed'\n"
     "\n"
-    "                title = await Chats.get_chat_title_by_id(metadata['chat_id'])"
+    "                title = (\n"
+    "                    await Chats.get_chat_title_by_id(metadata['chat_id'])\n"
+    "                    if not metadata['chat_id'].startswith('channel:')\n"
+    "                    else ''\n"
+    "                )"
 )
 
 # ============================================================


### PR DESCRIPTION
## Summary

- Bump Open WebUI base image from `0.9.2` to `0.9.5` (upstream shipped 0.9.3/0.9.4/0.9.5 on 2026-05-09).
- Re-audit all 8 patches against the new source tree: **none became obsolete** — upstream did not natively close any of the eight problem domains in 0.9.3–0.9.5.
- Refresh SEARCH/REPLACE anchors in 4 backend patches that drifted with upstream refactors (`reasoning_format` kwarg, `title=` ternary, new `_validate_collection_access` guard).
- Frontend patches (`fix_artifacts_auto_show`, `fix_preview_url_detection`) apply to 0.9.5 compiled chunks without changes.

## Patches touched

| Patch | Reason |
|-------|--------|
| `fix_tool_loop_errors` Mod 1 | `convert_output_to_messages()` is now multi-line with new `reasoning_format=get_reasoning_format(model)` kwarg at both call sites |
| `fix_tool_loop_errors` Mod 2 | `title = await Chats.get_chat_title_by_id(...)` is now a multi-line parenthesized ternary guarded by `startswith('channel:')` |
| `fix_large_tool_results` Mod 3 | Same `reasoning_format` kwarg refactor on `process_messages_with_output()` |
| `fix_skip_embedding_chat_files` Patch 1 | Upstream PR #24524 inserted `else: await _validate_collection_access(...)` between the collection bootstrap and the `form_data.content` guard |

All other patches: docstring/error-message version bumps only.

## Upstream behavior changes worth knowing

- New default `AIOHTTP_CLIENT_ALLOW_REDIRECTS=False` (3xx redirects blocked on web fetch / tool servers / OAuth).
- `POST /api/v1/auth/signout` (was GET) — `init.sh` does not call signout.
- New `IFRAME_CSP` env knob for Artifacts iframe CSP.
- Per-model `params` dict now stripped from non-write-access users on `GET /api/v1/models`.

## Test plan

- [x] Backend dry-run: all 6 middleware/retrieval patches apply cleanly against a fresh `v0.9.5` source tree; `ast.parse` OK on resulting files.
- [x] Docker build: `docker build --platform linux/amd64 -t open-webui-ocu:0.9.5.0-rc.2 -f openwebui/Dockerfile openwebui/` end-to-end green; all 8 hard-fail guards passed.
- [ ] Live smoke: `docker compose -f docker-compose.webui.yml up -d` → enable `computer_use` → exercise (a) Artifacts auto-open on HTML output, (b) preview-URL auto-detect, (c) large tool result truncation, (d) tool-loop error path (no UI hang).
- [ ] `init.sh` bootstrap still wires Valves on startup (`docker logs <ctr> | grep -i 'valves\|configs/models'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated to Open WebUI v0.9.5
  * New `IFRAME_CSP` environment variable for enhanced security control

* **Bug Fixes**
  * Re-audited and reapplied critical patches for upstream compatibility
  * Improved error handling for tool operations and message processing

* **Updates**
  * Updated runtime behavior for redirect blocking and authentication flows
  * Per-model parameter stripping for non-write access users
  * Documentation and changelog updated for v0.9.5 compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wide-Moat/open-computer-use/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->