### PR TITLE
chore(ci): extend .semgrepignore to cover missed legacy paths

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -51,10 +51,23 @@ cleanup/
 
 # Bundled-skills PoC code — defused-xml gaps, file-perms issues. v1 ships
 # zero default skills (per manifesto/04-non-goals.md); SkillProvider stays
-# TBD. These directories will be deleted, not refactored.
+# TBD. These directories will be deleted, not refactored. Both
+# `skills/public/` and `skills/examples/` are out of scope: v1 GA does
+# not bundle any skill, the directories die together.
 skills/public/pptx/
 skills/public/docx/
 skills/public/webapp-testing/
+skills/examples/
+
+# Main-line Helm chart release workflow — pre-existing run-shell-injection
+# on its `gh release` step. Replaced by the Layer 6+ release workflow once
+# the supply-chain.yml pattern is extended to chart artifacts.
+.github/workflows/release-chart.yml
+
+# Main-line test code — stdlib XML parsing in PoC test fixtures. New
+# components ship their own tests under each component's directory;
+# this top-level `tests/` tree dies as the legacy code does.
+tests/
 
 # --- Not legacy, just out of scope for SAST ---------------------------------
 

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -51,9 +51,11 @@ cleanup/
 
 # Bundled-skills PoC code — defused-xml gaps, file-perms issues. v1 ships
 # zero default skills (per manifesto/04-non-goals.md); SkillProvider stays
-# TBD. These directories will be deleted, not refactored. Both
-# `skills/public/` and `skills/examples/` are out of scope: v1 GA does
-# not bundle any skill, the directories die together.
+# TBD. These directories will be deleted, not refactored. Three specific
+# `skills/public/` subdirectories trip SAST today; the whole
+# `skills/examples/` tree is excluded because every example carries the
+# same upstream patterns. All three subtrees die together when v1 GA
+# locks in "zero bundled skills".
 skills/public/pptx/
 skills/public/docx/
 skills/public/webapp-testing/
@@ -65,9 +67,11 @@ skills/examples/
 .github/workflows/release-chart.yml
 
 # Main-line test code — stdlib XML parsing in PoC test fixtures. New
-# components ship their own tests under each component's directory;
-# this top-level `tests/` tree dies as the legacy code does.
-tests/
+# components ship their own tests under each component's directory.
+# The pattern is root-anchored (`/tests/`, not `tests/`) so it matches
+# only the top-level legacy tree, not nested `tests/` directories that
+# future components will own.
+/tests/
 
 # --- Not legacy, just out of scope for SAST ---------------------------------
 

--- a/docs/architecture/adr/0001-layer-0-gate-legacy-exclusion.md
+++ b/docs/architecture/adr/0001-layer-0-gate-legacy-exclusion.md
@@ -59,3 +59,15 @@ None.
 ## Threat mitigation
 
 None directly. The legacy code's threats (root containers, XXE, SSRF via `urllib`) are addressed by replacement, not by SAST suppression. The new-component-must-remove-its-path rule keeps that promise auditable.
+
+## Amendments
+
+### 2026-05-24 — initial exclusion-list completion
+
+The first version of `.semgrepignore` shipped in commit `709db53` missed three legacy areas that the SAST gate scans:
+
+- `.github/workflows/release-chart.yml` — `main`-line Helm release workflow with a pre-existing `run-shell-injection` finding on the `gh release create` step. Replaced when the supply-chain.yml pattern is extended to chart artifacts in Layer 6+.
+- `skills/examples/` — bundled skill examples carrying the same `defusedxml` gaps as `skills/public/`. v1 GA ships zero skills per `manifesto/04-non-goals.md`; both directories die together.
+- `tests/` — top-level PoC test tree using stdlib `xml.etree`. New components ship their own tests under each component's directory; this tree dies with the code it tests.
+
+Discovered by the third verifier pass on commit `709db53`. The amendment adds them under the same policy with no change to the decision or alternatives.


### PR DESCRIPTION
## Summary

Amendment to PR #139. Adds three legacy paths the initial exclusion list missed:

- `.github/workflows/release-chart.yml` — `run-shell-injection` finding on `gh release create`
- `skills/examples/` — same `defusedxml` gaps as `skills/public/` (v1 GA ships zero skills)
- `tests/` — stdlib `xml.etree` in PoC test fixtures (new components ship their own tests)

ADR-0001 gains an "Amendments" section recording the addition with the same policy unchanged.

## Why

Third verifier pass on `709db53` (post PR #139 merge) flagged 12 blocking Semgrep findings still present because the initial `.semgrepignore` covered `skills/public/` but not `skills/examples/`, and didn't list `release-chart.yml` or `tests/` at all. Per ADR-0001's own rule — "Adding a path requires an ADR amendment" — this PR records the amendment in the ADR alongside the file changes.

## Test plan

- [x] ADR-0001 ≤ 200 lines (73 lines after amendment)
- [x] English-only (pre-commit hook passed)
- [ ] `security` workflow green on the PR commit
- [ ] All other CI gates green
- [ ] CodeRabbit review clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated security scanning exclusions to omit additional legacy code areas, a CI workflow, and a top-level test tree from analysis.
* **Documentation**
  * Recorded an amendment to the architecture decision log (dated entry) documenting the updated exclusion list and its discovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wide-Moat/open-computer-use/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->