### PR TITLE
docs(architecture): resolve custody/broker cardinality inline — single-box v1 (#175)

### DIFF
--- a/docs/architecture/05-c4-container.md
+++ b/docs/architecture/05-c4-container.md
@@ -88,4 +88,4 @@ Two seams diverge from the field by design, for an in-perimeter regulated buyer 
 ## 7. Open questions
 
 1. Does the Session sandbox warrant a sub-container split once the workload-trust tier and guest-agent protocol are specified, or stay one container with internal components? — [#174](https://github.com/Wide-Moat/open-computer-use/issues/174).
-2. Is Credential custody (and the Storage broker) one container per deployment or one per sandbox host, and does the answer change the diagram? — [#175](https://github.com/Wide-Moat/open-computer-use/issues/175).
+2. Credential custody and the Storage broker are one container per deployment in v1 with no diagram change; the per-sandbox-host split ([1..N] behind sharding) is deferred ([#175](https://github.com/Wide-Moat/open-computer-use/issues/175)).

--- a/docs/architecture/components/03-credential-custody.md
+++ b/docs/architecture/components/03-credential-custody.md
@@ -81,7 +81,7 @@ Config surface: the upstream-resource catalogue (which bucket prefixes / API-key
 
 Observability and audit: custody emits OCSF on the fan-in flow `F11` for every lease mint, rotate, scope-change, and revoke — system-initiated issues under [NFR-SEC-72](../manifesto/02-nfrs.md), operator-forced actions under [NFR-SEC-45](../manifesto/02-nfrs.md) — written via the durable bus on the critical path ([NFR-REL-12](../manifesto/02-nfrs.md)) into the hash-chained store under the retention floor ([NFR-COMP-01](../manifesto/02-nfrs.md)). The lease-issue event is a host-authored record; it is not the NFR-SEC-47 out-of-band evidence set for in-sandbox actions, which is the audit pipeline's concern.
 
-Scaling axis: per-deployment or per-sandbox-host, open at [#175](https://github.com/Wide-Moat/open-computer-use/issues/175), which also decides whether the container diagram changes. Capacity is bounded by lease-issuance rate; the lease issuer never buffers a root in a returnable response. No REL NFR pins a custody RTO/RPO; the accepted gap is recorded in Open questions rather than invented here.
+Scaling axis: one instance per deployment in v1; a per-sandbox-host split ([1..N] behind sharding) is deferred ([#175](https://github.com/Wide-Moat/open-computer-use/issues/175)) and does not change the v1 container diagram. Capacity is bounded by lease-issuance rate; the lease issuer never buffers a root in a returnable response. No REL NFR pins a custody RTO/RPO; the accepted gap is recorded in Open questions rather than invented here.
 
 Rotation discipline: rotating the root is custody-internal and does not invalidate in-flight leases — those self-expire and revoke per the TTL and audit invariants above; the one new fact is that root rotation is independent of live-lease validity.
 
@@ -89,7 +89,7 @@ Shelf delta from [`05-c4-container.md`](../05-c4-container.md) §5: minimal shel
 
 ## Open questions
 
-1. One custody per deployment or one per sandbox host, and does the answer change the container diagram? — [#175](https://github.com/Wide-Moat/open-computer-use/issues/175).
+1. v1 is one custody per deployment with no diagram change; the per-sandbox-host split is deferred behind sharding ([#175](https://github.com/Wide-Moat/open-computer-use/issues/175)).
 2. Does Credential custody collapse into a generic Secrets-custody context, and the build-vs-buy call for the secret store / delegated-STS issuer? — [#169](https://github.com/Wide-Moat/open-computer-use/issues/169).
 3. Minimum lease scope per tool/action below resource-class (least-privilege) — [#187](https://github.com/Wide-Moat/open-computer-use/issues/187).
 4. Custody-side credential class and lease discipline for mTLS / cert-pin / DPoP upstreams the edge re-originates — [#176](https://github.com/Wide-Moat/open-computer-use/issues/176).

--- a/docs/architecture/components/04-storage-broker.md
+++ b/docs/architecture/components/04-storage-broker.md
@@ -92,13 +92,13 @@ Config surface: the `filesystem_id`→prefix map, the north-face ingress binding
 
 The container emits OCSF on the audit fan-in flow F11, fail-closed, per the audit contract ([`audit-fanin`](../../../contracts/audit/audit-fanin.asyncapi.yaml)) and NFR-SEC-03 / NFR-SEC-79 — both faces author the same File System Activity event class.
 
-Scaling axis: per-tenant instantiation (NFR-SEC-76) — one broker principal per tenant filesystem scope. Whether that principal is also per-sandbox-host or per-deployment, and whether that changes the container diagram, is open ([#175](https://github.com/Wide-Moat/open-computer-use/issues/175)). Capacity is bounded by the per-session file-op and inbound-byte ceilings (NFR-SEC-46, NFR-SEC-78); a one-per-host broker serving many sessions is a shared DoS surface, which is why those ceilings are per-session, not per-broker.
+Scaling axis: per-tenant instantiation (NFR-SEC-76) — one broker principal per tenant filesystem scope. In v1 that principal is one per deployment with no diagram change; a per-sandbox-host split ([1..N] behind sharding) is deferred ([#175](https://github.com/Wide-Moat/open-computer-use/issues/175)). Capacity is bounded by the per-session file-op and inbound-byte ceilings (NFR-SEC-46, NFR-SEC-78); a one-per-host broker serving many sessions is a shared DoS surface, which is why those ceilings are per-session, not per-broker.
 
 Shelf delta (from [`05-c4-container.md`](../05-c4-container.md) §5): the minimal shelf holds a host-local backend credential, admitted only under `workload_trust_profile = trusted_operator` and single-tenant (NFR-SEC-60); the full shelf uses a customer-PKI workload identity with STS scoped per session (NFR-SEC-25). All invariants hold on both shelves; only the credential substrate and its blast radius (P4-S2 / P4-I1 residual) change. The runtime tier that hosts the broker and the build-vs-buy of the object-store engine are deferred (`needs ADR:` object-store engine selection; `needs ADR:` broker runtime tier); this spec records the two-face split and the cardinality question, it picks no engine or tier.
 
 ## Open questions
 
-1. Is the broker one instance per deployment or one per sandbox host, and does the answer change the container diagram? — [#175](https://github.com/Wide-Moat/open-computer-use/issues/175).
+1. v1 is one broker per deployment with no diagram change; the per-sandbox-host split is deferred behind sharding ([#175](https://github.com/Wide-Moat/open-computer-use/issues/175)).
 2. Does the broker file-operation contract stay distinct from any object-store API at every shelf, and where is that boundary asserted? — [#208](https://github.com/Wide-Moat/open-computer-use/issues/208).
 3. Embed-token replay-binding (`jti`/nonce single-use or token↔channel binding) within the `exp` window — [#217](https://github.com/Wide-Moat/open-computer-use/issues/217).
 4. Preview-render parser isolation for untrusted artifact bodies on the north face — [#218](https://github.com/Wide-Moat/open-computer-use/issues/218).


### PR DESCRIPTION
Resolves the custody/broker deployment-cardinality question (#175) — the L9 scope-skeptic verdict was that this is **not an ADR**: it is a per-component scaling detail (content-routing step 4), and the v1 decision *defers* a split rather than adding structure.

**Resolution:** v1 runs one custody and one broker per deployment, no container-diagram change. The per-sandbox-host split ([1..N] behind sharding) is deferred. Updates the §Scaling axis + open-question lines in components 03 and 04 and the 05-c4-container open question; #175 stays open as the deferred-sharding tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)