### PR TITLE
docs(architecture): manifesto 03 — build-scope root principle

### DIFF
--- a/docs/architecture/manifesto/03-non-negotiables.md
+++ b/docs/architecture/manifesto/03-non-negotiables.md
@@ -3,7 +3,7 @@
 
 ---
 status: draft
-last-reviewed: 2026-06-02
+last-reviewed: 2026-06-05
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
 ---
@@ -11,6 +11,8 @@ applies-to: next/v1
 Principles every architectural decision must respect. Audience: reviewers and architects deciding whether a proposal fits the platform.
 
 ## Non-negotiable principles
+
+**We build the control plane and the sandbox runtime; everything else we integrate.** Those two are OCU's accountable surface — what no mature market product provides — so every neighbouring capability is integrated off-the-shelf or customer-provided over a published contract, and a dependency is bundled only when it is part of that core ([02-nfrs.md](02-nfrs.md) §Scope ownership; [05-licensing-posture.md](05-licensing-posture.md) §Bundled vs not-bundled). Anti-example: shipping a bundled audit bus and owning its CVE, SBOM, and version lifecycle when the customer already runs Kafka.
 
 **Agent loop stays outside OCU.** The loop — model query, response handling, reflection — runs in the calling client, never in OCU. Anti-example: OCU as an LLM proxy that selects the model and runs the tool-execution loop internally.
 


### PR DESCRIPTION
## What

Adds one root principle to `manifesto/03-non-negotiables.md`, inserted first (before "Agent loop stays outside OCU"):

> **We build the control plane and the sandbox runtime; everything else we integrate.** Those two are OCU's accountable surface — what no mature market product provides — so every neighbouring capability is integrated off-the-shelf or customer-provided over a published contract, and a dependency is bundled only when it is part of that core (02-nfrs §Scope ownership; 05-licensing-posture §Bundled vs not-bundled). Anti-example: shipping a bundled audit bus and owning its CVE, SBOM, and version lifecycle when the customer already runs Kafka.

## Why

The file already carries the *children* of this rule — model-agnostic, guest-holds-no-secret, one-click-solo, skill-registry-deferred — but not the rule itself. The `02-nfrs` DELIVER/ENABLE/REVISIT scope classes and the `05` bundled/not-bundled table are its implementation, with no parent in 03 to descend from. Without the root, each ADR re-derives the build/buy line independently.

The principle links 02 §Scope ownership and 05 §Bundled-vs-not-bundled rather than restating them (one-source-of-truth; ≤3 outbound links per section).

## Sequence

This is PR-A of three. It is the parent the audit-pipeline ADR-0009 (PR-C) cites, so it lands first to avoid a forward-reference. PR-B splits NFR-COMP-01 (retention floor on both shelves vs Object-Lock substrate full-shelf-only); PR-C is ADR-0009 "Audit pipeline is pluggable-by-contract".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Documentation**
* Updated architectural documentation to clarify system scope: core responsibilities are limited to control plane and sandbox runtime, with adjacent capabilities integrated through published contracts or customer-provided solutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->