### PR TITLE
feat(helm): Kata Containers + Block-mode PVC support

### DIFF
--- a/helm/computer-use-server/templates/_helpers.tpl
+++ b/helm/computer-use-server/templates/_helpers.tpl
@@ -82,11 +82,19 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/*
 Whether the inner dind container must run privileged.
-true => stock runc (no Sysbox) — required for dockerd to start.
-false => sysbox-runc handles isolation; privileged stays off.
+- true  => stock runc (no Sysbox) or Kata runtime (VM-isolated, privileged safe).
+- false => sysbox-runc handles isolation; privileged stays off.
+
+Set .Values.dind.privileged explicitly to override the runtimeClassName-based
+auto-detection. Useful when running under Kata Containers, which need
+privileged=true so dockerd inside the guest VM can set up iptables, but where
+"privileged" is contained by the hypervisor boundary rather than escaping to
+the host.
 */}}
 {{- define "computer-use-server.dindPrivileged" -}}
-{{- if eq (default "" .Values.orchestrator.runtimeClassName) "" -}}
+{{- if hasKey .Values.dind "privileged" -}}
+{{- .Values.dind.privileged -}}
+{{- else if eq (default "" .Values.orchestrator.runtimeClassName) "" -}}
 true
 {{- else -}}
 false

--- a/helm/computer-use-server/templates/deployment.yaml
+++ b/helm/computer-use-server/templates/deployment.yaml
@@ -57,11 +57,22 @@ spec:
         # Shared via emptyDir per the Sysbox sidecar pattern (sysbox docs + nestybox#406).
         - name: dind-socket
           emptyDir: {}
-        # /var/lib/docker for the inner dockerd. MUST be a dedicated emptyDir mounted
-        # only into the dind container — see nestybox/sysbox#406.
+        # /var/lib/docker for the inner dockerd. Default is a dedicated emptyDir
+        # mounted only into the dind container (see nestybox/sysbox#406). When
+        # .Values.persistence.varLibDocker.enabled=true AND volumeMode=Block,
+        # a Block PVC is used instead (entrypoint mkfs.ext4 + mount, useful for
+        # Kata + virtio-fs xattr workaround).
         - name: var-lib-docker
+          {{- if .Values.persistence.varLibDocker.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.varLibDocker.existingClaim }}
+          {{- else if and .Values.persistence.varLibDocker.enabled (eq (.Values.persistence.varLibDocker.volumeMode | default "Filesystem") "Block") }}
+          persistentVolumeClaim:
+            claimName: {{ include "computer-use-server.fullname" . }}-var-lib-docker
+          {{- else }}
           emptyDir:
             sizeLimit: {{ .Values.persistence.varLibDocker.sizeLimit }}
+          {{- end }}
         # PVCs follow the same enabled / existingClaim / emptyDir-fallback pattern
         # so disabling any volume in values.yaml does not produce an unschedulable Pod.
         - name: user-data
@@ -161,23 +172,68 @@ spec:
           # Use the docker:dind entrypoint, but pin the socket location so the
           # orchestrator (and the cleanup sidecar) can talk to it over the
           # shared emptyDir at /var/run/docker.sock.
+          # Entrypoint wrapper for Kata-compatible startup:
+          # 1. mknod /dev/fuse if absent (Kata-qemu guest doesn't auto-create it
+          #    even though `fuse` is in /proc/filesystems; fuse-overlayfs needs
+          #    /dev/fuse char dev 10:229; privileged container has CAP_MKNOD).
+          #    No-op on Sysbox (already has /dev/fuse).
+          # 2. cgroup v2 PID-1-evacuation: when systemd in the Kata guest puts
+          #    PID 1 in the unified-root cgroup, the root becomes a "domain
+          #    threaded" cgroup and runc inside child containers fails with
+          #    "cannot enter cgroupv2 ... with domain controllers". Canonical
+          #    fix per docker-library/docker#308: move processes to a child
+          #    cgroup and re-publish controllers at the root. No-op on cgroup v1
+          #    or on hosts where this is already done.
           command:
-            - dockerd
+            - /bin/sh
+            - -c
           args:
