### PR TITLE
refactor(claude-md): reorganize + update Project Structure & Versioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,65 +1,21 @@
 # Project Instructions
 
+## Branches and scope
+
+This repository has two long-lived branches with different rules:
+
+- **`main`** — the current PoC / production branch. Open WebUI integration, Docker Compose deployment, MCP orchestrator. The rules below apply. Quick fixes welcome.
+- **`next/v1`** — the long-lived enterprise architecture branch. Same global rules apply, plus the additional architecture-work rules in the `# Architecture work on next/v1` section below. Designed for US/EU bank deployments; every architectural decision is recorded as an ADR.
+
+When working on a feature branch, the rules of its base branch apply (e.g. `feat/foo` based on `next/v1` inherits the `next/v1` rules).
+
+---
+
+# Global rules (apply to every branch)
+
 ## Language
 
 All code, comments, commit messages, PR titles, PR descriptions, documentation, and any text visible in the repository MUST be written in **English only**. No exceptions.
-
-## Building Docker Image
-
-Always build with `--platform linux/amd64`:
-
-```bash
-docker build --platform linux/amd64 -t open-computer-use:latest .
-```
-
-## Testing
-
-After building the image or changing `Dockerfile`, `package.json`, `requirements.txt`, skills, or npm configuration — run tests:
-
-```bash
-./tests/test-docker-image.sh [image-name]
-./tests/test-no-corporate.sh
-./tests/test-project-structure.sh
-```
-
-Default image: `open-computer-use:latest`.
-
-Tests verify: npm packages (CommonJS `require()`, ESM `import`), CLI tools (mmdc, tsc, tsx, claude), Python packages, Playwright, html2pptx, volume size (`/home/assistant/` < 1MB), file permissions, project structure, no corporate references.
-
-## npm Packages Layout
-
-Packages are installed outside `/home/assistant` (volume mount point) to avoid duplication per container:
-
-| Path | Contents | Storage |
-|------|----------|---------|
-| `/home/node_modules/` | Libraries (react, pptxgenjs, pdf-lib...) | Image layer (shared) |
-| `/usr/local/lib/node_modules_global/` | CLI tools (mmdc, tsc, tsx, claude) | Image layer (shared) |
-| `/home/assistant/node_modules/` | User-installed packages (`npm install`) | Volume (per-container) |
-
-Node.js uses parent directory resolution: if a package isn't found in `/home/assistant/node_modules`, it looks in `/home/node_modules`.
-
-## Versioning
-
-Format: `v0.8.X.Y` — the first three segments (`0.8.X`) track the **Open WebUI** base version this project is built on. Never bump them independently.
-
-- **Patch release** (`Y+1`): bug fixes, security patches, dependency bumps, test additions → e.g. `v0.8.12.3` → `v0.8.12.4`
-- **Minor release** (`X+1`, reset `Y=0`): new features, new tools, significant changes → only when Open WebUI base version also bumps
-
-To release:
-1. Update `CHANGELOG.md` with the new version heading
-2. Commit: `chore: release vX.X.X.X`
-3. Tag: `git tag vX.X.X.X && git push origin main --tags`
-
-## Project Structure
-
-- `Dockerfile` — Sandbox container image (Ubuntu 24.04, Python, Node.js, CDP, ttyd)
-- `computer-use-server/` — MCP orchestrator (FastAPI, Docker management, CDP/terminal proxy)
-- `openwebui/` — Open WebUI integration (tools, functions, patches)
-- `skills/` — AI skills (pptx, xlsx, docx, pdf, sub-agent, playwright-cli, etc.)
-- `docs/` — Documentation
-- `tests/` — Test scripts
-- `docker-compose.yml` — Computer Use Server
-- `docker-compose.webui.yml` — Open WebUI + PostgreSQL (connects to server via `host.docker.internal`)
 
 ## License Headers
 
@@ -72,6 +28,73 @@ All new source files MUST include an SPDX license header as the first comment:
 Always include: `# Copyright (c) 2025 Open Computer Use Contributors`
 
 The FSL-1.1-Apache-2.0 license permits use, modification, forking, internal self-hosting, and redistribution. It prohibits offering the Software as a hosted or embedded service that competes with our paid version(s). Each release automatically converts to Apache-2.0 two years after publication.
