### PR TITLE
docs(architecture): NFR-COMP-01 — split retention floor from WORM substrate by shelf

### DIFF
--- a/docs/architecture/manifesto/02-nfrs.md
+++ b/docs/architecture/manifesto/02-nfrs.md
@@ -3,7 +3,7 @@
 
 ---
 status: draft
-last-reviewed: 2026-05-31
+last-reviewed: 2026-06-06
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
 ---
@@ -249,7 +249,7 @@ Scope: determinism, replay, and reproducibility properties of the agent loop. Fu
 
 | ID | Scenario | Target | Verification | Source |
 |---|---|---|---|---|
-| NFR-COMP-01 | Audit-log retention — 7 y default / 10 y configurable; WORM (S3 Object Lock Compliance or equivalent); two-tier hot (≤90 d) → cold | retention-policy audit | per-release | FCA SYSC 9 / FINRA / MAS overlay + EU AI Act Art. 19(1) floor |
+| NFR-COMP-01 | Audit-log retention — 7 y default / 10 y configurable, two-tier hot (≤90 d) → cold, machine-enforced by the Audit-pipeline retention policy on both shelves. The cold tier is realized as WORM (S3 Object Lock Compliance or equivalent) on the full shelf; on the minimal shelf the retention floor holds on a plain file system with tamper-evidence supplied by the hash-chain + signed Merkle head (NFR-SEC-03) — tamper-evident (deletion detectable via the chain and the transparency-log head), not WORM-immutable. The retention floor is mandatory on both shelves; only the WORM substrate is shelf-conditional | retention-policy audit on both shelves; WORM object-lock check when the full-shelf cold tier is wired | per-release | FCA SYSC 9 / FINRA / MAS overlay + EU AI Act Art. 19(1) floor |
 | NFR-COMP-02 | DORA Register of Information — 7 fields per third-party ICT provider populated for every BoM row | BoM linter | per-release | DORA Art. 28 + RTS-2025/532 |
 | NFR-COMP-03 | EU AI Act Annex III conformity checklist per release; release blocks if controls absent; Art. 12/13/14/15/17/19/49 each mapped | pass/fail | release-pipeline | EU AI Act Art. 12 + 15 + 72 + Annex III §5(b) |
 | NFR-COMP-04 | DORA major-incident classification candidate emission — platform telemetry enables customer to meet timeline (classification is customer-side) | telemetry available ≤1 h post-event; bundle supports initial ≤4 h after classification (≤24 h after detection), intermediate ≤72 h, final ≤1 month | incident-drill | DORA-RTS-2025/301 Art. 5 verbatim |


### PR DESCRIPTION
## What

Rewords `NFR-COMP-01` (one row, ID preserved) to separate two things the current cell fuses:

- **Retention floor** (7y/10y, hot→cold, machine-enforced) — mandatory on **both** shelves.
- **WORM Object-Lock substrate** (S3 Object Lock Compliance or equivalent) — the **full-shelf** cold-tier realization. On the **minimal shelf** the floor holds on a plain file system with hash-chain + signed Merkle-head tamper-evidence (NFR-SEC-03) — tamper-evident, *not* WORM-immutable.

## Why

The current row reads "Audit-log retention … WORM (S3 Object Lock Compliance or equivalent) … hot→cold" with no shelf qualifier. A reviewer can read it as Object-Lock mandatory on every shelf — which the one-click-solo minimal shelf (no object store) cannot satisfy, breaking the one-click-solo non-negotiable. The split keeps retention mandatory everywhere while making only the *substrate* shelf-conditional, mirroring the host-local/HSM split already in NFR-SEC-03.

The preventive-vs-detective distinction (full-shelf WORM is immutable; minimal-shelf hash-chain detects tampering after the fact) is stated in-cell so a bank InfoSec reviewer is not misled.

## Consistency

ID preserved and retention stays the headline noun, so the four NFR-COMP-01 cross-refs stay valid unchanged: `02-trust-boundaries.md` §10, AP-13, and `07-audit-pipeline.md` Config/Capacity rows all anchor on *retention*. `07-audit-pipeline.md` Shelf-delta (line 102) already defers the WORM substrate to an ADR — now matched, not contradicted.

## Sequence

PR-B of three. PR-A (build-scope principle, #245) merged. PR-C is ADR-0009 "Audit pipeline is pluggable-by-contract", which cites this split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified audit-log retention policies and data protection mechanisms across different storage tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->