-            - --host=unix:///var/run/docker.sock
-            - --storage-driver={{ .Values.dind.storageDriver }}
+            - |
+              set -e
+              # Step 1: mknod /dev/fuse if missing (Kata-qemu, etc.)
+              if [ ! -c /dev/fuse ]; then
+                mknod /dev/fuse c 10 229 && chmod 666 /dev/fuse
+              fi
+              {{- if and .Values.persistence.varLibDocker.enabled (eq (.Values.persistence.varLibDocker.volumeMode | default "Filesystem") "Block") }}
+              # Block-mode /var/lib/docker: mkfs.ext4 (one-time) and mount.
+              DEV=/dev/dind-data
+              if ! blkid -s TYPE -o value "$DEV" | grep -q ext4; then
+                mkfs.ext4 -F "$DEV"
+              fi
+              mkdir -p /var/lib/docker
+              mount "$DEV" /var/lib/docker
+              {{- end }}
+              # Step 2: cgroup v2 PID-1 evacuation (no-op if not needed)
+              if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+                mkdir -p /sys/fs/cgroup/init
+                xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs 2>/dev/null || true
+                sed -e 's/ / +/g; s/^/+/' < /sys/fs/cgroup/cgroup.controllers \
+                  > /sys/fs/cgroup/cgroup.subtree_control 2>/dev/null || true
+              fi
+              exec dockerd \
+                --host=unix:///var/run/docker.sock \
+                --storage-driver={{ .Values.dind.storageDriver }}
           securityContext:
             privileged: {{ eq (include "computer-use-server.dindPrivileged" .) "true" }}
           volumeMounts:
             - name: dind-socket
               mountPath: /var/run
+            {{- if not (and .Values.persistence.varLibDocker.enabled (eq (.Values.persistence.varLibDocker.volumeMode | default "Filesystem") "Block")) }}
             - name: var-lib-docker
               mountPath: /var/lib/docker
+            {{- end }}
             # The inner dockerd needs access to /tmp/computer-use-data so the
             # bind mounts it creates for workspace containers resolve to real
             # files (same path inside the pod and inside spawned containers).
             - name: user-data
               mountPath: /tmp/computer-use-data
+          {{- if and .Values.persistence.varLibDocker.enabled (eq (.Values.persistence.varLibDocker.volumeMode | default "Filesystem") "Block") }}
+          # Raw block device for /var/lib/docker (entrypoint mkfs.ext4 + mount).
+          # See pvc-var-lib-docker.yaml header for rationale.
+          volumeDevices:
+            - name: var-lib-docker
+              devicePath: /dev/dind-data
+          {{- end }}
           resources:
             {{- toYaml .Values.dind.resources | nindent 12 }}
         {{- if .Values.cleanup.enabled }}

