### PR TITLE
docs(architecture): ADR-0003 — sandbox runtime tier ladder

### DIFF
--- a/docs/architecture/adr/0003-sandbox-runtime-tier-ladder.md
+++ b/docs/architecture/adr/0003-sandbox-runtime-tier-ladder.md
@@ -1,0 +1,63 @@
+<!-- SPDX-License-Identifier: FSL-1.1-Apache-2.0 -->
+<!-- Copyright (c) 2025 Open Computer Use Contributors -->
+
+---
+status: proposed
+last-reviewed: 2026-06-01
+owner: "@Wide-Moat/architects"
+applies-to: next/v1
+supersedes: []
+superseded-by: null
+compliance-impact: [EU-AI-Act-Art.15, DORA-Art.28, NIST-SP-800-190]
+license-impact: none
+threat-mitigation-link: ../02-trust-boundaries.md#4-per-tenant-isolation-menu
+---
+
+Fixes the axis that selects the sandbox runtime tier, and which tiers v1 GA ships. Audience: anyone touching the Session sandbox substrate or its admission rules.
+
+# ADR-0003: Sandbox runtime tier ladder
+
+## Status
+
+`proposed`
+
+## Context
+
+The Session sandbox ([component 05](../components/05-session-sandbox.md)) runs agent-issued actions inside an isolation boundary. The strength of that boundary — bare namespaces, a user-space kernel, or hardware virtualization — sets escape resistance, host footprint, and whether a deployment runs from a single `docker-compose up`.
+
+Two axes compete to drive the choice: data classification (stronger tier for more sensitive data) versus workload trust (the tier follows who supplies the prompts the agent executes). §02 and AP-13 already record the split — data classification governs retention, custody, and residency; workload trust governs the tier. The remaining question is the product-level one this ADR closes: which tiers v1 GA ships and which it defers.
+
+The one-click solo install is an NFR-shaping invariant: the default deployment runs single-operator, no IdP, no KVM, and must not pay for a bank's isolation or audit machinery to start.
+
+## Decision
+
+The sandbox runtime tier is selected by the deployment-wide workload-trust profile — `runc` for `trusted_operator`, gVisor/`runsc` for `internal_workforce`, with microVM as the `untrusted` tier deferred post-v1 — and never by data classification (AP-13).
+
+## Consequences
+
+- v1 GA bundles two runtimes and ships three deployable cells; the profile/tier matrix, allowed pairings, and rejected cells live in NFR-SEC-38, enforced at deploy time by the Control / operator API ([component 02](../components/02-control-operator-api.md)). This ADR does not restate them.
+- The `trusted_operator` × `runc` cell preserves the one-click solo install — no KVM, no IdP, zero-config. gVisor is the hardened default for `internal_workforce`.
+- Enterprise audit machinery stays opt-in for the solo default: the local audit-event emit is mandatory in code for every tier (NFR-SEC-45, fail-closed), but the external sinks and alarms that consume it — SIEM-bridge, SOAR webhook, the NFR-SEC-39 tier-downgrade alarm — are off when no such sink is configured. A solo operator reconfiguring their own tier raises a local event and nothing external fires.
+- Per-tier escape resistance and the per-release red-team gate stay governed by NFR-SEC-02; the tier-downgrade alarm by NFR-SEC-39, emitted as `config.trust_profile.downgraded` through the Audit pipeline ([component 07](../components/07-audit-pipeline.md)). This ADR adds no requirement to either.
+- The Session sandbox records this ADR in its `adr:` front-matter; its host-side exec-supervisor and runtime-supervisor model is unchanged, so the tier choice forces no Layer-6 container split.
+- microVM packaging (Firecracker vs Kata, [#161](https://github.com/Wide-Moat/open-computer-use/issues/161)), per-session trust profile ([#162](https://github.com/Wide-Moat/open-computer-use/issues/162)), and the sandbox sub-split ([#174](https://github.com/Wide-Moat/open-computer-use/issues/174)) are downstream seams this ADR names but does not design.
+
+## Alternatives considered
+
+- **microVM-default (E2B-style)** — hardware virtualization for every deployment. Rejected because it requires KVM on the `trusted_operator` path that needs no hardware boundary, breaking the one-click solo invariant.
+- **gVisor-only floor** — drop `runc`, run `runsc` everywhere. Rejected because it removes zero-config `runc` from the `trusted_operator` path and pays user-space-kernel overhead where the workload-trust profile does not call for it.
+- **Tier by data classification** — pick the tier from the data the agent touches. Rejected by AP-13: the container-escape surface for adversarial agent-issued code is identical regardless of data class.
+
+## Compliance impact
+
+- `EU-AI-Act-Art.15` (4)/(5): the tier ladder is the agent-execution boundary's cybersecurity measure under the Article's accuracy-and-cybersecurity requirement for high-risk systems; per-tier red-team evidence lands via NFR-SEC-02.
+- `DORA-Art.28` (4): the active runtime substrate per deployment is declared at deploy and auditable, so it is recordable in the ITS register of information.
+- `NIST-SP-800-190` §3: workload separation is realized through each tier's isolation primitives (`runc` namespaces, gVisor user-space kernel, microVM hardware boundary) — cited for the primitives, not for the selection axis.
+
+## License impact
+
+This is the adopting ADR for `runc` and gVisor, so both enter the Bill of Materials in [`manifesto/05-licensing-posture.md`](../manifesto/05-licensing-posture.md) as bundled (Apache-2.0; gVisor carries per-file MIT/BSD). Both clear the licence gate. Firecracker and Kata clear the same gate but are not bundled in v1; they enter the Bill of Materials when the microVM tier lands ([#161](https://github.com/Wide-Moat/open-computer-use/issues/161)).
+
+## Threat mitigation
+
+The multi-tenant agent-execution invariant in [`02-trust-boundaries.md`](../02-trust-boundaries.md#4-per-tenant-isolation-menu) §4 forbids bare `runc` for multi-tenant execution and requires a user-space kernel or hardware virtualization; the tier ladder is how a deployment satisfies it. Per-tier escape resistance — seccomp BPF, Landlock, cap-drop ALL, read-only rootfs, and the zero-pass red-team gate — is held by NFR-SEC-02.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -19,6 +19,7 @@ Architecture Decision Records. One file per decision. ADRs appear on demand foll
 | Number | Title | Status | Supersedes | Last-reviewed |
 |---|---|---|---|---|
 | [0001](0001-layer-0-gate-legacy-exclusion.md) | Layer 0 gate — legacy exclusion | accepted | — | 2026-05-24 |
+| [0003](0003-sandbox-runtime-tier-ladder.md) | Sandbox runtime tier ladder | proposed | — | 2026-06-01 |
 
 ## Lifecycle
 

--- a/docs/architecture/components/00-overview.md
+++ b/docs/architecture/components/00-overview.md
@@ -37,7 +37,7 @@ The guest agent is the process that constitutes the Session sandbox container ([
 All seven are at `draft`. The ones a contract or a pending decision already pins harden to `proposed`/`accepted` first, because their spec has the least free design left and the most to verify against:
 
 1. **Storage broker** — three contracts and seven NFR anchors already fix its surface; the spec records the two-face component split and the per-tenant instantiation question ([#175](https://github.com/Wide-Moat/open-computer-use/issues/175)).
-2. **Session sandbox** — the exec-channel contract fixes its machine edge; the runtime-tier-by-`workload_trust_profile` decision is ADR-bearing and the sub-container split is open ([#174](https://github.com/Wide-Moat/open-computer-use/issues/174)).
+2. **Session sandbox** — the exec-channel contract fixes its machine edge; the runtime-tier-by-`workload_trust_profile` decision is fixed by [ADR-0003](../adr/0003-sandbox-runtime-tier-ladder.md) and the sub-container split is open ([#174](https://github.com/Wide-Moat/open-computer-use/issues/174)).
 3. **Egress trust-edge** — no built contract yet, but the deny-reason and MITM-mode behaviour are NFR-anchored and cross the broker and custody boundaries.
 
 The other four reach `accepted` once these three settle their shared invariants and the ADRs their `adr:` keys await (runtime tier, operator-auth, object-store engine) land.

--- a/docs/architecture/components/05-session-sandbox.md
+++ b/docs/architecture/components/05-session-sandbox.md
@@ -9,7 +9,7 @@ applies-to: next/v1
 compliance: []
 threat-model: 06-threat-model.md
 contract: contracts/exec/exec-channel.schema.json
-adr: []
+adr: [0003]
 ---
 
 Internal design of the per-session execution container, for engineers implementing and auditing the guest agent and its host-side edges. The guest agent is the process that constitutes this container ([`05-c4-container.md`](../05-c4-container.md) §3): it is PID 1 and dies with the session.

--- a/docs/architecture/manifesto/05-licensing-posture.md
+++ b/docs/architecture/manifesto/05-licensing-posture.md
@@ -37,7 +37,12 @@ Each accepted dependency is recorded as bundled or not-bundled when an ADR or co
 - **Bundled** — OCU ships the binary, image, or library as part of a release. OCU owns its CVE response, version pinning, vulnerability scanning, and SBOM entry.
 - **Not bundled** — the customer provides it over a standard API (for example an IdP, a secret store, a SIEM, or a customer KMS). OCU documents the integration contract; the customer owns the lifecycle.
 
-The Bill of Materials is the table of accepted dependencies with this flag. It is not pre-populated: a row is added when the ADR or component spec that adopts a dependency lands, so the bundled/not-bundled call is made with the rationale that needs it, not in advance. Until the first such ADR lands, the only firm entries are the rejections below.
+The Bill of Materials is the table of accepted dependencies with this flag. It is not pre-populated: a row is added when the ADR or component spec that adopts a dependency lands, so the bundled/not-bundled call is made with the rationale that needs it, not in advance.
+
+| Dependency | Licence | Bundled | Adopted by |
+|---|---|---|---|
+| runc | Apache-2.0 | bundled | [ADR-0003](../adr/0003-sandbox-runtime-tier-ladder.md) |
+| gVisor (`runsc`) | Apache-2.0 (per-file MIT/BSD) | bundled | [ADR-0003](../adr/0003-sandbox-runtime-tier-ladder.md) |
 
 ## Rejected dependencies
 


### PR DESCRIPTION
## What

First substantive component-tech ADR on `next/v1`. Fixes the axis that selects the sandbox runtime tier and which tiers v1 GA ships.

**Decision:** tier is selected by the deployment-wide `workload_trust_profile` — `runc` for `trusted_operator`, gVisor/`runsc` for `internal_workforce`, microVM deferred post-v1 (#161) — and never by data classification (AP-13).

## Lean scope

The ADR **ratifies** the workload-trust axis the §02 NFRs already encode (NFR-SEC-02/38/39, AP-13, the §02 sandbox-tier table) and **references** them rather than restating — its new content is the v1/post-v1 cut and the closed debate (microVM-default vs gVisor-floor).

## Solo / enterprise split

The `trusted_operator` × `runc` cell preserves one-click solo (no KVM, no IdP, zero-config). Enterprise audit machinery stays opt-in for the solo default: the **local audit-event emit is mandatory in code** for every tier (NFR-SEC-45, fail-closed), but the **external sinks and alarms** that consume it — SIEM-bridge, SOAR webhook, the NFR-SEC-39 tier-downgrade alarm — are off when no such sink is configured.

## Files

- `adr/0003-sandbox-runtime-tier-ladder.md` (new, 63 lines, ≤200 budget)
- `manifesto/05-licensing-posture.md` — first Bill-of-Materials rows: runc + gVisor (Apache-2.0, bundled), adopted by this ADR
- `components/05-session-sandbox.md` — `adr:[0003]`
- `components/00-overview.md` + `adr/README.md` — links/index

## Process

Drafted via a draft→skeptic→anti-slop pipeline; applied by hand. Scope-skeptic verdict `minor-edits` (no over-engineering, one-click preserved); 2 real fixes applied — corrected a broken trust-boundaries anchor and rewrote License-impact to **add** the BoM rows rather than claim pre-existing membership. microVM packaging (#161), per-session profile (#162), sub-split (#174) named as deferred seams. Local gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ADR-0003 defining the sandbox runtime tier ladder and deployment implications for v1.
  * Updated ADR index and component docs to reference ADR-0003 for session sandbox maturation.
  * Added a Bill of Materials and clarified licensing/bundling posture for accepted runtimes (runc, gVisor/runsc) and dependency gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->