### PR TITLE
docs(architecture): ADR-0010 — object-store engine is an S3-conform seam

### DIFF
--- a/docs/architecture/08-contracts.md
+++ b/docs/architecture/08-contracts.md
@@ -3,7 +3,7 @@
 
 ---
 status: draft
-last-reviewed: 2026-05-31
+last-reviewed: 2026-06-07
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
 ---
@@ -28,7 +28,7 @@ OCU does not define every contract it speaks. Five external surfaces are integra
 | File / artifact data plane (north face) | Data-plane client → Storage broker (north face) | OpenAPI 3.1 (HTTP+JSON: upload/list/download/getManifest/preview-render + embeddable SPA) | define | NFR-SEC-78, NFR-SEC-82, NFR-SEC-49, NFR-SEC-73 |
 | Secret delivery | SDS source → Egress trust-edge | Envoy SDS (gRPC xDS) | wire off-the-shelf; the dynamic per-SNI minter implementing the SDS server is OCU code ([ADR-0007](adr/0007-egress-auth-mechanism.md)), the file SDS source is off-the-shelf | NFR-SEC-29 |
 | Outbound | Session sandbox → Egress trust-edge | network policy (no wire schema) | network property | NFR-SEC-27 |
-| Broker backend leg | Storage broker → Egress trust-edge → backend | external backend protocol | conform | NFR-SEC-16 |
+| Broker backend leg | Storage broker → Egress trust-edge → backend | S3 HTTP data-access API | conform | NFR-SEC-16, [ADR-0010](adr/0010-object-store-engine-s3-conform.md) |
 | Audit fan-in / SIEM | five containers → Audit pipeline → SIEM | AsyncAPI 3.0 / OCSF | publish | NFR-SEC-03 |
 | SOAR webhook (outbound) | Audit pipeline → SOAR | AsyncAPI 3.0 | define | NFR-COMP-27 |
 | Transparency-log submission | Audit pipeline → log | submission envelope | define (envelope only) | NFR-SEC-03 |