--- a/helm/computer-use-server/templates/pvc-var-lib-docker.yaml
+++ b/helm/computer-use-server/templates/pvc-var-lib-docker.yaml
@@ -1,0 +1,29 @@
+{{- /*
+Optional Block-mode PVC for /var/lib/docker. Useful when running under Kata
+Containers + virtio-fs: virtio-fs drops security.capability xattrs
+(kata-containers/runtime#1888, CVE-2021-20263), which breaks images whose
+layers carry xattrs (most distro packages). A Block-mode PVC arrives as
+virtio-blk in the Kata guest, where it can be mkfs.ext4'd and mounted
+inside the container — full xattr support, durable image cache.
+
+Defaults to disabled; the chart falls back to emptyDir when this is off.
+*/ -}}
+{{- if and .Values.persistence.varLibDocker.enabled (eq (.Values.persistence.varLibDocker.volumeMode | default "Filesystem") "Block") (not .Values.persistence.varLibDocker.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "computer-use-server.fullname" . }}-var-lib-docker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "computer-use-server.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.varLibDocker.accessMode | default "ReadWriteOnce" }}
+  volumeMode: Block
+  resources:
+    requests:
+      storage: {{ .Values.persistence.varLibDocker.size }}
+  {{- if .Values.persistence.varLibDocker.storageClass }}
+  storageClassName: {{ .Values.persistence.varLibDocker.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/computer-use-server/values.yaml
+++ b/helm/computer-use-server/values.yaml
@@ -108,6 +108,12 @@ orchestrator:
   affinity: {}
 
 dind:
+  # Optional override for the dind container's `privileged` SecurityContext.
+  # When unset, _helpers.tpl auto-detects: true if runtimeClassName is empty
+  # (stock runc), false otherwise (Sysbox). Set true explicitly when running
+  # under Kata Containers (VM-isolated; privileged caps cannot escape host).
+  # privileged: true   # uncomment to override auto-detection
+
   # Image for the inner Docker daemon. Must accept the standard dockerd flags.
   image:
     repository: docker
@@ -183,9 +189,25 @@ persistence:
     accessMode: ReadWriteOnce
     existingClaim: ""
 
-  # /var/lib/docker inside the dind container. Must be a dedicated emptyDir —
-  # NEVER a PVC and NEVER shared with other containers (nestybox/sysbox#406).
+  # /var/lib/docker inside the dind container.
+  #
+  # Default: emptyDir (must be dedicated — see nestybox/sysbox#406).
+  # sizeLimit applies only to the emptyDir mode.
+  #
+  # Optional: Block-mode PVC. Set enabled=true + volumeMode=Block to use a
+  # PersistentVolumeClaim (Block volumeMode) instead of emptyDir. The entrypoint
+  # will mkfs.ext4 the raw device and mount it at /var/lib/docker. This is the
+  # supported workaround for Kata + virtio-fs xattr loss (kata#1888,
+  # CVE-2021-20263) where overlay2 layers with security.capability xattrs fail.
   varLibDocker:
+    enabled: false
+    size: 30Gi
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    # Filesystem | Block. Block requires storage class supporting block volumes.
+    volumeMode: Filesystem
+    existingClaim: ""
+    # emptyDir fallback (used when enabled=false or volumeMode=Filesystem without existingClaim)
     sizeLimit: 50Gi
 
 service:


### PR DESCRIPTION
## Summary

Four backward-compatible patches to make the chart usable under [Kata Containers](https://katacontainers.io/) (VM-isolated runtime) without changing default behavior for existing Sysbox/stock-runc users.

All defaults preserved. Each patch is opt-in or a safe no-op when the relevant runtime is not present.

## Patches

### 1. `dind.privileged` override (`templates/_helpers.tpl`)
New optional `.Values.dind.privileged` key. Takes precedence over the existing `runtimeClassName`-based auto-detection. Kata needs `privileged: true` (the VM boundary contains the capability set), but the existing helper assumes any non-empty `runtimeClassName` is Sysbox and forces `privileged: false`.

### 2. `mknod /dev/fuse` in entrypoint (`templates/deployment.yaml`)
The Kata-qemu guest does not auto-create `/dev/fuse` even when `fuse` is in `/proc/filesystems`. `fuse-overlayfs` needs the char device (10:229). Privileged containers have `CAP_MKNOD`, so this is allowed. No-op when the device already exists (Sysbox, etc.).

### 3. cgroup v2 PID-1 evacuation (`templates/deployment.yaml`)
Kata guest systemd places PID 1 in the unified-root cgroup, marking it domain-threaded. `runc` inside child containers then fails with `cannot enter cgroupv2 ... with domain controllers`. Canonical workaround from [docker-library/docker#308](https://github.com/docker-library/docker/issues/308): move processes to a child cgroup and re-publish controllers at the root. No-op on cgroup v1 or when already done.

### 4. Optional Block-mode PVC for `/var/lib/docker`
New optional `persistence.varLibDocker.enabled` + `volumeMode: Block` combination. When set, the chart creates a `PersistentVolumeClaim` (Block volumeMode), attaches it via `volumeDevices`, and the entrypoint `mkfs.ext4`s + mounts the raw device at `/var/lib/docker`.

Rationale: Kata + virtio-fs drops `security.capability` xattrs ([kata-containers/runtime#1888](https://github.com/kata-containers/runtime/issues/1888), [CVE-2021-20263](https://nvd.nist.gov/vuln/detail/CVE-2021-20263)). Images whose layers carry xattrs (most distros) fail to unpack. A Block PVC arrives as `virtio-blk` in the guest → real ext4 → full xattr support.

Default `enabled: false` keeps the existing emptyDir behavior.

## Backward compatibility matrix

| `runtimeClassName` | `dind.privileged` | `varLibDocker.enabled` | Result |
|---|---|---|---|
| `""` (stock runc) | unset | false | `privileged: true`, emptyDir (unchanged) |
| `sysbox-runc` | unset | false | `privileged: false`, emptyDir (unchanged) |
| `kata-qemu` (or any) | `true` | true + Block | `privileged: true`, Block PVC + volumeDevices |
| any | unset | false | works the same as before this PR |

Verified locally with `helm template` for all four rows.

## Files

- `templates/_helpers.tpl` (+9 / -2)
- `templates/deployment.yaml` (+58 / -8)
- `templates/pvc-var-lib-docker.yaml` (new)
- `values.yaml` (+24 / -2)

## Tests

- `helm lint` — passes (pre-existing schema errors unrelated to this PR)
- `helm template` — renders correctly for all combinations above
- Real deployment — verified on a Kata-qemu cluster with Longhorn (Block storage class)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable persistent storage for Docker daemon data with support for custom PVCs and block-mode volumes
  * Added explicit privilege mode override for Docker container configuration
  * Enhanced container startup compatibility with Kata containers and cgroup v2 environments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wide-Moat/open-computer-use/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->