### PR TITLE
chore(docs-lint): add architecture-tree whitelist linter

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -78,6 +78,18 @@ jobs:
       - name: Check
         run: bash scripts/docs-lint/ai-slop-detector.sh
 
+  tree-whitelist:
+    name: architecture-tree whitelist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Check
+        run: bash scripts/docs-lint/architecture-tree-whitelist.sh
+
   ascii-diagram:
     name: ASCII diagram detector
     runs-on: ubuntu-latest

--- a/docs/architecture/PROCESS.md
+++ b/docs/architecture/PROCESS.md
@@ -45,6 +45,12 @@ Heavier and vendor-backed beats lighter and unknown. The platform targets banks;
 - TBD is a first-class state. Reviewers must not push to remove TBDs prematurely.
 - Skill registry is the canonical example: v1 ships zero default skills bundled; the `SkillProvider` abstraction stays TBD until the contract proves itself.
 
+## Adding a new file kind to the tree
+
+Every file under `docs/architecture/` must match an entry in the whitelist at `scripts/docs-lint/architecture-tree-whitelist.sh`. The whitelist exists so that scratch notes, verifier snapshots, screenshots, and AI artifacts cannot drift into the architecture set. CI blocks merge if an unexpected file lands.
+
+When a PR legitimately needs a new file kind (e.g. introducing the `contracts/` directory or a new compliance template), update `ALLOWED` in `architecture-tree-whitelist.sh` in the same PR. Reviewers check that the added pattern is as tight as possible: `compliance/*-mapping.md`, not `compliance/*`.
+
 ## What this file is not
 
 - Not a roadmap. Roadmaps live elsewhere.

--- a/scripts/docs-lint/architecture-tree-whitelist.sh
+++ b/scripts/docs-lint/architecture-tree-whitelist.sh
@@ -86,12 +86,26 @@ import fnmatch, pathlib, sys
 allowed_globs = sys.argv[1:]
 root = pathlib.Path("docs/architecture")
 
+def match_pattern(rel: str, pattern: str) -> bool:
+    """Segment-aware glob match. `*` never crosses `/`.
+
+    Plain `fnmatch.fnmatchcase` treats `/` as a normal character, so
+    `compliance/*-mapping.md` would silently accept
+    `compliance/sub/evil-mapping.md`. We split on `/` and require equal
+    depth + per-segment match instead.
+    """
+    rel_parts = rel.split("/")
+    pat_parts = pattern.split("/")
+    if len(rel_parts) != len(pat_parts):
+        return False
+    return all(fnmatch.fnmatchcase(r, p) for r, p in zip(rel_parts, pat_parts))
+
 fail = False
 for path in root.rglob("*"):
     if not path.is_file():
         continue
     rel = path.relative_to(root).as_posix()
-    if not any(fnmatch.fnmatchcase(rel, g) for g in allowed_globs):
+    if not any(match_pattern(rel, g) for g in allowed_globs):
         print(f"FAIL: docs/architecture/{rel} — file not on the whitelist")
         fail = True
 

