### PR TITLE
docs(architecture): ADR-0006 — egress forward-proxy substrate

### DIFF
--- a/docs/architecture/adr/0006-egress-forward-proxy-substrate.md
+++ b/docs/architecture/adr/0006-egress-forward-proxy-substrate.md
@@ -47,7 +47,7 @@ The Egress trust-edge runs an Apache-2.0/MIT/BSD forward proxy — Envoy is the 
 
 - **Squid (GPL-2.0+)** — mature forward proxy with SslBump for the later MITM leg; clears the allow-list, but a bundled GPL binary triggers the distribution review noted in [`manifesto/05-licensing-posture.md`](../manifesto/05-licensing-posture.md), and its config model fits the deny-by-default floor less directly than Envoy's filter chain.
 - **HAProxy (GPL-2.0+ / LGPL)** — passes the allow-list and handles SNI routing, but bundling carries the same GPL distribution review and it lacks a first-class external-authorization seam equivalent to `ext_authz`.
-- **Hand-rolled CONNECT proxy** — a minimal Go/Rust proxy owned end to end. Rejected: re-implementing resolver pinning, filter chains, and an `ext_authz` seam is net-new attack surface a bank InfoSec review would not credit against a vendor-backed proxy.
+- **Hand-rolled CONNECT proxy** — a minimal Go/Rust proxy owned end to end. Rejected: re-implementing resolver pinning, filter chains, and an `ext_authz` seam is net-new attack surface a regulated-enterprise InfoSec review would not credit against a vendor-backed proxy.
 
 ## Compliance impact
 

