### PR TITLE
docs: add Tuning Engines OpenCode route

### DIFF
--- a/docs/cli-config-templates.md
+++ b/docs/cli-config-templates.md
@@ -176,6 +176,40 @@ GATEWAY_TOKEN="<your-token>"
 SUBAGENT_CLI=opencode
 ```
 
+For a governed endpoint such as Tuning Engines, keep the same provider shape
+and point `baseURL` at the Tuning Engines inference API:
+
+```bash
+OPENCODE_CONFIG_EXTRA='{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "tuning-engines": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Tuning Engines",
+      "options": {
+        "baseURL": "https://api.tuningengines.com/v1",
+        "apiKey": "{env:TUNING_ENGINES_API_KEY}"
+      },
+      "models": {
+        "gpt-5.4-mini": { "name": "GPT 5.4 Mini" }
+      }
+    }
+  },
+  "model": "tuning-engines/gpt-5.4-mini"
+}'
+```
+
+Set the matching env var in `.env`:
+
+```bash
+TUNING_ENGINES_API_KEY="<your-tuning-engines-inference-key>"
+SUBAGENT_CLI=opencode
+```
+
+Open Computer Use still owns the sandbox, MCP tools, browser automation, and
+sub-agent runtime. Tuning Engines adds governed model access, tenant policy,
+traces, approvals, and usage visibility behind the OpenAI-compatible route.
+
 ---
 
 ## OpenCode — agent personas


### PR DESCRIPTION
Hi Open Computer Use maintainers, we are an AI infrastructure team using Open Computer Use with governed OpenAI-compatible endpoints. Since the docs already show an OpenCode custom provider for corporate gateways, I added a small Tuning Engines example using the same @ai-sdk/openai-compatible shape.

Open Computer Use still owns the sandbox, MCP tools, browser automation, and sub-agent runtime. Tuning Engines gives teams an optional control plane around model access with tenant policy, traces, approvals, and usage visibility.

It would mean a lot to us if you are open to including this for operators who want a governed endpoint behind OpenCode.

Validation:
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new configuration template example for integrating OpenAI-compatible custom providers with governance-enabled endpoints.
  * Included environment variable setup instructions and explanatory documentation describing provider integration patterns and responsibility boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wide-Moat/open-computer-use/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->