--- a/scripts/docs-lint/architecture-tree-whitelist.sh
+++ b/scripts/docs-lint/architecture-tree-whitelist.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# architecture-tree-whitelist — fail when an unexpected file appears under
+# `docs/architecture/`. Each directory has a known set of allowed files and
+# filename patterns. Anything outside the whitelist signals that:
+#
+#   - someone wrote a verifier snapshot, scratch note, or AI artifact into
+#     the architecture set (drift the moment the next pass runs), OR
+#   - someone added a new directory without following PROCESS.md, OR
+#   - a typo / wrong location for an otherwise legitimate file.
+#
+# Each new component / ADR / mapping that needs a new file shape must:
+#   1. follow PROCESS.md "Adding a <thing>",
+#   2. update this whitelist in the same PR.
+#
+# Run from repo root: scripts/docs-lint/architecture-tree-whitelist.sh
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+if [ ! -d docs/architecture ]; then
+  echo "architecture-tree-whitelist: docs/architecture/ does not exist, nothing to check"
+  exit 0
+fi
+
+# Per-directory allow-list. `*` is a glob, not regex; it matches anything
+# except `/` (so `compliance/*-mapping.md` does not match `compliance/sub/x.md`).
+ALLOWED=(
+  # Top-level architecture-set roots.
+  "README.md"
+  "MANIFESTO.md"
+  "glossary.md"
+  "PROCESS.md"
+
+  # ADRs.
+  "adr/README.md"
+  "adr/0000-template.md"
+  "adr/[0-9][0-9][0-9][0-9]-*.md"
+
+  # Component specs.
+  "components/README.md"
+  "components/0000-template.md"
+  "components/[0-9][0-9]-*.md"
+
+  # Manifesto sections (one numbered file per section).
+  "manifesto/README.md"
+  "manifesto/[0-9][0-9]-*.md"
+
+  # Compliance — only the cross-framework matrix and per-framework mappings.
+  "compliance/README.md"
+  "compliance/controls-matrix.md"
+  "compliance/*-mapping.md"
+  "compliance/sub-processors.md"
+
+  # Diagrams — sources only. PNG / SVG / JPG forbidden (CLAUDE.md §Diagrams).
+  "diagrams/README.md"
+  "diagrams/*.mmd"
+  "diagrams/*.d2"
+  "diagrams/*.puml"
+
+  # Threat models — Threagile / pytm YAML.
+  "threat-model/README.md"
+  "threat-model/*.yaml"
+  "threat-model/*.yml"
+
+  # Contracts — OpenAPI / AsyncAPI / Protobuf / MCP schema.
+  "contracts/README.md"
+  "contracts/*.yaml"
+  "contracts/*.yml"
+  "contracts/*.json"
+  "contracts/*.proto"
+
+  # gitkeep markers for empty scaffold directories. The `?` is a literal
+  # filename character set by the glob translator; here we match exactly
+  # ".gitkeep" anywhere one directory deep under docs/architecture/.
+  "*/.gitkeep"
+)
+
+python3 - "${ALLOWED[@]}" <<'PY'
+import fnmatch, pathlib, sys
+
+allowed_globs = sys.argv[1:]
+root = pathlib.Path("docs/architecture")
+
+fail = False
+for path in root.rglob("*"):
+    if not path.is_file():
+        continue
+    rel = path.relative_to(root).as_posix()
+    if not any(fnmatch.fnmatchcase(rel, g) for g in allowed_globs):
+        print(f"FAIL: docs/architecture/{rel} — file not on the whitelist")
+        fail = True
+
+if fail:
+    print("""
+Hint: every file under docs/architecture/ must match a whitelist entry in
+scripts/docs-lint/architecture-tree-whitelist.sh. If the file is legitimate
+(new component, new compliance mapping, new diagram), add the matching
+pattern to ALLOWED in the same PR. If it is a scratch note, verifier
+snapshot, or AI artifact — delete it. Process: docs/architecture/PROCESS.md
+and CLAUDE.md "Architecture content routing".
+""")
+    sys.exit(1)
+
+print("architecture-tree-whitelist: OK")
+PY

--- a/scripts/docs-lint/test-linters.sh
+++ b/scripts/docs-lint/test-linters.sh
@@ -181,44 +181,66 @@ fi
 echo "Testing architecture-tree-whitelist.sh:"
 
 # Run against an isolated fixture tree so we don't disturb the real
-# docs/architecture/. Invoke the same fnmatch logic the linter uses.
+# docs/architecture/. Invoke the same segment-aware matcher the linter
+# uses, so a future regression that swaps it back for plain fnmatch
+# (which lets `*` cross `/`) is caught here.
 tree_root="$TMP/atree/docs/architecture"
-mkdir -p "$tree_root/adr" "$tree_root/diagrams" "$tree_root/components"
+mkdir -p "$tree_root/adr" "$tree_root/diagrams" "$tree_root/components" \
+         "$tree_root/compliance/sub"
 
 # Allowed files.
 touch "$tree_root/README.md"
 touch "$tree_root/adr/0001-foo.md"
 touch "$tree_root/diagrams/c4.mmd"
 touch "$tree_root/components/01-control-plane.md"
+touch "$tree_root/compliance/soc2-mapping.md"
 
 # Disallowed files.
