### PR TITLE
docs(architecture): pre-ADR-0009 cleanup — issue links, ADR-0002 binding, index drift

### DIFF
--- a/docs/architecture/components/00-overview.md
+++ b/docs/architecture/components/00-overview.md
@@ -3,7 +3,7 @@
 
 ---
 status: draft
-last-reviewed: 2026-05-31
+last-reviewed: 2026-06-03
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
 ---
@@ -18,15 +18,15 @@ A spec is added per [PROCESS.md](../PROCESS.md): open an issue, create `componen
 
 ## 2. Container specs
 
-Each row links the container's responsibility (Layer 6) and lists the spec file, its current status, and the ADRs and contracts that already bind it. `—` for a spec status means the file does not exist yet; opening it is its own PR.
+Each row links the container's responsibility (Layer 6) and lists the spec file, its current status, and the ADRs and contracts that already bind it. `—` in the Bound ADRs column means no ADR binds the container yet; opening one is its own PR. `NN` is the container row identifier — there is no `03`, the set is the six containers of [`05-c4-container.md`](../05-c4-container.md) §3, and the number does not track a trust zone (the Session sandbox is container 05, trust zone 3).
 
 | NN | Container | Spec | Status | Bound ADRs | Bound contracts |
 |---|---|---|---|---|---|
 | 01 | MCP gateway (agent-facing) | [`01-mcp-gateway.md`](01-mcp-gateway.md) | draft | — | [`mcp/ocu-constraints`](../../../contracts/mcp/2025-06-18/ocu-constraints.schema.json) |
 | 02 | Control / operator API | [`02-control-operator-api.md`](02-control-operator-api.md) | draft | [0004](../adr/0004-operator-authentication-substrate.md) | — |
-| 04 | Storage broker | [`04-storage-broker.md`](04-storage-broker.md) | draft | — | [`storage/mount-config`](../../../contracts/storage/mount-config.schema.json), [`storage/file-ops`](../../../contracts/storage/file-ops.schema.json), [`storage/file-artifact-api`](../../../contracts/storage/file-artifact-api.schema.json) |
-| 05 | Session sandbox `[1..N]` | [`05-session-sandbox.md`](05-session-sandbox.md) | draft | — | [`exec/exec-channel`](../../../contracts/exec/exec-channel.schema.json) |
-| 06 | Egress trust-edge proxy | [`06-egress-trust-edge.md`](06-egress-trust-edge.md) | draft | [0005](../adr/0005-egress-credential-delivery-envoy-sds.md), [0006](../adr/0006-egress-forward-proxy-substrate.md), [0007](../adr/0007-egress-auth-mechanism.md) | — |
+| 04 | Storage broker | [`04-storage-broker.md`](04-storage-broker.md) | draft | [0002](../adr/0002-session-view-descriptor.md) | [`storage/mount-config`](../../../contracts/storage/mount-config.schema.json), [`storage/file-ops`](../../../contracts/storage/file-ops.schema.json), [`storage/file-artifact-api`](../../../contracts/storage/file-artifact-api.schema.json) |
+| 05 | Session sandbox `[1..N]` | [`05-session-sandbox.md`](05-session-sandbox.md) | draft | [0003](../adr/0003-sandbox-runtime-tier-ladder.md) | [`exec/exec-channel`](../../../contracts/exec/exec-channel.schema.json) |
+| 06 | Egress trust-edge proxy | [`06-egress-trust-edge.md`](06-egress-trust-edge.md) | draft | [0005](../adr/0005-egress-credential-delivery-envoy-sds.md), [0006](../adr/0006-egress-forward-proxy-substrate.md), [0007](../adr/0007-egress-auth-mechanism.md), [0008](../adr/0008-session-egress-attribution.md) | — |
 | 07 | Audit pipeline | [`07-audit-pipeline.md`](07-audit-pipeline.md) | draft | — | [`audit/audit-fanin`](../../../contracts/audit/audit-fanin.asyncapi.yaml) |
 
 The guest agent is the process that constitutes the Session sandbox container ([`05-c4-container.md`](../05-c4-container.md) §3), not a separate row; its protocol is specified inside `05-session-sandbox.md`.

--- a/docs/architecture/components/01-mcp-gateway.md
+++ b/docs/architecture/components/01-mcp-gateway.md
@@ -3,7 +3,7 @@
 
 ---
 status: draft
-last-reviewed: 2026-05-31
+last-reviewed: 2026-06-03
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
 compliance: []
@@ -77,4 +77,4 @@ Shelf delta ([`05-c4-container.md`](../05-c4-container.md) §5): the minimal she
 1. Does NFR-IC-04 bind only the Control/operator API and internal RPC, leaving the MCP edge governed solely by date-revision negotiation, or does it need an explicit MCP-edge clause? — [#207](https://github.com/Wide-Moat/open-computer-use/issues/207).
 2. Per-action / per-tool authorization at the gateway (deny-by-default keyed on caller, tool name, action parameters) — [#187](https://github.com/Wide-Moat/open-computer-use/issues/187).
 3. Outbound error/discovery identifier-minimization and size-bound enforcement at the gateway decoder — [#149](https://github.com/Wide-Moat/open-computer-use/issues/149).
-4. Whether the per-session sequential-execution serializer (the NFR-IC-05 carrier, today a gateway behaviour with no wire field) needs its own versioned conformance fixture so opt-in parallelism is testable independently of the MCP profile — needs issue: gateway-side serializer test surface.
+4. Whether the per-session sequential-execution serializer (the NFR-IC-05 carrier, today a gateway behaviour with no wire field) needs its own versioned conformance fixture so opt-in parallelism is testable independently of the MCP profile ([#239](https://github.com/Wide-Moat/open-computer-use/issues/239)).

--- a/docs/architecture/components/04-storage-broker.md
+++ b/docs/architecture/components/04-storage-broker.md
@@ -3,13 +3,13 @@
 
 ---
 status: draft
-last-reviewed: 2026-05-31
+last-reviewed: 2026-06-03
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
 compliance: []
 threat-model: 06-threat-model.md
 contract: [contracts/storage/mount-config.schema.json, contracts/storage/file-ops.schema.json, contracts/storage/file-artifact-api.schema.json]
-adr: []
+adr: [0002]
 ---
 
 The host-side object-store client that custodies the backend credential and resolves file authorization for the guest mount and an external data-plane client, so neither holds a backend key. Audience: engineers and security reviewers implementing or auditing the storage surface.
@@ -35,7 +35,7 @@ flowchart LR
     AUTHZ --> OSC
 ```
 