@@ -102,5 +102,4 @@ Not built:
 
 1. Does NFR-IC-04 bind only the Control/operator API and internal gRPC, leaving the MCP gateway governed solely by date-revision negotiation, or does it need an explicit MCP-edge clause? — [#207](https://github.com/Wide-Moat/open-computer-use/issues/207).
 2. Is the inbound gateway contract MCP-only per NFR-FLEX-14, and is `REST fallback` (used in Layer 4 prose, undefined in glossary) dropped or promoted to a defined surface? — [#158](https://github.com/Wide-Moat/open-computer-use/issues/158).
-3. Does the broker file-operation contract (open/read/write/list) stay distinct from any object-store API at every shelf, and where is that boundary asserted? — [#208](https://github.com/Wide-Moat/open-computer-use/issues/208).
-4. The §4 additive-vs-breaking rules, transition window, RFC 9745/8594 headers, and the `oasdiff`/`buf breaking` CI gates extend NFR-IC-04 across two surfaces — should this versioning policy move to a dedicated ADR, leaving §4 a pointer? — [#209](https://github.com/Wide-Moat/open-computer-use/issues/209).
+3. The §4 additive-vs-breaking rules, transition window, RFC 9745/8594 headers, and the `oasdiff`/`buf breaking` CI gates extend NFR-IC-04 across two surfaces — should this versioning policy move to a dedicated ADR, leaving §4 a pointer? — [#209](https://github.com/Wide-Moat/open-computer-use/issues/209).

--- a/docs/architecture/adr/0010-object-store-engine-s3-conform.md
+++ b/docs/architecture/adr/0010-object-store-engine-s3-conform.md
@@ -1,0 +1,60 @@
+<!-- SPDX-License-Identifier: FSL-1.1-Apache-2.0 -->
+<!-- Copyright (c) 2025 Open Computer Use Contributors -->
+
+---
+status: proposed
+last-reviewed: 2026-06-07
+owner: "@Wide-Moat/architects"
+applies-to: next/v1
+supersedes: []
+superseded-by: null
+compliance-impact: [SOC2-CC6.1, ISO27001-A.8.10]
+license-impact: none
+threat-mitigation-link: ../06-threat-model.md
+---
+
+The Storage broker's object-store client speaks the S3 data-access API to a customer-provided engine; the guest's file-operation contract stays distinct from it, and the solo shelf bundles one Apache-2.0 local-filesystem S3 server as the reference.
+
+# ADR-0010: Object-store engine is an S3-conform seam
+
+## Status
+
+`proposed`
+
+## Context
+
+The Storage broker ([component 04](../components/04-storage-broker.md)) is the sole component that speaks the backend object-store protocol ([NFR-SEC-25](../manifesto/02-nfrs.md)); the guest holds only a `filesystem_id` handle. Two things were left undecided: which engine the broker's object-store client speaks to, and which protocol it speaks ([component 04](../components/04-storage-broker.md) Shelf delta — "needs ADR: object-store engine selection; picks no engine"). [08-contracts.md](../08-contracts.md) frames the broker backend leg generically as "external backend protocol / conform", and the broker open question on whether the guest file-operation contract stays distinct from the backend API is unanswered ([#208](https://github.com/Wide-Moat/open-computer-use/issues/208)).
+
+OCU is an ephemeral workspace ([04-non-goals.md](../manifesto/04-non-goals.md)): it retains no customer file bytes past the session, so the engine carries no retention, WORM, versioning, or erasure duty — those are the customer store's. What remains is a build/buy choice for a neighbouring system ([03-non-negotiables.md](../manifesto/03-non-negotiables.md)).
+
+## Decision
+
+The broker's object-store client speaks the S3 HTTP data-access API to a customer-provided engine, the guest↔broker file-operation contract stays distinct from that S3 API inside the object-store client, and the solo shelf bundles one Apache-2.0/MIT/BSD local-filesystem S3 server as the reference engine — no engine is bundled for production, and the ephemeral model attaches no retention, WORM, versioning, or erasure duty to the engine.
+
+## Consequences
+
+- The backend conform-contract is the S3 data-access subset — `PutObject` / `GetObject` / `ListObjectsV2` / `DeleteObject` over AWS Signature v4 — not the full AWS surface. [08-contracts.md](../08-contracts.md) narrows from "external backend protocol" to "S3 HTTP data-access API"; the broker conforms, it does not define ([NFR-SEC-16](../manifesto/02-nfrs.md)). Every store a regulated enterprise runs already exposes this subset (AWS S3, Ceph RGW, NetApp StorageGRID / ONTAP S3, Dell ECS / ObjectScale, Pure, VAST, Scality), so the broker targets one protocol and engine choice collapses to deployment config behind the `filesystem_id`→prefix map.
+- **The two contracts stay distinct, and this closes [#208](https://github.com/Wide-Moat/open-computer-use/issues/208).** The south-face guest↔broker contract is the OCU-defined file-operation interface (open/read/write/list over FUSE/virtio-fs/9p, [08-contracts.md](../08-contracts.md)), deliberately POSIX-shaped, never S3. The broker's object-store client translates a file-operation verb into a broker-signed S3 request ([component 04](../components/04-storage-broker.md) invariant 2); the S3 API is never visible guest-ward. The boundary lives inside the object-store client — file-operation in, broker-signed S3 out.
+- Positive: the broker's S3 client is identical on both shelves; only the endpoint and the credential substrate change ([component 04](../components/04-storage-broker.md) Shelf delta — host-local credential on the minimal shelf per [NFR-SEC-60](../manifesto/02-nfrs.md), STS-scoped per session on the full shelf per [NFR-SEC-25](../manifesto/02-nfrs.md)).
+- Positive: production engines are customer-provided and not bundled — AWS S3, Ceph RGW (the reference object store in [05-licensing-posture.md](../manifesto/05-licensing-posture.md)), or any S3-compatible appliance. OCU owns no engine CVE, SBOM, or version lifecycle.
+- The solo shelf bundles one Apache-2.0 local-filesystem S3 server so the one-click path has an object store with no customer infrastructure — lead candidate `versitygw` (Apache-2.0, single Go binary, S3-over-local-filesystem), with the final binary fixed in the component spec per the [ADR-0006](0006-egress-forward-proxy-substrate.md) pattern. Unlike the audit WORM seam ([ADR-0009](0009-audit-pipeline-pluggable-by-contract.md)) whose solo default can be "none — the file system is the floor", the broker needs a real S3 endpoint on every shelf, so a reference engine is required.
+- Negative: "S3-compatible" is not "S3-identical" — Ceph RGW implements a subset and appliances vary. The four-operation data-access subset (`PutObject` / `GetObject` / `ListObjectsV2` / `DeleteObject`) is the contract ceiling; no feature outside it is assumed.
+- Neutral: this resolves the engine half of the [component 04](../components/04-storage-broker.md) Shelf-delta picks; the broker runtime tier stays a separate decision (its own ADR). Per-tenant instantiation ([NFR-SEC-76](../manifesto/02-nfrs.md)) is unchanged.
+
+## Alternatives considered
+
+- **Bundle a production engine (ship Ceph or MinIO, own its lifecycle).** Rejected: an object store is a neighbouring system that runs without OCU, so bundling it for production violates the build-scope principle and takes on a CVE surface the customer's platform team already operates. MinIO is also AGPL ([05-licensing-posture.md](../manifesto/05-licensing-posture.md) rejection table) and has moved to a maintenance posture; Garage is AGPL — both fail the licence gate, recorded so neither is re-proposed.
+- **Leave the backend protocol generic ("any object store the broker is configured for").** Rejected: a generic protocol forces the broker to carry per-engine SDKs and leaves #208 open. Fixing the S3 data-access subset gives one client and one signing path.
+- **Make the guest speak S3 directly to the store (skip the broker translation).** Rejected: violates [NFR-SEC-25](../manifesto/02-nfrs.md) — the guest would hold a backend credential and the broker would no longer be the sole object-store speaker; the per-session prefix isolation ([NFR-SEC-31](../manifesto/02-nfrs.md)) could not be host-enforced.
+
+## Compliance impact
+
+- `SOC2-CC6.1` / `ISO27001-A.8.10`: backend-credential confidentiality holds because the broker is the sole S3 speaker and the guest never receives a backend key; the engine choice does not change this property on either shelf.
+
+## License impact
+
+No production engine is bundled. The solo reference engine is Apache-2.0/MIT/BSD (lead candidate `versitygw`, Apache-2.0); its Bill-of-Materials row in [05-licensing-posture.md](../manifesto/05-licensing-posture.md) lands when the component spec fixes the final binary, per the [ADR-0006](0006-egress-forward-proxy-substrate.md) pattern. Customer-provided engines are integrated over the S3 API and carry no OCU lifecycle.
+
+## Threat mitigation
+
+Addresses Information Disclosure on the backend leg: the S3 API terminates inside the broker's object-store client, the request is broker-signed, and the egress edge forwards it allow-list-only without TLS termination ([ADR-0006](0006-egress-forward-proxy-substrate.md)), so the broker-signed request is byte-intact ([NFR-SEC-16](../manifesto/02-nfrs.md)) and no S3 credential or endpoint reaches the guest.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -3,7 +3,7 @@
 
 ---
 status: stub
-last-reviewed: 2026-06-06
+last-reviewed: 2026-06-07
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
 ---
@@ -27,6 +27,7 @@ Architecture Decision Records. One file per decision. ADRs appear on demand foll
 | [0007](0007-egress-auth-mechanism.md) | Egress auth mechanism — edge-inject vs protocol-broker | proposed | — | 2026-06-01 |
 | [0008](0008-session-egress-attribution.md) | Session-to-egress attribution by presented token | proposed | — | 2026-06-02 |
 | [0009](0009-audit-pipeline-pluggable-by-contract.md) | Audit pipeline is pluggable-by-contract | proposed | — | 2026-06-06 |
+| [0010](0010-object-store-engine-s3-conform.md) | Object-store engine is an S3-conform seam | proposed | — | 2026-06-07 |
 
 ## Lifecycle
 

--- a/docs/architecture/components/04-storage-broker.md
+++ b/docs/architecture/components/04-storage-broker.md
@@ -3,13 +3,13 @@
 
 ---
 status: draft
-last-reviewed: 2026-06-03
+last-reviewed: 2026-06-07
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
 compliance: []
 threat-model: 06-threat-model.md
 contract: [contracts/storage/mount-config.schema.json, contracts/storage/file-ops.schema.json, contracts/storage/file-artifact-api.schema.json]
-adr: [0002]
+adr: [0002, 0010]
 ---
 
 The host-side object-store client that custodies the backend credential and resolves file authorization for the guest mount and an external data-plane client, so neither holds a backend key. Audience: engineers and security reviewers implementing or auditing the storage surface.
@@ -94,12 +94,11 @@ The container emits OCSF on the audit fan-in flow F11, fail-closed, per the audi
 
 Scaling axis: per-tenant instantiation (NFR-SEC-76) — one broker principal per tenant filesystem scope. Whether that principal is also per-sandbox-host or per-deployment, and whether that changes the container diagram, is open ([#175](https://github.com/Wide-Moat/open-computer-use/issues/175)). Capacity is bounded by the per-session file-op and inbound-byte ceilings (NFR-SEC-46, NFR-SEC-78); a one-per-host broker serving many sessions is a shared DoS surface, which is why those ceilings are per-session, not per-broker.
 
-Shelf delta (from [`05-c4-container.md`](../05-c4-container.md) §5): the minimal shelf holds a host-local backend credential, admitted only under `workload_trust_profile = trusted_operator` and single-tenant (NFR-SEC-60); the full shelf uses a customer-PKI workload identity with STS scoped per session (NFR-SEC-25). All invariants hold on both shelves; only the credential substrate and its blast radius (P4-S2 / P4-I1 residual) change. The runtime tier that hosts the broker and the build-vs-buy of the object-store engine are deferred (`needs ADR:` object-store engine selection; `needs ADR:` broker runtime tier); this spec records the two-face split and the cardinality question, it picks no engine or tier.
+Shelf delta (from [`05-c4-container.md`](../05-c4-container.md) §5): the minimal shelf holds a host-local backend credential, admitted only under `workload_trust_profile = trusted_operator` and single-tenant (NFR-SEC-60); the full shelf uses a customer-PKI workload identity with STS scoped per session (NFR-SEC-25). All invariants hold on both shelves; only the credential substrate and its blast radius (P4-S2 / P4-I1 residual) change. The build-vs-buy of the object-store engine is fixed by [ADR-0010](../adr/0010-object-store-engine-s3-conform.md) (S3-conform seam; customer-provided production engine, Apache-2.0 local-filesystem reference on the solo shelf); the runtime tier that hosts the broker stays deferred (`needs ADR:` broker runtime tier). This spec records the two-face split and the cardinality question, it picks no runtime tier and no final engine binary.
 
 ## Open questions
 
 1. Is the broker one instance per deployment or one per sandbox host, and does the answer change the container diagram? — [#175](https://github.com/Wide-Moat/open-computer-use/issues/175).
-2. Does the broker file-operation contract stay distinct from any object-store API at every shelf, and where is that boundary asserted? — [#208](https://github.com/Wide-Moat/open-computer-use/issues/208).
-3. Embed-token replay-binding (`jti`/nonce single-use or token↔channel binding) within the `exp` window — [#217](https://github.com/Wide-Moat/open-computer-use/issues/217).
-4. Preview-render parser isolation for untrusted artifact bodies on the north face — [#218](https://github.com/Wide-Moat/open-computer-use/issues/218).
-5. Per-action / per-object authorization granularity and minimum lease scope beyond resource-class — [#187](https://github.com/Wide-Moat/open-computer-use/issues/187).
+2. Embed-token replay-binding (`jti`/nonce single-use or token↔channel binding) within the `exp` window — [#217](https://github.com/Wide-Moat/open-computer-use/issues/217).
+3. Preview-render parser isolation for untrusted artifact bodies on the north face — [#218](https://github.com/Wide-Moat/open-computer-use/issues/218).
+4. Per-action / per-object authorization granularity and minimum lease scope beyond resource-class — [#187](https://github.com/Wide-Moat/open-computer-use/issues/187).


### PR DESCRIPTION
## What

ADR-0010 fixes the build/buy line for the Storage broker's backend object store:

- **S3 HTTP data-access API** is the single backend conform-contract (`PutObject`/`GetObject`/`ListObjectsV2`/`DeleteObject` over SigV4) — the broker targets one protocol, not N engine SDKs. `08-contracts` narrows the broker backend leg from "external backend protocol" to "S3 HTTP data-access API".
- **Production engine = customer-provided, not bundled** (AWS S3, Ceph RGW reference, S3-compatible appliances). OCU owns no engine CVE/SBOM/lifecycle.
- **Solo shelf bundles one Apache-2.0 local-FS S3 server** as the reference (lead candidate `versitygw`, final binary to the component spec per ADR-0006) so the one-click path has an object store with no customer infra. Garage/MinIO rejected on AGPL.
- **Ephemeral model (#248)** attaches no retention/WORM/versioning/erasure duty to the engine — narrower than ADR-0009, not a restatement.

## Closes #208

The south-face guest↔broker file-operation contract (POSIX-shaped, OCU-defined) stays distinct from the S3 backend API; the boundary lives in the object-store client (file-op in, broker-signed S3 out, S3 never guest-visible). That boundary location is the answer #208 asked for.

## Load-bearing (the empty-ADR attack, answered)

Three facts neither build-scope nor ADR-0009 carries: S3 as the backend conform-contract; a bundleable Apache-2.0 solo reference (without which solo has no store, unlike the audit WORM seam whose solo default is "none"); customer production engines recorded not-bundled. ADR-0009 governs the audit tract and scopes the object store only as the audit WORM seam — it never pins the broker's backend protocol.

## Same-PR canon edits

ADR index row 0010; `04-storage-broker.md` adr:[0002,0010] + Shelf-delta marker → ADR link + open-Q #208 removed; `08-contracts.md` backend leg narrowed + open-Q #208 removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new architectural decision record (ADR-0010) documenting object-store engine specifications, including S3 HTTP data-access API requirements and reference implementation guidance.
  * Updated contract documentation to clarify broker backend specifications and component interaction boundaries.
  * Refreshed architecture documentation metadata and resolved pending design questions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->