### PR TITLE
chore(ci): enable CodeRabbit auto-review on next/v1 PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit configuration for open-computer-use.
+#
+# Enables CodeRabbit auto-review on PRs targeting `next/v1` (the long-lived
+# enterprise architecture branch) in addition to `main` (the repo default).
+# Without this, CodeRabbit auto-reviews only PRs targeting the default
+# branch and posts "Auto reviews are disabled on base/target branches other
+# than the default branch" on PRs to `next/v1`.
+#
+# Reference: https://docs.coderabbit.ai/reference/yaml-template
+language: en
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+      - next/v1


### PR DESCRIPTION
## Summary

Add `.coderabbit.yaml` listing both `main` and `next/v1` under `reviews.auto_review.base_branches`. CodeRabbit currently skips PRs targeting `next/v1` with the message "Auto reviews are disabled on base/target branches other than the default branch" (e.g. PR #132).

## Why

`next/v1` is the long-lived enterprise architecture branch. We're landing many sub-PRs against it over months. Without this config every PR needs a manual `@coderabbitai review` comment to trigger a one-off review — not sustainable.

## Config choices

- `profile: chill` — less noise on architecture/docs PRs.
- `auto_review.drafts: false` — drafts skip auto-review (cheaper, intentional).
- `request_changes_workflow: false` — CodeRabbit comments, doesn't block merge.

## Test plan

- [ ] Merge this PR into `next/v1`.
- [ ] Re-trigger CodeRabbit on PR #132 (or push a no-op commit) and confirm auto-review runs.
- [ ] Verify future PRs against `next/v1` get reviewed automatically without `@coderabbitai review` trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CodeRabbit configuration for automated code review workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wide-Moat/open-computer-use/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->