-The south-face mount adapter terminates the `filesystem_id`-scoped file-operation interface from the guest; the north-face component terminates the file/artifact API plus the authenticated SPA and the preview-render path. Both call one authz resolver, which calls one object-store client — the sole component that speaks the backend protocol and signs every backend request. The substrate under the mount (FUSE / virtio-fs / 9p) and the message-set transport are component-spec choices, not contract.
+The south-face mount adapter terminates the `filesystem_id`-scoped file-operation interface from the guest; the north-face component terminates the file/artifact API plus the authenticated SPA and the preview-render path. The files surface is one entry in the data-plane UI's descriptor-driven view list ([ADR-0002](../adr/0002-session-view-descriptor.md)); the broker serves that entry, while the descriptor shell and the deferred live-view surfaces sit outside this container. Both call one authz resolver, which calls one object-store client — the sole component that speaks the backend protocol and signs every backend request. The substrate under the mount (FUSE / virtio-fs / 9p) and the message-set transport are component-spec choices, not contract.
 
 ### Owned state
 

--- a/docs/architecture/components/06-egress-trust-edge.md
+++ b/docs/architecture/components/06-egress-trust-edge.md
@@ -3,7 +3,7 @@
 
 ---
 status: draft
-last-reviewed: 2026-05-31
+last-reviewed: 2026-06-03
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
 compliance: []
@@ -88,7 +88,7 @@ Residual, by [`06-threat-model.md`](../06-threat-model.md) §5 register: the tra
 
 ## Open questions
 