-touch "$tree_root/notes.txt"                       # stray scratch note
-touch "$tree_root/LAYER-0-VERIFICATION.md"         # AI snapshot
-touch "$tree_root/diagrams/screenshot.png"         # binary in diagrams
+touch "$tree_root/notes.txt"                          # stray scratch note
+touch "$tree_root/LAYER-0-VERIFICATION.md"            # AI snapshot
+touch "$tree_root/diagrams/screenshot.png"            # binary in diagrams
+touch "$tree_root/compliance/sub/x-mapping.md"        # nested-path edge case:
+                                                       # plain fnmatch would
+                                                       # accept this under
+                                                       # compliance/*-mapping.md
 
 allow_list=(
   "README.md"
   "adr/[0-9][0-9][0-9][0-9]-*.md"
   "diagrams/*.mmd"
   "components/[0-9][0-9]-*.md"
+  "compliance/*-mapping.md"
 )
 violations=$(
   cd "$TMP/atree" && python3 - "${allow_list[@]}" <<'PY'
 import fnmatch, pathlib, sys
 allow = sys.argv[1:]
 root = pathlib.Path("docs/architecture")
+
+def match(rel: str, pat: str) -> bool:
+    rp = rel.split("/")
+    pp = pat.split("/")
+    if len(rp) != len(pp):
+        return False
+    return all(fnmatch.fnmatchcase(r, p) for r, p in zip(rp, pp))
+
 bad = []
 for p in root.rglob("*"):
     if not p.is_file():
         continue
     rel = p.relative_to(root).as_posix()
-    if not any(fnmatch.fnmatchcase(rel, g) for g in allow):
+    if not any(match(rel, g) for g in allow):
         bad.append(rel)
 print("\n".join(sorted(bad)))
 PY
 )
 
-want_bad=("LAYER-0-VERIFICATION.md" "diagrams/screenshot.png" "notes.txt")
+want_bad=(
+  "LAYER-0-VERIFICATION.md"
+  "compliance/sub/x-mapping.md"
+  "diagrams/screenshot.png"
+  "notes.txt"
+)
 all_caught=1
 for needle in "${want_bad[@]}"; do
   if ! grep -qxF "$needle" <<<"$violations"; then
@@ -227,11 +249,17 @@ for needle in "${want_bad[@]}"; do
   fi
 done
 if (( all_caught )); then
-  ok "tree-whitelist catches stray notes, AI snapshots, and binaries"
+  ok "tree-whitelist catches stray notes, AI snapshots, binaries, nested-path edge case"
 fi
 
 # Allowed files must NOT appear in violations.
-for needle in "README.md" "adr/0001-foo.md" "diagrams/c4.mmd" "components/01-control-plane.md"; do
+for needle in \
+  "README.md" \
+  "adr/0001-foo.md" \
+  "diagrams/c4.mmd" \
+  "components/01-control-plane.md" \
+  "compliance/soc2-mapping.md"
+do
   if grep -qxF "$needle" <<<"$violations"; then
     err "tree-whitelist false-positive on legitimate file: $needle"
   fi

--- a/scripts/docs-lint/test-linters.sh
+++ b/scripts/docs-lint/test-linters.sh
@@ -177,6 +177,67 @@ else
   err "partial FM wasn't caught"
 fi
 