--- a/docs/architecture/adr/0006-egress-forward-proxy-substrate.md
+++ b/docs/architecture/adr/0006-egress-forward-proxy-substrate.md
@@ -1,0 +1,65 @@
+<!-- SPDX-License-Identifier: FSL-1.1-Apache-2.0 -->
+<!-- Copyright (c) 2025 Open Computer Use Contributors -->
+
+---
+status: proposed
+last-reviewed: 2026-06-01
+owner: "@Wide-Moat/architects"
+applies-to: next/v1
+supersedes: []
+superseded-by: null
+compliance-impact: [SOC2-CC6.6, SOC2-CC6.7, NYDFS-500.15, DORA-Art.9, EU-AI-Act-Art.12]
+license-impact: Envoy Apache-2.0; clears the allow-list, bundled by this ADR
+threat-mitigation-link: ../components/06-egress-trust-edge.md
+---
+
+Picks the forward-proxy substrate for the Egress trust-edge and scopes it to the v1 deny-by-default floor. Audience: anyone wiring or auditing the sandbox's outbound path.
+
+# ADR-0006: Egress forward-proxy substrate
+
+## Status
+
+`proposed`
+
+## Context
+
+The Egress trust-edge ([component 06](../components/06-egress-trust-edge.md)) is the sandbox's sole outbound network path. v1 ships one capability there: a deny-by-default destination allow-list applied at connect time on resolved-IP and SNI, with a machine-parseable reason on every block. That floor must run from a single `docker-compose up` with no certificate authority, no IdP, and no policy engine — the one-click solo install is an NFR-shaping invariant.
+
+The component spec carries no substrate decision (`adr: []`) and an open question on which proxy provides it (open-Q#2). A purpose-built forward proxy supplies connect-time allow-listing, a controllable resolver, and an external-authorization seam. The risk is over-buying: pulling in TLS termination, dynamic config distribution, or an inline content-inspection path that the v1 floor does not need and that would tax the solo default.
+
+MITM termination — per-SNI on-the-fly leaf certificates — is a separate, deferred decision (component 06 open question #2, the MITM-termination half) and is not in scope here.
+
+## Decision
+
+The Egress trust-edge runs an Apache-2.0/MIT/BSD forward proxy — Envoy is the lead candidate (Apache-2.0, native connect-time SNI/resolved-IP filtering and an `ext_authz`/`ext_proc` seam), with the final binary left to the component spec — configured to the v1 floor only: a deny-by-default allow-list at connect time on resolved-IP + SNI, a proxy-owned resolver carrying the mandatory deny-set, a machine-parseable `x-deny-reason` on block, one external-authorization seam whose default backend is a static allow-list, and a per-upstream-leg credential-origination hook.
+
+## Consequences
+
+- Component 06 records this ADR in its `adr:` front-matter (`[]` → `[0006]`). The allow-list at connect time satisfies NFR-SEC-08 and NFR-SEC-17; the proxy-owned resolver enforces NFR-SEC-12's mandatory deny-set; the structured block carries the `x-deny-reason` vocabulary the spec already defines. This ADR does not restate those NFRs.
+- The `ext_authz`/`ext_proc` seam ships with a static allow-list as its default backend — the solo path configures no policy engine. OPA as a full-shelf backend behind the same seam is deferred, not v1.
+- The credential-origination hook is the seam where the edge attaches the upstream authorization received over Envoy SDS ([ADR-0005](0005-egress-credential-delivery-envoy-sds.md)); it fires only on a leg that needs it, never on the transparent default route. No CA, cert-issuer, ICAP, or credential wiring lands on the transparent path.
+- The broker backend leg ([component 04](../components/04-storage-broker.md), F10) traverses the proxy as one allow-list destination with no TLS termination, so the broker-signed request is forwarded byte-intact per NFR-SEC-25.
+- Every allow and every deny is emitted as an OCSF event through the Audit pipeline ([component 07](../components/07-audit-pipeline.md)); the payload-independent exfil tripwire (NFR-SEC-57) runs on this path with no CA. This ADR adds no requirement to either.
+- The egress posture stays mode-selectable per NFR-FLEX-15: this ADR fixes the transparent default; MITM-mode origination (NFR-SEC-30, NFR-SEC-37, NFR-SEC-50) and DLP/ICAP as a MITM config (NFR-COMP-28) ride the same substrate but are decided in the deferred MITM-termination ADR (component 06 open question #2).
+- xDS dynamic config and per-node sharding ([#175](https://github.com/Wide-Moat/open-computer-use/issues/175)) are deferred seams this ADR names but does not design.
+
+## Alternatives considered
+
+- **Squid (GPL-2.0+)** — mature forward proxy with SslBump for the later MITM leg; clears the allow-list, but a bundled GPL binary triggers the distribution review noted in [`manifesto/05-licensing-posture.md`](../manifesto/05-licensing-posture.md), and its config model fits the deny-by-default floor less directly than Envoy's filter chain.
+- **HAProxy (GPL-2.0+ / LGPL)** — passes the allow-list and handles SNI routing, but bundling carries the same GPL distribution review and it lacks a first-class external-authorization seam equivalent to `ext_authz`.
+- **Hand-rolled CONNECT proxy** — a minimal Go/Rust proxy owned end to end. Rejected: re-implementing resolver pinning, filter chains, and an `ext_authz` seam is net-new attack surface a bank InfoSec review would not credit against a vendor-backed proxy.
+
+## Compliance impact
+
+- `SOC2-CC6.6` / `SOC2-CC6.7`: the deny-by-default allow-list and structured deny reason are the boundary-protection and transmission controls for outbound flows.
+- `NYDFS-500.15`: outbound destinations are gated and logged, supporting the access-and-monitoring controls.
+- `DORA-Art.9`: the edge is the network-segmentation and traffic-control measure for the sandbox's outbound leg, recordable per deployment.
+- `EU-AI-Act-Art.12`: allow/deny events emitted to the Audit pipeline contribute to the automatic record-keeping required of high-risk systems.
+
+## License impact
+
+This is the adopting ADR for the forward proxy: Envoy enters the Bill of Materials in [`manifesto/05-licensing-posture.md`](../manifesto/05-licensing-posture.md) as bundled (Apache-2.0), clearing the licence gate. The Squid and HAProxy alternatives clear the same gate, but a bundled GPL binary triggers the distribution review that file records; neither is bundled by this ADR.
+
+## Threat mitigation
+
+The deny-by-default floor is the v1 realization of the egress controls in [`06-egress-trust-edge.md`](../components/06-egress-trust-edge.md) (P6 rows): connect-time allow-listing on resolved-IP + SNI, the proxy-owned resolver's mandatory deny-set, and the payload-independent exfil tripwire (NFR-SEC-57) that runs in both postures without a CA. The credential-origination hook keeps the upstream authorization off the guest, attached over Envoy SDS ([ADR-0005](0005-egress-credential-delivery-envoy-sds.md)) only on the leg that needs it.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -23,6 +23,7 @@ Architecture Decision Records. One file per decision. ADRs appear on demand foll
 | [0003](0003-sandbox-runtime-tier-ladder.md) | Sandbox runtime tier ladder | proposed | — | 2026-06-01 |
 | [0004](0004-operator-authentication-substrate.md) | Operator authentication substrate | proposed | — | 2026-06-01 |
 | [0005](0005-egress-credential-delivery-envoy-sds.md) | Egress credential delivery is off-the-shelf Envoy SDS | proposed | — | 2026-06-01 |
+| [0006](0006-egress-forward-proxy-substrate.md) | Egress forward-proxy substrate | proposed | — | 2026-06-01 |
 
 ## Lifecycle
 

--- a/docs/architecture/components/06-egress-trust-edge.md
+++ b/docs/architecture/components/06-egress-trust-edge.md
@@ -9,7 +9,7 @@ applies-to: next/v1
 compliance: []
 threat-model: 06-threat-model.md
 contract: null
-adr: [0005]
+adr: [0005, 0006]
 ---
 
 The sandbox's sole outbound network path: it enforces a deny-by-default destination allow-list, emits a structured deny reason, and on the legs that need it attaches the upstream authorization received over Envoy SDS so the guest sends an unauthenticated request. Audience: engineers and security reviewers wiring or auditing egress policy.
@@ -83,12 +83,12 @@ Residual, by [`06-threat-model.md`](../06-threat-model.md) §5 register: the tra
 
 **Rotation / lifecycle.** The edge receives the credential from SDS per-connection and drops it after use; rotation belongs to the SDS source, not the edge ([NFR-SEC-04](../manifesto/02-nfrs.md)). On sandbox teardown the host-driven finalizer drops the network-bound egress route host-side even if the guest is unresponsive ([NFR-SEC-65](../manifesto/02-nfrs.md)).
 
-**Shelf delta** ([`05-c4-container.md`](../05-c4-container.md) §5): the minimal shelf runs transparent pass-through (static-file SDS source, one-click solo path) and cannot inject; the full shelf adds opt-in MITM-inspecting mode with a customer CA in the sandbox trust store and a customer-provided SDS source, attaching an upstream credential on the edge-originated leg. The boundary properties in the Invariants section hold on both shelves; the SDS source and the TLS-termination capability change with the mode. Envoy is the forward-proxy substrate ([ADR-0005](../adr/0005-egress-credential-delivery-envoy-sds.md)); the MITM-termination substrate is a future ADR — `needs ADR:` (see Open questions).
+**Shelf delta** ([`05-c4-container.md`](../05-c4-container.md) §5): the minimal shelf runs transparent pass-through (static-file SDS source, one-click solo path) and cannot inject; the full shelf adds opt-in MITM-inspecting mode with a customer CA in the sandbox trust store and a customer-provided SDS source, attaching an upstream credential on the edge-originated leg. The boundary properties in the Invariants section hold on both shelves; the SDS source and the TLS-termination capability change with the mode. Envoy is the forward-proxy substrate ([ADR-0006](../adr/0006-egress-forward-proxy-substrate.md)); the MITM-termination substrate is a future ADR — `needs ADR:` (see Open questions).
 
 ## Open questions
 
 1. Envoy's `credential_injector` filter and its OAuth2 extension carry an upstream maturity caveat — not substantial production burn-in, an unknown security posture, intended for trusted-on-both-ends paths — while a third-party LLM API is an untrusted upstream. The regulated-tier posture for this filter is deferred pending a security review — needs issue.
-2. MITM-termination technology is undecided — needs ADR: record the termination substrate (role named here only, never decided in prose), coupled to [NFR-FLEX-15](../manifesto/02-nfrs.md) / [NFR-COMP-28](../manifesto/02-nfrs.md).
+2. The forward-proxy substrate is fixed by [ADR-0006](../adr/0006-egress-forward-proxy-substrate.md); MITM-termination technology (per-SNI on-the-fly leaf-cert generation) remains undecided — needs ADR, coupled to [NFR-FLEX-15](../manifesto/02-nfrs.md) / [NFR-COMP-28](../manifesto/02-nfrs.md).
 3. SNI/Host consistency on the transparent (non-inspected) leg, where the SNI pre-filter alone misses domain-fronting — [#198](https://github.com/Wide-Moat/open-computer-use/issues/198).
 4. No-credential-in-response stripping, edge-binary/config attestation, and plaintext-zeroization for the MITM mode lack an explicit NFR — [#197](https://github.com/Wide-Moat/open-computer-use/issues/197).
 5. mTLS / cert-pin / DPoP upstreams the edge cannot serve by injection, and the guest-resident-key schemes declared unsupported — [#176](https://github.com/Wide-Moat/open-computer-use/issues/176).

--- a/docs/architecture/manifesto/05-licensing-posture.md
+++ b/docs/architecture/manifesto/05-licensing-posture.md
@@ -43,7 +43,7 @@ The Bill of Materials is the table of accepted dependencies with this flag. It i
 |---|---|---|---|
 | runc | Apache-2.0 | bundled | [ADR-0003](../adr/0003-sandbox-runtime-tier-ladder.md) |
 | gVisor (`runsc`) | Apache-2.0 (per-file MIT/BSD) | bundled | [ADR-0003](../adr/0003-sandbox-runtime-tier-ladder.md) |
-| Envoy | Apache-2.0 | bundled | [ADR-0005](../adr/0005-egress-credential-delivery-envoy-sds.md) |
+| Envoy | Apache-2.0 | bundled | [ADR-0005](../adr/0005-egress-credential-delivery-envoy-sds.md), [ADR-0006](../adr/0006-egress-forward-proxy-substrate.md) |
 
 ## Rejected dependencies
 


### PR DESCRIPTION
Third L9 substrate ADR. Closes the forward-proxy half of egress open-Q#2 (the MITM-termination half stays a separate deferred ADR).

**Decision:** one Apache-2.0/MIT/BSD forward proxy (Envoy lead candidate) at the v1 **deny-by-default floor only** — allow-list at connect on resolved-IP+SNI (NFR-SEC-08/17), proxy-owned resolver with the NFR-SEC-12 deny-set, machine-parseable `x-deny-reason`, one `ext_authz`/`ext_proc` seam (static allow-list default, OPA deferred to full-shelf), and a per-upstream-leg credential-origination hook.

**Cut by the scope-skeptic ('trim'):** no CA / cert-issuer / SDS sidecar / ICAP / xDS / custody-lease wiring on the transparent default path. Corrected the factual error that 'Envoy has native ICAP' (it does not). MITM-termination (per-SNI leaf-cert) is its own deferred ADR. NFR-SEC-50 already decides the mTLS/cert-pin/DPoP re-origination (#176).

**Audit-optionality:** transparent default needs no CA; the NFR-SEC-57 exfil tripwire runs in both postures without one.

License: Envoy Apache-2.0, added to the §05 BoM as bundled. Squid/HAProxy GPL alternatives pass the allow-list but a bundled GPL binary triggers distribution review; neither bundled. Drafted via draft→skeptic→anti-slop; fixes applied by hand (#197/#198 mis-citation removed → open-Q#2).

> Note: this PR and #224 (ADR-0003) both add a row to the §05 Bill of Materials table and touch the same intro line — they will need a trivial merge-order reconcile (both rows kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new architecture decision record specifying the forward-proxy substrate for egress trust-edge implementation with defined scoping and constraints.
  * Updated architecture documentation and dependency tables to reference and align with the new decision record.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->