-1. Envoy's `credential_injector` filter and its OAuth2 extension carry an upstream maturity caveat — not substantial production burn-in, an unknown security posture, intended for trusted-on-both-ends paths — while a third-party LLM API is an untrusted upstream. The regulated-tier posture for this filter is deferred pending a security review — needs issue.
+1. Envoy's `credential_injector` filter and its OAuth2 extension carry an upstream maturity caveat — not substantial production burn-in, an unknown security posture, intended for trusted-on-both-ends paths — while a third-party LLM API is an untrusted upstream. The regulated-tier posture for this filter is deferred pending a security review ([#240](https://github.com/Wide-Moat/open-computer-use/issues/240)).
 2. ~~MITM-termination technology undecided.~~ Resolved by [ADR-0007](../adr/0007-egress-auth-mechanism.md): the bump rung terminates with a leaf minted per SNI from a per-deployment CA, served by the Envoy data plane plus a self-hosted SDS minting service; a config-time-enumerable allow-list uses pre-minted leaves over a file SDS source instead. Selection between edge-inject and a protocol broker is per upstream; v1 ships edge-inject only.
 3. SNI/Host consistency on the transparent (non-inspected) leg, where the SNI pre-filter alone misses domain-fronting — [#198](https://github.com/Wide-Moat/open-computer-use/issues/198).
 4. No-credential-in-response stripping, edge-binary/config attestation, and plaintext-zeroization for the bump rung lack an explicit NFR — [#197](https://github.com/Wide-Moat/open-computer-use/issues/197).

--- a/docs/architecture/components/07-audit-pipeline.md
+++ b/docs/architecture/components/07-audit-pipeline.md
@@ -3,7 +3,7 @@
 
 ---
 status: draft
-last-reviewed: 2026-05-31
+last-reviewed: 2026-06-03
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
 compliance: []
@@ -107,4 +107,4 @@ Backpressure behaviour is spill, not block: events commit to the durable bus and
 2. Transparency-log publishing path (auth, retry, RPO if the log is unreachable) and whether the minimal shelf publishes at all — [#151](https://github.com/Wide-Moat/open-computer-use/issues/151).
 3. Out-of-band evidence for in-sandbox actions and host-attested binding of the OCSF source at ingestion (the P7-S1 / P7-R2 residual) — [#181](https://github.com/Wide-Moat/open-computer-use/issues/181).
 4. Per-source retention-budget cap and forensic-dilution-within-budget at the audit fan-in — [#188](https://github.com/Wide-Moat/open-computer-use/issues/188).
-5. ComputeMetering / SaturationEvent payload schema: OCSF v1.x ships no metering or saturation class, so the channel surface is stable but the payload `$ref` is held TBD. needs issue: split the metering/saturation OCSF-class payload-schema TBD off [#150](https://github.com/Wide-Moat/open-computer-use/issues/150) so the Published-Language gap is tracked separately from SIEM-bridge transport.
+5. ComputeMetering / SaturationEvent payload schema: OCSF v1.x ships no metering or saturation class, so the channel surface is stable but the payload `$ref` is held TBD, split off [#150](https://github.com/Wide-Moat/open-computer-use/issues/150) so the Published-Language gap is tracked separately from SIEM-bridge transport ([#241](https://github.com/Wide-Moat/open-computer-use/issues/241)).


### PR DESCRIPTION
Non-decision gate items the L9/L10 readiness audit surfaced, cleared before ADR-0009 (audit substrate) lands. No new decision here — linkage, bindings, and index hygiene only.

## What
- **Open-questions issue links** (doc-discipline: every open question must link an issue):
  - `01-mcp-gateway` Q4 → #239 (gateway serializer conformance test surface)
  - `06-egress-trust-edge` Q1 → #240 (credential_injector regulated-tier security review)
  - `07-audit-pipeline` Q5 → #241 (ComputeMetering/SaturationEvent OCSF payload-schema split off #150)
- **ADR-0002 binding gap**: ADR-0002 (session view is descriptor-driven) was bound from zero specs. Its files surface is served by the Storage-broker north face, so `04-storage-broker` now carries `adr: [0002]` and a Boundaries clause naming the descriptor-list entry.
- **Index drift** in `00-overview` reconciled with spec front-matter: row 04 → 0002, row 05 → 0003, row 06 adds 0008.
- **component-03 hygiene**: `00-overview` now states `NN` is container row order (no `03`), not a trust-zone number — the Session sandbox is container 05, trust zone 3.

## Why now
Clears the path so the ADR-0009 PR carries only the decision, not bookkeeping. Part of the first-version gate (L0-8 + L9/L10 ≥50% by written+complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)