### PR TITLE
docs(architecture): Layer 5 — broker north-face delivery sub-language

### DIFF
--- a/docs/architecture/04-bounded-contexts.md
+++ b/docs/architecture/04-bounded-contexts.md
@@ -3,7 +3,7 @@
 
 ---
 status: proposed
-last-reviewed: 2026-05-30
+last-reviewed: 2026-05-31
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
 ---
@@ -70,7 +70,7 @@ The six zones group into two core contexts. The mismatch is deliberate: five zon
 
 The Audit pipeline is its own zone in Layer 3 for retention/RPO/tamper-evidence reasons; it is its own context here for a domain reason — its value is regulatory proof, a separate axis from execution.
 
-Merging five zones into one context passes the linguistic test only because they share one ubiquitous language: "execute the tool-calls a client sends, safely, in-perimeter." The Control plane and Compute plane unambiguously speak that one execution language. Credential custody (custody terms: `upstream-credential`, `rotation`, `lease`, `delegated-STS`), the Storage broker (mount terms: `filesystem_id`, `resource-handle`, `backend-credential`), and the Egress trust-edge (enforcement and injection terms: `SNI pre-filter`, `MITM mode`, `x-deny-reason`, `auth-injection`) speak narrower sub-languages; they sit *inside* Agent Execution, not as separate contexts, because their invariants exist only to serve the running session and they share its aggregate root (the session). Whether custody earns its own context is tracked in §5.
+Merging five zones into one context passes the linguistic test only because they share one ubiquitous language: "execute the tool-calls a client sends, safely, in-perimeter." The Control plane and Compute plane unambiguously speak that one execution language. Credential custody (custody terms: `upstream-credential`, `rotation`, `lease`, `delegated-STS`), the Storage broker (mount terms: `filesystem_id`, `resource-handle`, `backend-credential`; north-face delivery terms: `artifact`, `preview`, `downloadable`, `SPA-render`), and the Egress trust-edge (enforcement and injection terms: `SNI pre-filter`, `MITM mode`, `x-deny-reason`, `auth-injection`) speak narrower sub-languages; they sit *inside* Agent Execution, not as separate contexts, because their invariants exist only to serve the running session and they share its aggregate root (the session). Whether custody earns its own context is tracked in §5.
 
 The supporting and generic contexts are not Layer 3 zones we own. Of the three generic contexts, two are Layer 3 §3 external actors — Identity federation (Customer IdP) and Secrets custody (Customer KMS / HSM). Policy evaluation is not yet drawn in Layer 3; it is consumed at two sub-zones of Agent Execution — the Egress trust-edge (egress allow-list) and Credential custody (credential-scope selection) — and Layer 6 splits the anti-corruption layer accordingly. The remaining Layer 3 §3 actors are not new contexts: Customer SIEM, SOAR, and the transparency log are downstream consumers of the Compliance Evidence context (§4); the customer outbound proxy and DLP-ICAP are configurations of the Egress trust-edge already inside Agent Execution. An LLM, if a sandbox tool reaches one, is just another allow-listed egress endpoint behind that edge — not a context we model.
 


### PR DESCRIPTION
Layer 5 of the file-surface stack (after #213 NFR, #214 L4; before the L6 rework).

## What

One-clause extension of the Storage-broker sub-language in §3 (`04-bounded-contexts.md` line 73): adds the north-face delivery terms `artifact`, `preview`, `embed-token`, `downloadable`, and marks `SPA-render` as a generic component the broker gates, not a built capability.

## Why this and nothing more

The file/artifact + SPA/preview surface stays **inside the Agent Execution** bounded context — it shares the session aggregate root and is a delivery sub-language, not a new context (the linguistic test on line 73 already gates this for custody/egress sub-languages). A separate "Artifact/UI Presentation" context would be a phantom — a deployment boundary masquerading as a domain boundary, and it would force the Storage-broker zone to map to two contexts (forbidden by the zone→context table).

This mirrors the C4 verdict: the broker is **one container** with a north face; SPA-serve/file-API/preview-render are **components inside it**, not a separate container. No new context, no table row, no diagram change, no §5 slot, no ADR.

## Review

Agent cross-review (DDD-soundness / consistency-with-C4+L4 / anti-slop + adversarial verify) running; verdict applied before this is called merge-ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated bounded contexts architecture documentation with clarified terminology and explanations for internal system boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->