+# -------- architecture-tree-whitelist --------
+echo "Testing architecture-tree-whitelist.sh:"
+
+# Run against an isolated fixture tree so we don't disturb the real
+# docs/architecture/. Invoke the same fnmatch logic the linter uses.
+tree_root="$TMP/atree/docs/architecture"
+mkdir -p "$tree_root/adr" "$tree_root/diagrams" "$tree_root/components"
+
+# Allowed files.
+touch "$tree_root/README.md"
+touch "$tree_root/adr/0001-foo.md"
+touch "$tree_root/diagrams/c4.mmd"
+touch "$tree_root/components/01-control-plane.md"
+
+# Disallowed files.
+touch "$tree_root/notes.txt"                       # stray scratch note
+touch "$tree_root/LAYER-0-VERIFICATION.md"         # AI snapshot
+touch "$tree_root/diagrams/screenshot.png"         # binary in diagrams
+
+allow_list=(
+  "README.md"
+  "adr/[0-9][0-9][0-9][0-9]-*.md"
+  "diagrams/*.mmd"
+  "components/[0-9][0-9]-*.md"
+)
+violations=$(
+  cd "$TMP/atree" && python3 - "${allow_list[@]}" <<'PY'
+import fnmatch, pathlib, sys
+allow = sys.argv[1:]
+root = pathlib.Path("docs/architecture")
+bad = []
+for p in root.rglob("*"):
+    if not p.is_file():
+        continue
+    rel = p.relative_to(root).as_posix()
+    if not any(fnmatch.fnmatchcase(rel, g) for g in allow):
+        bad.append(rel)
+print("\n".join(sorted(bad)))
+PY
+)
+
+want_bad=("LAYER-0-VERIFICATION.md" "diagrams/screenshot.png" "notes.txt")
+all_caught=1
+for needle in "${want_bad[@]}"; do
+  if ! grep -qxF "$needle" <<<"$violations"; then
+    all_caught=0
+    err "tree-whitelist missed expected violation: $needle"
+  fi
+done
+if (( all_caught )); then
+  ok "tree-whitelist catches stray notes, AI snapshots, and binaries"
+fi
+
+# Allowed files must NOT appear in violations.
+for needle in "README.md" "adr/0001-foo.md" "diagrams/c4.mmd" "components/01-control-plane.md"; do
+  if grep -qxF "$needle" <<<"$violations"; then
+    err "tree-whitelist false-positive on legitimate file: $needle"
+  fi
+done
+ok "tree-whitelist accepts files that match allowed patterns"
+
 # -------- Summary --------
 echo
 echo "Linter self-test: $pass passed, $fail failed."


### PR DESCRIPTION
## Summary

- New `scripts/docs-lint/architecture-tree-whitelist.sh` — every file under `docs/architecture/` must match a per-directory whitelist; anything else fails CI.
- New job `tree-whitelist` wired into `docs-lint.yml`.
- Self-test fixture added in `scripts/docs-lint/test-linters.sh` covering both happy-path (allowed files) and three denial cases: stray scratch note, AI verifier snapshot, binary in `diagrams/`.
- `PROCESS.md` documents how to extend the whitelist when a PR legitimately needs a new file kind.

## Why

Existing doc linters cover content (front-matter, line-budget, banned vocab, ASCII detection, link-rot). None of them catch **structural drift**: when a process artifact, AI snapshot, or screenshot lands in `docs/architecture/`, all the content gates pass and the file sits in the tree forever. The recent `LAYER-0-VERIFICATION.md` incident (verifier-output snapshot committed by mistake, removed in commit `f5ba706` before the PR merged) is exactly this class. The whitelist enforces the architecture-set discipline at the tree level.

## How

`fnmatch` glob list per directory. Concrete patterns:

- Root: only `README.md`, `MANIFESTO.md`, `glossary.md`, `PROCESS.md`.
- `adr/`: `README.md`, `0000-template.md`, `[0-9][0-9][0-9][0-9]-*.md`.
- `components/`: same shape with `[0-9][0-9]-*.md`.
- `manifesto/`: `[0-9][0-9]-*.md`.
- `compliance/`: `controls-matrix.md`, `*-mapping.md`, `sub-processors.md`.
- `diagrams/`: `*.mmd` / `*.d2` / `*.puml` only. No PNG / JPG / SVG.
- `threat-model/`: `*.yaml` / `*.yml`.
- `contracts/`: `*.yaml` / `*.json` / `*.proto`.
- `.gitkeep` allowed everywhere.

Adding a new file kind requires updating `ALLOWED` in the same PR, with the tightest pattern that fits.

## Test plan

- [x] `scripts/docs-lint/architecture-tree-whitelist.sh` passes on the current tree
- [x] Three denial fixtures (`notes.txt`, `LAYER-0-VERIFICATION.md`, `diagrams/screenshot.png`) all caught
- [x] Self-test suite: 10/10 (was 8/8)
- [x] English-only, front-matter intact, line budgets respected
- [ ] CI green on this PR
- [ ] CodeRabbit clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a rule requiring new architecture docs file types to be explicitly allowed by the whitelist.

* **Chores**
  * CI now validates the architecture documentation directory against an allow-list to prevent unexpected files.

* **Tests**
  * Added self-tests covering the architecture-file whitelist validator, including edge cases for nested paths and disallowed artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wide-Moat/open-computer-use/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->