+
+## Building the Docker image
+
+Always build with `--platform linux/amd64`:
+
+```bash
+docker build --platform linux/amd64 -t open-computer-use:latest .
+```
+
+## Testing
+
+After building the image or changing `Dockerfile`, `package.json`, `requirements.txt`, skills, or npm configuration — run:
+
+```bash
+./tests/test-docker-image.sh [image-name]
+./tests/test-no-corporate.sh
+./tests/test-project-structure.sh
+```
+
+Default image: `open-computer-use:latest`.
+
+These verify: npm packages (CommonJS `require()`, ESM `import`), CLI tools (mmdc, tsc, tsx, claude), Python packages, Playwright, html2pptx, volume size (`/home/assistant/` < 1MB), file permissions, project structure, no corporate references.
+
+## npm packages layout
+
+Packages are installed outside `/home/assistant` (volume mount point) to avoid duplication per container:
+
+| Path | Contents | Storage |
+|------|----------|---------|
+| `/home/node_modules/` | Libraries (react, pptxgenjs, pdf-lib...) | Image layer (shared) |
+| `/usr/local/lib/node_modules_global/` | CLI tools (mmdc, tsc, tsx, claude) | Image layer (shared) |
+| `/home/assistant/node_modules/` | User-installed packages (`npm install`) | Volume (per-container) |
+
+Node.js uses parent-directory resolution: if a package isn't found in `/home/assistant/node_modules`, it looks in `/home/node_modules`.
+
+## Project structure
+
+| Path | Contents |
+|---|---|
+| `Dockerfile` | Sandbox container image (Ubuntu 24.04, Python, Node.js, CDP, ttyd) |
+| `computer-use-server/` | MCP orchestrator (FastAPI, Docker management, CDP/terminal proxy) |
+| `openwebui/` | Open WebUI integration (tools, functions, patches) |
+| `settings-wrapper/` | Settings sidecar service |
+| `skills/` | AI skills (pptx, xlsx, docx, pdf, sub-agent, playwright-cli, ...) |
+| `helm/` | Helm chart for Kubernetes deployment |
+| `vendor/` | Vendored third-party binaries (e.g. `extract-text`) |
+| `tests/` | Test scripts |
+| `docs/` | Project documentation |
+| `docs/architecture/` | Canonical enterprise architecture (`next/v1` only); read `MANIFESTO.md` first |
+| `docs/future-architecture/` | In-progress architecture buffer; superseded by `docs/architecture/` over time |
+| `docker-compose.yml` | Computer Use Server |
+| `docker-compose.webui.yml` | Open WebUI + PostgreSQL (connects to server via `host.docker.internal`) |
+
+## Versioning (current `main`-line scheme)
+
+Format: `v0.9.X.Y` — the first three segments (`0.9.X`) track the **Open WebUI** base version this project is built on. Never bump them independently.
+
+- **Patch release** (`Y+1`): bug fixes, security patches, dependency bumps, test additions → e.g. `v0.9.5.0` → `v0.9.5.1`
+- **Minor release** (`X+1`, reset `Y=0`): new features, new tools, significant changes → only when Open WebUI base version also bumps
+
+To release:
+
+1. Update `CHANGELOG.md` with the new version heading.
+2. Commit: `chore: release vX.X.X.X`.
+3. Tag: `git tag vX.X.X.X && git push origin main --tags`.
+
+The `next/v1` branch will define its own versioning scheme in an ADR; until then it carries no tagged releases.
 
 ---
 


### PR DESCRIPTION
## Summary

Pure structural refactor of `CLAUDE.md`. No new rules, no removed rules — better grouping and a few stale references corrected.

## What changed

- **New `## Branches and scope`** section at the top explaining `main` vs `next/v1` and how rules attach to feature branches.
- Existing rules grouped under `# Global rules (apply to every branch)`.
- **Project structure** updated: adds `settings-wrapper/`, `helm/`, `vendor/`, `docs/architecture/`, `docs/future-architecture/`. Switched from bullet list to table.
- **Versioning** example bumped from stale `v0.8.X.Y` to current `v0.9.X.Y`. Added line about `next/v1` defining its own versioning ADR.
- Section titles normalized to sentence case.

## What did NOT change

License Headers (already FSL via PR #132), Building / Testing / npm-layout rules, all FSL/English-only/SPDX wording.

## Why a separate PR

The `# Architecture work on next/v1` section (decision tree, diagrams, dependency policy, testing/QA, v1 non-goals, documentation discipline) lands in PR #134. Keeping refactor separate makes both PRs reviewable: this one shows reorganization cleanly; #134 shows new sections cleanly. After both merge the file reads top-to-bottom: Branches+Scope → Global rules → Architecture work.

Will conflict with #134 on `CLAUDE.md` (both touch the same file). Whichever lands first, the other rebases. Trivial conflict, expected.

## Test plan

- [x] `tests/test-project-structure.sh` would not be affected (this is docs-only). No tests run.
- [ ] CodeRabbit auto-reviews (yaml landed via #133).
- [ ] After merge: visual inspection that section order matches the new model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated versioning scheme for main branch releases from `v0.8.X.Y` to `v0.9.X.Y` and noted `next/v1` will define its own scheme via ADR (no tagged releases yet).
  * Clarified branch governance, English-only docs requirement, and license-header rules.
  * Expanded testing docs to enumerate verifications (packaging/import modes, CLI tools, Python packages, Playwright/html2pptx, volume size/permissions, project-structure constraints).
  * Aligned Docker build/test wording and improved Node.js dependency resolution guidance.
  * Added a path-to-contents project documentation table.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wide-Moat/open-computer-use/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->