### PR TITLE
chore: release v0.9.6.0 (Open WebUI base bump 0.9.5 → 0.9.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v0.9.6.0 — bump Open WebUI base to 0.9.6 (2026-06-07)
+
+Minor release: Open WebUI base bumped from `0.9.5` → `0.9.6` (upstream shipped 0.9.6 on 2026-06-01). All eight patches re-audited against the new source tree — none became obsolete (upstream did not natively address any of the eight problem domains). Both frontend patches (`fix_artifacts_auto_show`, `fix_preview_url_detection`) applied to the bumped base without changes — their regex anchors adapted to the renamed minified chunk variables. One backend patch (`fix_tool_loop_errors`) needed updated SEARCH/REPLACE anchors to track an upstream tool-loop refactor; the other five backend patches applied unchanged. Closes #243 (build failure on the 0.9.6 base).
+
+### Changed
+
+- **`openwebui/Dockerfile`** — `ARG OPENWEBUI_VERSION=0.9.5` → `0.9.6`.
+- **`fix_tool_loop_errors` Mod 1 (tool_loop)** — upstream inserted a tool-call iteration-limit block between the tool-retry `except`/`break` and the `if DETECT_CODE_INTERPRETER:` that previously followed it. The SEARCH/REPLACE anchor's trailing `if DETECT_CODE_INTERPRETER:` line was dropped so the anchor ends at `break`; the inserted block is left untouched between the patched try/except and the code-interpreter loop.
+- **`fix_tool_loop_errors` Mod 2 (code_interp)** — upstream changed the post-loop `title` ternary guard from `metadata['chat_id'].startswith('channel:')` to `metadata.get('chat_id', '').startswith('channel:')`. SEARCH/REPLACE updated to match.
+- **`fix_tool_loop_errors` Mod 4 (done_bg)** — upstream reordered the post-completion block from `background_tasks_handler(ctx)` → `assistant_message` → `outlet_filter_handler` to `assistant_message` → `outlet_filter_handler` → `background_tasks_handler(ctx)` (background tasks now run last). SEARCH/REPLACE track the new order; the try/except wrap still guards both the done-emit and the post-loop block.
+- **`fix_tool_loop_errors` Mod 5 (iter)** — upstream renamed the loop counter `tool_call_retries` → `tool_call_iterations` and replaced the single-line `while len(tool_calls) > 0 and tool_call_retries < CHAT_RESPONSE_MAX_TOOL_CALL_RETRIES:` with a multi-line `while tool_calls and (CHAT_RESPONSE_MAX_TOOL_CALL_ITERATIONS is None or tool_call_iterations < CHAT_RESPONSE_MAX_TOOL_CALL_ITERATIONS):`. SEARCH/REPLACE and the injected log lines updated to the new name and shape.
+- **`fix_tool_loop_errors` Mod 3 (sse)** — no change; the SSE-parse anchor matches 0.9.6 verbatim.
+
+### Tests
+
+- **Patch regression coverage extended to v0.9.6 for all eight patches.** Added byte-identical `tests/patches/fixtures/middleware_v0.9.6.py` and `retrieval_v0.9.6.py` extracted from upstream `v0.9.6`. Every patch suite now runs its 3-state coverage (fresh apply / idempotent re-run / fail-loud) against the v0.9.6 base the build targets. For `fix_tool_loop_errors`, `fix_large_tool_results`, and `fix_skip_embedding_chat_files` the stale v0.9.1/v0.9.2 classes (which can no longer match the refactored or current anchors) were replaced with v0.9.6 classes; for the version-stable `fix_attached_files_position`, `fix_large_tool_args`, and `fix_skip_rag_files_native_fc` a v0.9.6 class was added alongside the retained v0.9.1/v0.9.2 coverage. Synthetic `_base_middleware()` in `test_fix_large_tool_results.py` updated to the v0.9.5+ multi-line `process_messages_with_output(..., reasoning_format=...)` shape so its Mod 3 anchor matches.
+
+### Verified
+
+- Backend dry-run: all six middleware/retrieval patches apply cleanly in Dockerfile order against a fresh `v0.9.6` source tree; resulting files parse with `ast.parse`.
+- Frontend dry-run: both chunk patches locate and patch their anchors against the `v0.9.6` built frontend (artifacts chunk `B56SVFjv.js`, preview chunk `CBKmxchQ.js`).
+- Docker build: `docker build --platform linux/amd64 -t open-webui-ocu:0.9.6.0-rc.1 -f openwebui/Dockerfile openwebui/` succeeds end-to-end; all eight patches' hard-fail guards green; patched `middleware.py` and `retrieval.py` parse inside the image.
+- Patch regression suite: `pytest tests/patches/` — 51 passed (22 against the v0.9.6 base, covering all eight patches).
+
 ## v0.9.5.0 — bump Open WebUI base to 0.9.5 (2026-05-20)
 
 Minor release: Open WebUI base bumped from `0.9.2` → `0.9.5` (upstream shipped 0.9.3, 0.9.4, 0.9.5 on 2026-05-09). All eight patches re-audited against the new source tree — none became obsolete (upstream did not natively address any of the eight problem domains in 0.9.3–0.9.5). Frontend patches (`fix_artifacts_auto_show`, `fix_preview_url_detection`) applied to the bumped base without changes; four backend patches needed updated SEARCH/REPLACE anchors to track upstream refactors.

--- a/openwebui/Dockerfile
+++ b/openwebui/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BUSL-1.1
 # Copyright (c) 2025 Open Computer Use Contributors
-ARG OPENWEBUI_VERSION=0.9.5
+ARG OPENWEBUI_VERSION=0.9.6
 FROM ghcr.io/open-webui/open-webui:${OPENWEBUI_VERSION}
 
 # Copy all patches into the image

--- a/openwebui/patches/fix_large_tool_results.py
+++ b/openwebui/patches/fix_large_tool_results.py
@@ -25,7 +25,7 @@ Config env vars:
   ORCHESTRATOR_URL -- internal URL of computer-use-server for large-result uploads
 
 Must run AFTER fix_tool_loop_errors.py (Mod 2 targets its marker).
-Target: Open WebUI 0.9.5
+Target: Open WebUI 0.9.6
 """
 
 import os

--- a/openwebui/patches/fix_skip_embedding_chat_files.py
+++ b/openwebui/patches/fix_skip_embedding_chat_files.py
@@ -17,7 +17,7 @@ Solution:
 
 When adding a file to a knowledge base (collection_name is set), full processing works.
 
-Target: Open WebUI 0.9.5
+Target: Open WebUI 0.9.6
 """
 
 import os

--- a/openwebui/patches/fix_tool_loop_errors.py
+++ b/openwebui/patches/fix_tool_loop_errors.py
@@ -17,7 +17,7 @@ Problems solved:
 6. SSE parse errors logged at debug level only
 
 Applied at Docker build time. Works on ORIGINAL middleware.py (no dependencies).
-Target: Open WebUI 0.9.5 (output-based architecture, serialize_output, prior_output).
+Target: Open WebUI 0.9.6 (output-based architecture, serialize_output, prior_output).
 
 Fail-loud: ANY sub-anchor miss triggers sys.exit(1) with stderr ERROR — refuses
 to ship a partially-patched middleware.py. Idempotent: re-run prints ALREADY PATCHED.
@@ -135,8 +135,7 @@ SEARCH_TOOL_LOOP = """\
                     except Exception as e:
                         log.debug(e)
                         break
-
-                if DETECT_CODE_INTERPRETER:"""
+"""
 
 REPLACE_TOOL_LOOP = (
     "                    _saved_output = json.loads(json.dumps(output))  # TOOL_LOOP_ERRORS_UNIFIED: save for restore on error\n"
@@ -236,7 +235,7 @@ REPLACE_TOOL_LOOP = (
     "                                _err_detail = f'Non-streaming error response: {type(res).__name__}'\n"
     "                            if _err_detail:\n"
     "                                log.error('NON_STREAM_ERROR: chat=%s iter=%d error=%s',\n"
-    "                                    metadata.get('chat_id', '')[:8], tool_call_retries, _err_detail)\n"
+    "                                    metadata.get('chat_id', '')[:8], tool_call_iterations, _err_detail)\n"
     "                                if 'Model not found' in _err_detail:\n"
     "                                    _err_detail = '" + _BUDGET_MSG + "'\n"
     "                                # Keep only message items (text the user already saw)\n"
@@ -257,11 +256,11 @@ REPLACE_TOOL_LOOP = (
     "                        _is_transport = 'aiohttp' in _err_mod or isinstance(e, (ConnectionError, TimeoutError, OSError))\n"
     "                        if _is_transport:\n"
     "                            log.warning('TRANSPORT_ERROR: chat=%s iter=%d error=%s',\n"
-    "                                metadata.get('chat_id', '')[:8], tool_call_retries, e)\n"
+    "                                metadata.get('chat_id', '')[:8], tool_call_iterations, e)\n"
     "                            _ui_err = '" + _TRANSPORT_MSG + "'\n"
     "                        else:\n"
     "                            log.error('TOOL_LOOP_ERROR: chat=%s iter=%d error=%s\\n%s',\n"
-    "                                metadata.get('chat_id', '')[:8], tool_call_retries, e, _tb.format_exc())\n"
+    "                                metadata.get('chat_id', '')[:8], tool_call_iterations, e, _tb.format_exc())\n"
     "                            _ui_err = str(e)[:1000]\n"
     "                            if 'Model not found' in _ui_err:\n"
     "                                _ui_err = '" + _BUDGET_MSG + "'\n"
@@ -273,8 +272,6 @@ REPLACE_TOOL_LOOP = (
     "                        except Exception:\n"
     "                            pass\n"
     "                        break\n"
-    "\n"
-    "                if DETECT_CODE_INTERPRETER:"
 )
 
 # ============================================================
@@ -294,7 +291,7 @@ SEARCH_CODE_INTERP = """\
 
                 title = (
                     await Chats.get_chat_title_by_id(metadata['chat_id'])
-                    if not metadata['chat_id'].startswith('channel:')
+                    if not metadata.get('chat_id', '').startswith('channel:')
                     else ''
                 )"""
 
@@ -317,7 +314,7 @@ REPLACE_CODE_INTERP = (
     "\n"
     "                title = (\n"
     "                    await Chats.get_chat_title_by_id(metadata['chat_id'])\n"
-    "                    if not metadata['chat_id'].startswith('channel:')\n"
+    "                    if not metadata.get('chat_id', '').startswith('channel:')\n"
     "                    else ''\n"
     "                )"
 )
@@ -349,6 +346,9 @@ REPLACE_SSE = """\
 # v0.9.1: two new lines inserted between `await background_tasks_handler(ctx)`
 # and `except asyncio.CancelledError:` — `ctx['assistant_message'] = {...}` +
 # `await outlet_filter_handler(ctx)`. Both must be preserved inside the wrap.
+# v0.9.6: upstream reordered to assistant_message -> outlet_filter_handler ->
+# background_tasks_handler (background tasks now run last). SEARCH/REPLACE track
+# the new order; the wrap still guards both the done-emit and the post-loop block.
 # ============================================================
 SEARCH_DONE_BG = """\
                 await event_emitter(
@@ -358,13 +358,13 @@ SEARCH_DONE_BG = """\
                     }
                 )
 
-                await background_tasks_handler(ctx)
                 ctx['assistant_message'] = {
                     'content': serialize_output(output),
                     'output': output,
                     **({'usage': usage} if usage else {}),
                 }
                 await outlet_filter_handler(ctx)
+                await background_tasks_handler(ctx)
             except asyncio.CancelledError:"""
 
 REPLACE_DONE_BG = """\
@@ -380,13 +380,13 @@ REPLACE_DONE_BG = """\
                         metadata.get('chat_id', '')[:8], _done_err)
 
                 try:
-                    await background_tasks_handler(ctx)
                     ctx['assistant_message'] = {
                         'content': serialize_output(output),
                         'output': output,
                         **({'usage': usage} if usage else {}),
                     }
                     await outlet_filter_handler(ctx)
+                    await background_tasks_handler(ctx)
                 except Exception as _bg_err:
                     log.error('BACKGROUND_TASK_ERROR: chat=%s error=%s',  # TOOL_LOOP_ERRORS_UNIFIED
                         metadata.get('chat_id', '')[:8], _bg_err)
@@ -394,16 +394,25 @@ REPLACE_DONE_BG = """\
 
 # ============================================================
 # Mod 5: TOOL_LOOP_ITER lifecycle logging
+# v0.9.6: upstream renamed `tool_call_retries` -> `tool_call_iterations` and
+# replaced the single-line `while len(tool_calls) > 0 and ... < ...RETRIES:`
+# with a multi-line `while tool_calls and (...ITERATIONS is None or ... < ...)`.
 # ============================================================
 SEARCH_ITER = """\
-                while len(tool_calls) > 0 and tool_call_retries < CHAT_RESPONSE_MAX_TOOL_CALL_RETRIES:
-                    tool_call_retries += 1"""
+                while tool_calls and (
+                    CHAT_RESPONSE_MAX_TOOL_CALL_ITERATIONS is None
+                    or tool_call_iterations < CHAT_RESPONSE_MAX_TOOL_CALL_ITERATIONS
+                ):
+                    tool_call_iterations += 1"""
 
 REPLACE_ITER = """\
-                while len(tool_calls) > 0 and tool_call_retries < CHAT_RESPONSE_MAX_TOOL_CALL_RETRIES:
-                    tool_call_retries += 1
+                while tool_calls and (
+                    CHAT_RESPONSE_MAX_TOOL_CALL_ITERATIONS is None
+                    or tool_call_iterations < CHAT_RESPONSE_MAX_TOOL_CALL_ITERATIONS
+                ):
+                    tool_call_iterations += 1
                     log.debug('TOOL_LOOP_ITER: chat=%s iter=%d pending_tc=%d',  # TOOL_LOOP_ERRORS_UNIFIED; FIX_TOOL_LOOP_ERRORS
-                        metadata.get('chat_id', '')[:8], tool_call_retries, len(tool_calls))"""
+                        metadata.get('chat_id', '')[:8], tool_call_iterations, len(tool_calls))"""
 
 
 def apply_patch():

--- a/tests/patches/conftest.py
+++ b/tests/patches/conftest.py
@@ -2,8 +2,9 @@
 # Copyright (c) 2025 Open Computer Use Contributors
 """Shared pytest fixtures for backend patch tests.
 
-Provides byte-identical v0.9.1 upstream source as test fixtures for
-patch-apply / idempotency / fail-loud coverage.
+Provides byte-identical upstream source as test fixtures for
+patch-apply / idempotency / fail-loud coverage. v0.9.6 matches the version
+the build targets; v0.9.1 / v0.9.2 retain coverage for version-stable anchors.
 """
 from pathlib import Path
 
@@ -12,6 +13,8 @@ MIDDLEWARE_V091 = FIXTURES_DIR / "middleware_v0.9.1.py"
 RETRIEVAL_V091 = FIXTURES_DIR / "retrieval_v0.9.1.py"
 MIDDLEWARE_V092 = FIXTURES_DIR / "middleware_v0.9.2.py"
 RETRIEVAL_V092 = FIXTURES_DIR / "retrieval_v0.9.2.py"
+MIDDLEWARE_V096 = FIXTURES_DIR / "middleware_v0.9.6.py"
+RETRIEVAL_V096 = FIXTURES_DIR / "retrieval_v0.9.6.py"
 
 
 def load_middleware_v091() -> str:
@@ -28,3 +31,11 @@ def load_middleware_v092() -> str:
 
 def load_retrieval_v092() -> str:
     return RETRIEVAL_V092.read_text(encoding="utf-8")
+
+
+def load_middleware_v096() -> str:
+    return MIDDLEWARE_V096.read_text(encoding="utf-8")
+
+
+def load_retrieval_v096() -> str:
+    return RETRIEVAL_V096.read_text(encoding="utf-8")

--- a/tests/patches/fixtures/__init__.py
+++ b/tests/patches/fixtures/__init__.py
@@ -2,9 +2,10 @@
 # Copyright (c) 2025 Open Computer Use Contributors
 """Fixture package for backend patch tests.
 
-Fixture files (middleware_v0.9.{1,2}.py, retrieval_v0.9.{1,2}.py) are
-byte-identical extracts from upstream Open WebUI v0.9.1 / v0.9.2 — DO NOT
-modify them. They are not imported as Python modules; they are read as
-text by the patch test harness. The v0.9.1 fixtures pin shim regression
-coverage; the build itself targets v0.9.2 strictly.
+Fixture files (middleware_v0.9.{1,2,6}.py, retrieval_v0.9.{1,2,6}.py) are
+byte-identical extracts from upstream Open WebUI — DO NOT modify them. They
+are not imported as Python modules; they are read as text by the patch test
+harness. The v0.9.6 fixtures match the version the build targets
+(openwebui/Dockerfile ARG OPENWEBUI_VERSION); the v0.9.1 / v0.9.2 fixtures
+retain coverage for patches whose anchors are stable across versions.
 """

--- a/tests/patches/fixtures/middleware_v0.9.6.py
+++ b/tests/patches/fixtures/middleware_v0.9.6.py
@@ -1,0 +1,5272 @@
+import ast
+import asyncio
+import base64
+import copy
+import html
+import inspect
+import json
+import logging
+import os
+import random
+import re
+import sys
+import textwrap
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Optional
+from uuid import uuid4
+
+from aiocache import cached
+from fastapi import HTTPException, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+from open_webui.config import (
+    CACHE_DIR,
+    CODE_INTERPRETER_BLOCKED_MODULES,
+    CODE_INTERPRETER_PYODIDE_PROMPT,
+    DEFAULT_CODE_INTERPRETER_PROMPT,
+    DEFAULT_TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE,
+    DEFAULT_VOICE_MODE_PROMPT_TEMPLATE,
+)
+from open_webui.constants import TASKS
+from open_webui.env import (
+    BYPASS_MODEL_ACCESS_CONTROL,
+    CHAT_RESPONSE_MAX_TOOL_CALL_ITERATIONS,
+    CHAT_RESPONSE_STREAM_DELTA_CHUNK_SIZE,
+    ENABLE_CHAT_RESPONSE_BASE64_IMAGE_URL_CONVERSION,
+    ENABLE_QUERIES_CACHE,
+    ENABLE_REALTIME_CHAT_SAVE,
+    ENABLE_RESPONSES_API_STATEFUL,
+    GLOBAL_LOG_LEVEL,
+    RAG_SYSTEM_CONTEXT,
+)
+from open_webui.models.chats import Chats
+from open_webui.models.folders import Folders
+from open_webui.models.functions import Functions
+from open_webui.models.models import Models
+from open_webui.models.oauth_sessions import OAuthSessions
+from open_webui.models.users import UserModel, Users
+from open_webui.retrieval.utils import get_sources_from_items
+from open_webui.routers.images import (
+    CreateImageForm,
+    EditImageForm,
+    image_edits,
+    image_generations,
+)
+from open_webui.routers.memories import QueryMemoryForm, query_memory
+from open_webui.routers.pipelines import (
+    process_pipeline_inlet_filter,
+    process_pipeline_outlet_filter,
+)
+from open_webui.routers.retrieval import (
+    SearchForm,
+    process_web_search,
+)
+from open_webui.routers.tasks import (
+    generate_chat_tags,
+    generate_follow_ups,
+    generate_image_prompt,
+    generate_queries,
+    generate_title,
+)
+from open_webui.socket.main import (
+    get_event_call,
+    get_event_emitter,
+)
+from open_webui.utils.access_control import has_connection_access, has_permission
+from open_webui.utils.access_control.files import get_accessible_folder_files
+from open_webui.utils.chat import generate_chat_completion
+from open_webui.utils.code_interpreter import execute_code_jupyter
+from open_webui.utils.files import (
+    convert_markdown_base64_images,
+    get_file_url_from_base64,
+    get_image_base64_from_url,
+    get_image_url_from_base64,
+)
+from open_webui.utils.filter import (
+    get_sorted_filter_ids,
+    process_filter_functions,
+)
+
+from open_webui.utils.mcp.client import MCPClient
+from open_webui.utils.misc import (
+    add_or_update_system_message,
+    add_or_update_user_message,
+    convert_logit_bias_input_to_json,
+    convert_output_to_messages,
+    deep_update,
+    extract_urls,
+    get_content_from_message,
+    get_last_assistant_message,
+    get_last_user_message,
+    get_last_user_message_item,
+    get_message_list,
+    get_system_message,
+    is_string_allowed,
+    merge_system_messages,
+    prepend_to_first_user_message_content,
+    replace_system_message_content,
+    set_last_user_message_content,
+    strip_empty_content_blocks,
+)
+from open_webui.utils.payload import apply_system_prompt_to_body
+from open_webui.utils.plugin import load_function_module_by_id
+from open_webui.utils.response import normalize_usage
+from open_webui.utils.sanitize import sanitize_code
+from open_webui.utils.task import (
+    get_task_model_id,
+    rag_template,
+    tools_function_calling_generation_template,
+)
+from open_webui.utils.tools import (
+    build_tool_server_headers,
+    get_builtin_tools,
+    get_terminal_tools,
+    get_tools,
+    get_updated_tool_function,
+)
+from open_webui.utils.webhook import post_webhook
+from starlette.responses import JSONResponse, Response, StreamingResponse
+
+logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
+log = logging.getLogger(__name__)
+
+
+# We believe in one maker of all models, seen and unseen,
+# and in the reasoning which proceeds from the architect.
+# We look for the resurrection of dead processes and the
+# inference of the world to come.
+DEFAULT_REASONING_TAGS = [
+    ('<think>', '</think>'),
+    ('<thinking>', '</thinking>'),
+    ('<reason>', '</reason>'),
+    ('<reasoning>', '</reasoning>'),
+    ('<thought>', '</thought>'),
+    ('<Thought>', '</Thought>'),
+    ('<|begin_of_thought|>', '<|end_of_thought|>'),
+    ('◁think▷', '◁/think▷'),
+]
+DEFAULT_SOLUTION_TAGS = [('<|begin_of_solution|>', '<|end_of_solution|>')]
+DEFAULT_CODE_INTERPRETER_TAGS = [('<code_interpreter>', '</code_interpreter>')]
+
+
+def output_id(prefix: str) -> str:
+    """Generate OR-style ID: prefix + 24-char hex UUID."""
+    return f'{prefix}_{uuid4().hex[:24]}'
+
+
+def _split_tool_calls(
+    tool_calls: list[dict],
+) -> list[dict]:
+    """Expand tool calls whose arguments contain multiple back-to-back JSON objects.
+
+    Some models (e.g. GPT-5.4) send multiple complete JSON argument objects
+    under the same tool call index, producing concatenated invalid JSON like:
+        '{"query":"A","count":5}{"query":"B","count":5}'
+
+    Each such tool call is split into separate entries so each gets executed
+    independently. Single-object arguments pass through unchanged.
+    """
+
+    def split_json_objects(raw: str) -> list[str]:
+        decoder = json.JSONDecoder()
+        results = []
+        position = 0
+
+        while position < len(raw):
+            while position < len(raw) and raw[position].isspace():
+                position += 1
+            if position >= len(raw):
+                break
+            try:
+                _, end = decoder.raw_decode(raw, position)
+                results.append(raw[position:end].strip())
+                position = end
+            except json.JSONDecodeError:
+                return [raw]
+
+        return results or [raw]
+
+    expanded = []
+    for tool_call in tool_calls:
+        arguments = tool_call.get('function', {}).get('arguments', '')
+        split_arguments = split_json_objects(arguments)
+
+        if len(split_arguments) <= 1:
+            expanded.append(tool_call)
+        else:
+            for argument in split_arguments:
+                cloned = copy.deepcopy(tool_call)
+                cloned['id'] = f'call_{uuid4().hex[:24]}'
+                cloned['function']['arguments'] = argument
+                expanded.append(cloned)
+
+    return expanded
+
+
+def get_citation_source_from_tool_result(
+    tool_name: str, tool_params: dict, tool_result: str, tool_id: str = ''
+) -> list[dict]:
+    """
+    Parse a tool's result and convert it to source dicts for citation display.
+
+    Follows the source format conventions from get_sources_from_items:
+    - source: file/item info object with id, name, type
+    - document: list of document contents
+    - metadata: list of metadata objects with source, file_id, name fields
+
+    Returns a list of sources (usually one, but query_knowledge_files may return multiple).
+    """
+    _EXPECTS_LIST = {'search_web', 'query_knowledge_files'}
+    _EXPECTS_DICT = {'view_knowledge_file', 'view_file'}
+
+    try:
+        try:
+            tool_result = json.loads(tool_result)
+        except (json.JSONDecodeError, TypeError):
+            pass  # keep tool_result as-is (e.g. fetch_url returns plain text)
+        if isinstance(tool_result, dict) and 'error' in tool_result:
+            return []
+
+        # Validate tool_result type based on what the branch expects
+        if tool_name in _EXPECTS_LIST and not isinstance(tool_result, list):
+            return []
+        elif tool_name in _EXPECTS_DICT and not isinstance(tool_result, dict):
+            return []
+
+        if tool_name == 'search_web':
+            # Parse JSON array: [{"title": "...", "link": "...", "snippet": "..."}]
+            results = tool_result
+            documents = []
+            metadata = []
+
+            for result in results:
+                title = result.get('title', '')
+                link = result.get('link', '')
+                snippet = result.get('snippet', '')
+
+                documents.append(f'{title}\n{snippet}')
+                metadata.append(
+                    {
+                        'source': link,
+                        'name': title,
+                        'url': link,
+                    }
+                )
+
+            return [
+                {
+                    'source': {'name': 'search_web', 'id': 'search_web'},
+                    'document': documents,
+                    'metadata': metadata,
+                }
+            ]
+
+        elif tool_name in ('view_knowledge_file', 'view_file'):
+            file_data = tool_result
+            filename = file_data.get('filename', 'Unknown File')
+            file_id = file_data.get('id', '')
+            knowledge_name = file_data.get('knowledge_name', '')
+
+            return [
+                {
+                    'source': {
+                        'id': file_id,
+                        'name': filename,
+                        'type': 'file',
+                    },
+                    'document': [file_data.get('content', '')],
+                    'metadata': [
+                        {
+                            'file_id': file_id,
+                            'name': filename,
+                            'source': filename,
+                            **({'knowledge_name': knowledge_name} if knowledge_name else {}),
+                        }
+                    ],
+                }
+            ]
+
+        elif tool_name == 'fetch_url':
+            url = tool_params.get('url', '')
+            content = tool_result if isinstance(tool_result, str) else str(tool_result)
+            snippet = content[:500] + ('...' if len(content) > 500 else '')
+
+            return [
+                {
+                    'source': {'name': url or 'fetch_url', 'id': url or 'fetch_url'},
+                    'document': [snippet],
+                    'metadata': [
+                        {
+                            'source': url,
+                            'name': url,
+                            'url': url,
+                        }
+                    ],
+                }
+            ]
+
+        elif tool_name == 'query_knowledge_files':
+            chunks = tool_result
+
+            # Group chunks by source for better citation display
+            # Each unique source becomes a separate source entry
+            sources_by_file = {}
+
+            for chunk in chunks:
+                source_name = chunk.get('source', 'Unknown')
+                file_id = chunk.get('file_id', '')
+                note_id = chunk.get('note_id', '')
+                chunk_type = chunk.get('type', 'file')
+                content = chunk.get('content', '')
+
+                # Use file_id or note_id as the key
+                key = file_id or note_id or source_name
+
+                if key not in sources_by_file:
+                    sources_by_file[key] = {
+                        'source': {
+                            'id': file_id or note_id,
+                            'name': source_name,
+                            'type': chunk_type,
+                        },
+                        'document': [],
+                        'metadata': [],
+                    }
+
+                sources_by_file[key]['document'].append(content)
+                sources_by_file[key]['metadata'].append(
+                    {
+                        'file_id': file_id,
+                        'name': source_name,
+                        'source': source_name,
+                        **({'note_id': note_id} if note_id else {}),
+                    }
+                )
+
+            # Return all grouped sources as a list
+            if sources_by_file:
+                return list(sources_by_file.values())
+
+            # Empty result fallback
+            return []
+
+        else:
+            # Fallback for other tools
+            return [
+                {
+                    'source': {
+                        'name': tool_name,
+                        'type': 'tool',
+                        'id': tool_id or tool_name,
+                    },
+                    'document': [str(tool_result)],
+                    'metadata': [{'source': tool_name, 'name': tool_name}],
+                }
+            ]
+    except Exception as e:
+        log.exception(f'Error parsing tool result for {tool_name}: {e}')
+        return [
+            {
+                'source': {'name': tool_name, 'type': 'tool'},
+                'document': [str(tool_result)],
+                'metadata': [{'source': tool_name}],
+            }
+        ]
+
+
+def split_content_and_whitespace(content):
+    content_stripped = content.rstrip()
+    original_whitespace = content[len(content_stripped) :] if len(content) > len(content_stripped) else ''
+    return content_stripped, original_whitespace
+
+
+def is_opening_code_block(content):
+    backtick_segments = content.split('```')
+    # Even number of segments means the last backticks are opening a new block
+    return len(backtick_segments) > 1 and len(backtick_segments) % 2 == 0
+
+
+_OPENAI_TOOL_DISPLAY_NAMES = {
+    'web_search_call': 'Web Search',
+    'file_search_call': 'File Search',
+    'computer_call': 'Computer Use',
+}
+
+
+def _render_openai_tool_call_handler(item: dict, done: bool) -> str:
+    """Render an OpenAI Responses API server-side tool item as a <details> block.
+
+    Handles web_search_call, file_search_call, and computer_call items whose
+    schemas are defined in the openai-python SDK (generated from OpenAPI spec).
+    """
+    item_type = item.get('type', '')
+    call_id = item.get('id', '')
+    display_name = _OPENAI_TOOL_DISPLAY_NAMES.get(item_type, item_type)
+
+    # Build a short summary of what the tool did
+    summary = ''
+    if item_type == 'web_search_call':
+        action = item.get('action', {})
+        if isinstance(action, dict):
+            atype = action.get('type', '')
+            if atype == 'search':
+                queries = action.get('queries') or []
+                query = action.get('query', '')
+                summary = (
+                    f'Search: {", ".join(str(q) for q in queries)}'
+                    if queries
+                    else (f'Search: {query}' if query else '')
+                )
+            elif atype == 'open_page':
+                summary = f'Open page: {action.get("url", "")}' if action.get('url') else ''
+            elif atype == 'find_in_page':
+                summary = f'Find in page: {action.get("pattern", "")}' if action.get('pattern') else ''
+    elif item_type == 'file_search_call':
+        queries = item.get('queries', [])
+        if queries:
+            summary = f'Queries: {", ".join(str(q) for q in queries)}'
+    elif item_type == 'computer_call':
+        action = item.get('action')
+        actions = item.get('actions')
+        if isinstance(action, dict):
+            summary = f'Action: {action.get("type", "unknown")}'
+        elif isinstance(actions, list) and actions:
+            summary = f'Actions: {", ".join(a.get("type", "?") for a in actions if isinstance(a, dict))}'
+
+    escaped_name = html.escape(display_name)
+    if done:
+        return f'<details type="tool_calls" done="true" id="{call_id}" name="{escaped_name}" arguments="">\n<summary>Tool Executed</summary>\n{html.escape(summary)}\n</details>\n'
+    return f'<details type="tool_calls" done="false" id="{call_id}" name="{escaped_name}" arguments="">\n<summary>Executing...</summary>\n</details>\n'
+
+
+def serialize_output(output: list) -> str:
+    """
+    Convert OR-aligned output items to HTML for display.
+    For LLM consumption, use convert_output_to_messages() instead.
+    """
+    parts: list[str] = []
+
+    # First pass: collect function_call_output items by call_id for lookup
+    tool_outputs = {}
+    for item in output:
+        if item.get('type') == 'function_call_output':
+            tool_outputs[item.get('call_id')] = item
+
+    # Second pass: render items in order
+    for idx, item in enumerate(output):
+        item_type = item.get('type', '')
+
+        if item_type == 'message':
+            for content_part in item.get('content', []):
+                if 'text' in content_part:
+                    text = content_part.get('text', '').strip()
+                    if text:
+                        parts.append(text)
+
+        elif item_type == 'function_call':
+            call_id = item.get('call_id', '')
+            name = item.get('name', '')
+            arguments = item.get('arguments', '')
+
+            result_item = tool_outputs.get(call_id)
+            if result_item:
+                result_parts: list[str] = []
+                for result_output in result_item.get('output', []):
+                    if 'text' in result_output:
+                        output_text = result_output.get('text', '')
+                        result_parts.append(str(output_text) if not isinstance(output_text, str) else output_text)
+                result_text = ''.join(result_parts)
+                files = result_item.get('files')
+                embeds = result_item.get('embeds', '')
+
+                parts.append(
+                    f'<details type="tool_calls" done="true" id="{call_id}" name="{name}" arguments="{html.escape(json.dumps(arguments))}" files="{html.escape(json.dumps(files)) if files else ""}" embeds="{html.escape(json.dumps(embeds))}">\n<summary>Tool Executed</summary>\n{html.escape(json.dumps(result_text, ensure_ascii=False))}\n</details>'
+                )
+            else:
+                parts.append(
+                    f'<details type="tool_calls" done="false" id="{call_id}" name="{name}" arguments="{html.escape(json.dumps(arguments))}">\n<summary>Executing...</summary>\n</details>'
+                )
+
+        elif item_type == 'function_call_output':
+            # Already handled inline with function_call above
+            pass
+
+        elif item_type in _OPENAI_TOOL_DISPLAY_NAMES:
+            status = item.get('status', 'in_progress')
+            done = status in ('completed', 'failed', 'incomplete') or idx != len(output) - 1
+            parts.append(_render_openai_tool_call_handler(item, done).rstrip('\n'))
+
+        elif item_type == 'reasoning':
+            reasoning_parts: list[str] = []
+            # Check for 'summary' (new structure) or 'content' (legacy/fallback)
+            source_list = item.get('summary', []) or item.get('content', [])
+            for content_part in source_list:
+                if 'text' in content_part:
+                    reasoning_parts.append(content_part.get('text', ''))
+                elif 'summary' in content_part:  # Handle potential nested logic if any
+                    pass
+
+            reasoning_content = ''.join(reasoning_parts).strip()
+
+            duration = item.get('duration')
+            status = item.get('status', 'in_progress')
+
+            # Infer completion: if this reasoning item is NOT the last item,
+            # render as done (a subsequent item means reasoning is complete)
+            is_last_item = idx == len(output) - 1
+
+            display = html.escape(
+                '\n'.join(
+                    (f'> {line}' if not line.startswith('>') else line) for line in reasoning_content.splitlines()
+                )
+            )
+
+            if status == 'completed' or duration is not None or not is_last_item:
+                parts.append(
+                    f'<details type="reasoning" done="true" duration="{duration or 0}">\n<summary>Thought for {duration or 0} seconds</summary>\n{display}\n</details>'
+                )
+            else:
+                parts.append(
+                    f'<details type="reasoning" done="false">\n<summary>Thinking…</summary>\n{display}\n</details>'
+                )
+
+        elif item_type == 'open_webui:code_interpreter':
+            # Code interpreter needs to inspect/mutate prior accumulated content
+            # to strip trailing unclosed code fences — materialize only here.
+            content = '\n'.join(parts)
+            content_stripped, original_whitespace = split_content_and_whitespace(content)
+            if is_opening_code_block(content_stripped):
+                content = content_stripped.rstrip('`').rstrip() + original_whitespace
+            else:
+                content = content_stripped + original_whitespace
+
+            # Re-split back into parts list after mutation
+            parts = [content] if content else []
+
+            # Render the code_interpreter item as a <details> block
+            # so the frontend Collapsible renders "Analyzing..."/"Analyzed".
+            code = item.get('code', '').strip()
+            lang = item.get('lang', 'python')
+            status = item.get('status', 'in_progress')
+            duration = item.get('duration')
+            is_last_item = idx == len(output) - 1
+
+            # Build inner content: code block
+            display = ''
+            if code:
+                display = f'```{lang}\n{code}\n```'
+
+            # Build output attribute as HTML-escaped JSON for CodeBlock.svelte
+            ci_output = item.get('output')
+            output_attr = ''
+            if ci_output:
+                if isinstance(ci_output, dict):
+                    output_json = json.dumps(ci_output, ensure_ascii=False)
+                else:
+                    output_json = json.dumps({'result': str(ci_output)}, ensure_ascii=False)
+                output_attr = f' output="{html.escape(output_json)}"'
+
+            if status == 'completed' or duration is not None or not is_last_item:
+                parts.append(
+                    f'<details type="code_interpreter" done="true" duration="{duration or 0}"{output_attr}>\n<summary>Analyzed</summary>\n{display}\n</details>'
+                )
+            else:
+                parts.append(
+                    f'<details type="code_interpreter" done="false"{output_attr}>\n<summary>Analyzing…</summary>\n{display}\n</details>'
+                )
+
+    return '\n'.join(parts).strip()
+
+
+def deep_merge(target, source):
+    """
+    Merge source into target recursively (returning new structure).
+    - Dicts: Recursive merge.
+    - Strings: Concatenation.
+    - Others: Overwrite.
+    """
+    if isinstance(target, dict) and isinstance(source, dict):
+        new_target = target.copy()
+        for k, v in source.items():
+            if k in new_target:
+                new_target[k] = deep_merge(new_target[k], v)
+            else:
+                new_target[k] = v
+        return new_target
+    elif isinstance(target, str) and isinstance(source, str):
+        return target + source
+    else:
+        return source
+
+
+def handle_responses_streaming_event(
+    data: dict,
+    current_output: list,
+) -> tuple[list, dict | None]:
+    """
+    Handle Responses API streaming events in a pure functional way.
+
+    Args:
+        data: The event data
+        current_output: List of output items (treated as immutable)
+
+    Returns:
+        tuple[list, dict | None]: (new_output, metadata)
+        - new_output: The updated output list.
+        - metadata: Metadata to emit (e.g. usage), {} if update occurred, None if skip.
+    """
+    # Default: no change
+    # Note: treating current_output as immutable, but avoiding full deepcopy for perf.
+    # We will shallow copy only if we need to modify the list structure or items.
+
+    event_type = data.get('type', '')
+
+    if event_type == 'response.output_item.added':
+        item = data.get('item', {})
+        if item:
+            new_output = list(current_output)
+            new_output.append(item)
+            return new_output, None
+        return current_output, None
+
+    elif event_type == 'response.content_part.added':
+        part = data.get('part', {})
+        output_index = data.get('output_index', len(current_output) - 1)
+
+        if current_output and 0 <= output_index < len(current_output):
+            new_output = list(current_output)
+            # Copy the item to mutate it
+            item = new_output[output_index].copy()
+            new_output[output_index] = item
+
+            if 'content' not in item:
+                item['content'] = []
+            else:
+                # Copy content list
+                item['content'] = list(item['content'])
+
+            if item.get('type') == 'reasoning':
+                # Reasoning items should not have content parts
+                pass
+            else:
+                item['content'].append(part)
+            return new_output, None
+        return current_output, None
+
+    elif event_type == 'response.reasoning_summary_part.added':
+        part = data.get('part', {})
+        output_index = data.get('output_index', len(current_output) - 1)
+
+        if current_output and 0 <= output_index < len(current_output):
+            new_output = list(current_output)
+            item = new_output[output_index].copy()
+            new_output[output_index] = item
+
+            if 'summary' not in item:
+                item['summary'] = []
+            else:
+                item['summary'] = list(item['summary'])
+
+            item['summary'].append(part)
+            return new_output, None
+        return current_output, None
+
+    elif event_type.startswith('response.') and event_type.endswith('.delta'):
+        # Generic Delta Handling
+        parts = event_type.split('.')
+        if len(parts) >= 3:
+            delta_type = parts[1]
+            delta = data.get('delta', '')
+
+            output_index = data.get('output_index', len(current_output) - 1)
+
+            if current_output and 0 <= output_index < len(current_output):
+                new_output = list(current_output)
+                item = new_output[output_index].copy()
+                new_output[output_index] = item
+                item_type = item.get('type', '')
+
+                # Determine target field and object based on delta_type and item_type
+                if delta_type == 'function_call_arguments':
+                    key = 'arguments'
+                    if item_type == 'function_call':
+                        # Function call args are usually strings
+                        item[key] = item.get(key, '') + str(delta)
+                else:
+                    # Generic handling, refined by item type below
+                    pass
+
+                    if item_type == 'message':
+                        # Message items: "text"/"output_text" -> "text"
+                        # "reasoning_text" -> Skipped (should use reasoning item)
+                        if delta_type in ['text', 'output_text']:
+                            key = 'text'
+                        elif delta_type in ['reasoning_text', 'reasoning_summary_text']:
+                            # Skip reasoning updates for message items
+                            return new_output, None
+                        else:
+                            key = delta_type
+
+                        content_index = data.get('content_index', 0)
+                        if 'content' not in item:
+                            item['content'] = []
+                        else:
+                            item['content'] = list(item['content'])
+                        content_list = item['content']
+
+                        while len(content_list) <= content_index:
+                            content_list.append({'type': 'text', 'text': ''})
+
+                        # Copy the part to mutate it
+                        part = content_list[content_index].copy()
+                        content_list[content_index] = part
+
+                        current_val = part.get(key)
+                        if current_val is None:
+                            # Initialize based on delta type
+                            current_val = {} if isinstance(delta, dict) else ''
+
+                        part[key] = deep_merge(current_val, delta)
+
+                    elif item_type == 'reasoning':
+                        # Reasoning items: "reasoning_text"/"reasoning_summary_text" -> "text"
+                        # "text"/"output_text" -> Skipped (should use message item)
+                        if delta_type == 'reasoning_summary_text':
+                            # Summary updates -> item['summary']
+                            key = 'text'
+                            summary_index = data.get('summary_index', 0)
+                            if 'summary' not in item:
+                                item['summary'] = []
+                            else:
+                                item['summary'] = list(item['summary'])
+                            summary_list = item['summary']
+
+                            while len(summary_list) <= summary_index:
+                                summary_list.append({'type': 'summary_text', 'text': ''})
+
+                            part = summary_list[summary_index].copy()
+                            summary_list[summary_index] = part
+
+                            target_val = part.get(key, '')
+                            part[key] = deep_merge(target_val, delta)
+
+                        elif delta_type == 'reasoning_text':
+                            # Reasoning body updates -> item['content']
+                            key = 'text'
+                            content_index = data.get('content_index', 0)
+                            if 'content' not in item:
+                                item['content'] = []
+                            else:
+                                item['content'] = list(item['content'])
+                            content_list = item['content']
+
+                            while len(content_list) <= content_index:
+                                # Reasoning content parts default to text
+                                content_list.append({'type': 'text', 'text': ''})
+
+                            part = content_list[content_index].copy()
+                            content_list[content_index] = part
+
+                            target_val = part.get(key, '')
+                            part[key] = deep_merge(target_val, delta)
+
+                        elif delta_type in ['text', 'output_text']:
+                            return new_output, None
+                        else:
+                            # Fallback just in case other deltas target reasoning?
+                            pass
+
+                    else:
+                        # Fallback for other item types
+                        if delta_type in ['text', 'output_text']:
+                            key = 'text'
+                        else:
+                            key = delta_type
+
+                        current_val = item.get(key)
+                        if current_val is None:
+                            current_val = {} if isinstance(delta, dict) else ''
+                        item[key] = deep_merge(current_val, delta)
+
+            return new_output, None
+
+    elif event_type.startswith('response.') and event_type.endswith('.done'):
+        # Delta Events: response.content_part.done, response.text.done, etc.
+        parts = event_type.split('.')
+        if len(parts) >= 3:
+            type_name = parts[1]
+
+            # 1. Handle specific Delta "done" signals
+            if type_name == 'content_part':
+                # "Signaling that no further changes will occur to a content part"
+                # If payloads contains the full part, we could update it.
+                # Usually purely signaling in standard implementation, but we check payload.
+                part = data.get('part')
+                output_index = data.get('output_index', len(current_output) - 1)
+
+                if part and current_output and 0 <= output_index < len(current_output):
+                    new_output = list(current_output)
+                    item = new_output[output_index].copy()
+                    new_output[output_index] = item
+
+                    if 'content' in item:
+                        item['content'] = list(item['content'])
+                        content_index = data.get('content_index', len(item['content']) - 1)
+                        if 0 <= content_index < len(item['content']):
+                            item['content'][content_index] = part
+                            return new_output, {}
+                return current_output, None
+
+            elif type_name == 'reasoning_summary_part':
+                part = data.get('part')
+                output_index = data.get('output_index', len(current_output) - 1)
+
+                if part and current_output and 0 <= output_index < len(current_output):
+                    new_output = list(current_output)
+                    item = new_output[output_index].copy()
+                    new_output[output_index] = item
+
+                    if 'summary' in item:
+                        item['summary'] = list(item['summary'])
+                        summary_index = data.get('summary_index', len(item['summary']) - 1)
+                        if 0 <= summary_index < len(item['summary']):
+                            item['summary'][summary_index] = part
+                            return new_output, {}
+                return current_output, None
+
+            # 2. Skip Output Item done (handled specifically below)
+            if type_name == 'output_item':
+                pass
+
+            # 3. Generic Field Done (text.done, audio.done)
+            elif type_name not in ['completed', 'failed']:
+                output_index = data.get('output_index', len(current_output) - 1)
+                if current_output and 0 <= output_index < len(current_output):
+                    key = (
+                        'text'
+                        if type_name
+                        in [
+                            'text',
+                            'output_text',
+                            'reasoning_text',
+                            'reasoning_summary_text',
+                        ]
+                        else type_name
+                    )
+                    if type_name == 'function_call_arguments':
+                        key = 'arguments'
+
+                    if key in data:
+                        final_value = data[key]
+                        new_output = list(current_output)
+                        item = new_output[output_index].copy()
+                        new_output[output_index] = item
+                        item_type = item.get('type', '')
+
+                        if type_name == 'function_call_arguments':
+                            if item_type == 'function_call':
+                                item['arguments'] = final_value
+                        elif item_type == 'message':
+                            content_index = data.get('content_index', 0)
+                            if 'content' in item:
+                                item['content'] = list(item['content'])
+                                if len(item['content']) > content_index:
+                                    part = item['content'][content_index].copy()
+                                    item['content'][content_index] = part
+                                    part[key] = final_value
+                        elif item_type == 'reasoning':
+                            item['status'] = 'completed'
+                        else:
+                            item[key] = final_value
+
+                        return new_output, {}
+
+        return current_output, None
+
+    elif event_type == 'response.output_item.done':
+        # Delta Event: Output item complete
+        item = data.get('item')
+        output_index = data.get('output_index', len(current_output) - 1)
+
+        new_output = list(current_output)
+        if item and 0 <= output_index < len(current_output):
+            new_output[output_index] = item
+        elif item:
+            new_output.append(item)
+        return new_output, {}
+
+    elif event_type == 'response.completed':
+        # State Machine Event: Completed
+        response_data = data.get('response', {})
+        final_output = response_data.get('output')
+
+        new_output = final_output if final_output is not None else current_output
+
+        # Ensure reasoning items are marked as completed in the final output
+        if new_output:
+            for item in new_output:
+                if item.get('type') == 'reasoning' and item.get('status') != 'completed':
+                    item['status'] = 'completed'
+
+        return new_output, {
+            'usage': response_data.get('usage'),
+            'done': True,
+            'response_id': response_data.get('id'),
+        }
+
+    elif event_type == 'response.in_progress':
+        # State Machine Event: In Progress
+        # We could extract metadata if needed, but for now just acknowledge iteration
+        return current_output, None
+
+    elif event_type == 'response.failed':
+        # State Machine Event: Failed
+        error = data.get('response', {}).get('error', {})
+        return current_output, {'error': error}
+
+    else:
+        return current_output, None
+
+
+def get_source_context(sources: list, source_ids: dict = None, include_content: bool = True) -> str:
+    """
+    Build <source> tag context string from citation sources.
+    """
+    context_string = ''
+    if source_ids is None:
+        source_ids = {}
+    for source in sources:
+        for doc, meta in zip(source.get('document', []), source.get('metadata', [])):
+            source_id = meta.get('source') or source.get('source', {}).get('id') or 'N/A'
+            if source_id not in source_ids:
+                source_ids[source_id] = len(source_ids) + 1
+            src_name = source.get('source', {}).get('name')
+            src_type = source.get('source', {}).get('type')
+            src_rid = source.get('source', {}).get('id')
+            body = doc if include_content else ''
+            context_string += (
+                f'<source id="{source_ids[source_id]}"'
+                + (f' name="{src_name}"' if src_name else '')
+                + (f' resource-type="{src_type}"' if src_type else '')
+                + (f' resource-id="{src_rid}"' if src_rid else '')
+                + f'>{body}</source>\n'
+            )
+    return context_string
+
+
+async def apply_source_context_to_messages(
+    request: Request,
+    messages: list,
+    sources: list,
+    user_message: str,
+    include_content: bool = True,
+) -> list:
+    """
+    Build source context from citation sources and apply to messages.
+    Uses RAG template to format context for model consumption.
+
+    When include_content is False, emit <source> tags with id/name but no
+    document body — useful when the content is already present elsewhere
+    (e.g. in a tool result message) and only citation markers are needed.
+    """
+    if not sources or not user_message:
+        return messages
+
+    context = get_source_context(sources, include_content=include_content)
+
+    context = context.strip()
+    if not context:
+        return messages
+
+    if RAG_SYSTEM_CONTEXT:
+        return add_or_update_system_message(
+            await rag_template(request.app.state.config.RAG_TEMPLATE, context, user_message),
+            messages,
+            append=True,
+        )
+    else:
+        return add_or_update_user_message(
+            await rag_template(request.app.state.config.RAG_TEMPLATE, context, user_message),
+            messages,
+            append=False,
+        )
+
+
+async def process_tool_result(
+    request,
+    tool_function_name,
+    tool_result,
+    tool_type,
+    direct_tool=False,
+    metadata=None,
+    user=None,
+):
+    tool_result_embeds = []
+    EXTERNAL_TOOL_TYPES = ('external', 'action', 'terminal')
+
+    # Support (HTMLResponse, result_context) tuples: the optional second
+    # element lets tool authors provide the LLM with actionable context
+    # about the generated embed instead of the generic fallback message.
+    result_context = None
+    if isinstance(tool_result, tuple) and len(tool_result) == 2 and isinstance(tool_result[0], HTMLResponse):
+        tool_result, result_context = tool_result
+
+    if isinstance(tool_result, HTMLResponse):
+        content_disposition = tool_result.headers.get('Content-Disposition', '')
+        if 'inline' in content_disposition:
+            content = tool_result.body.decode('utf-8', 'replace')
+            tool_result_embeds.append(content)
+
+            if 200 <= tool_result.status_code < 300:
+                if result_context is not None and isinstance(result_context, (str, dict, list)):
+                    tool_result = result_context
+                else:
+                    tool_result = {
+                        'status': 'success',
+                        'code': 'ui_component',
+                        'message': f'{tool_function_name}: Embedded UI result is active and visible to the user.',
+                    }
+            elif 400 <= tool_result.status_code < 500:
+                tool_result = {
+                    'status': 'error',
+                    'code': 'ui_component',
+                    'message': f'{tool_function_name}: Client error {tool_result.status_code} from embedded UI result.',
+                }
+            elif 500 <= tool_result.status_code < 600:
+                tool_result = {
+                    'status': 'error',
+                    'code': 'ui_component',
+                    'message': f'{tool_function_name}: Server error {tool_result.status_code} from embedded UI result.',
+                }
+            else:
+                tool_result = {
+                    'status': 'error',
+                    'code': 'ui_component',
+                    'message': f'{tool_function_name}: Unexpected status code {tool_result.status_code} from embedded UI result.',
+                }
+        else:
+            tool_result = tool_result.body.decode('utf-8', 'replace')
+
+    elif (tool_type in EXTERNAL_TOOL_TYPES and isinstance(tool_result, tuple)) or (
+        direct_tool and isinstance(tool_result, list) and len(tool_result) == 2
+    ):
+        tool_result, tool_response_headers = tool_result
+
+        try:
+            if not isinstance(tool_response_headers, dict):
+                tool_response_headers = dict(tool_response_headers)
+        except Exception as e:
+            tool_response_headers = {}
+            log.debug(e)
+
+        if tool_response_headers and isinstance(tool_response_headers, dict):
+            content_disposition = tool_response_headers.get(
+                'Content-Disposition',
+                tool_response_headers.get('content-disposition', ''),
+            )
+
+            if 'inline' in content_disposition:
+                content_type = tool_response_headers.get(
+                    'Content-Type',
+                    tool_response_headers.get('content-type', ''),
+                )
+                location = tool_response_headers.get(
+                    'Location',
+                    tool_response_headers.get('location', ''),
+                )
+
+                if 'text/html' in content_type:
+                    # Support (html_content, result_context) nested tuple
+                    result_context = None
+                    html_content = tool_result
+                    if isinstance(tool_result, (tuple, list)) and len(tool_result) == 2:
+                        html_content, result_context = tool_result
+
+                    # Display as iframe embed
+                    tool_result_embeds.append(html_content)
+                    if result_context is not None and isinstance(result_context, (str, dict, list)):
+                        tool_result = result_context
+                    else:
+                        tool_result = {
+                            'status': 'success',
+                            'code': 'ui_component',
+                            'message': f'{tool_function_name}: Embedded UI result is active and visible to the user.',
+                        }
+                elif location:
+                    # Support (html_content, result_context) nested tuple for location embeds
+                    result_context = None
+                    if isinstance(tool_result, (tuple, list)) and len(tool_result) == 2:
+                        _, result_context = tool_result
+
+                    tool_result_embeds.append(location)
+                    if result_context is not None and isinstance(result_context, (str, dict, list)):
+                        tool_result = result_context
+                    else:
+                        tool_result = {
+                            'status': 'success',
+                            'code': 'ui_component',
+                            'message': f'{tool_function_name}: Embedded UI result is active and visible to the user.',
+                        }
+
+    tool_result_files = []
+
+    # Detect base64 image data URIs from tool results (e.g. binary image
+    # responses from execute_tool_server).  Move the data URI to
+    # tool_result_files and replace tool_result with a text summary.
+    if isinstance(tool_result, str) and tool_result.startswith('data:image/'):
+        tool_result_files.append({'type': 'image', 'url': tool_result})
+        tool_result = f'{tool_function_name}: Image file read successfully.'
+
+    if isinstance(tool_result, list):
+        if tool_type == 'mcp':  # MCP
+            tool_response = []
+            for item in tool_result:
+                if isinstance(item, dict):
+                    if item.get('type') == 'text':
+                        text = item.get('text', '')
+                        if isinstance(text, str):
+                            try:
+                                text = json.loads(text)
+                            except json.JSONDecodeError:
+                                pass
+                        tool_response.append(text)
+                    elif item.get('type') in ['image', 'audio']:
+                        file_url = await get_file_url_from_base64(
+                            request,
+                            f'data:{item.get("mimeType")};base64,{item.get("data", item.get("blob", ""))}',
+                            {
+                                'chat_id': metadata.get('chat_id', None),
+                                'message_id': metadata.get('message_id', None),
+                                'session_id': metadata.get('session_id', None),
+                                'result': item,
+                            },
+                            user,
+                        )
+
+                        tool_result_files.append(
+                            {
+                                'type': item.get('type', 'data'),
+                                'url': file_url,
+                            }
+                        )
+                    elif item.get('type') == 'resource':
+                        resource = item.get('resource', {})
+                        text = resource.get('text', '')
+                        if isinstance(text, str) and text:
+                            try:
+                                text = json.loads(text)
+                            except json.JSONDecodeError:
+                                pass
+                            tool_response.append(text)
+            tool_result = tool_response[0] if len(tool_response) == 1 else tool_response
+        else:  # OpenAPI
+            for item in tool_result:
+                if isinstance(item, str) and item.startswith('data:'):
+                    tool_result_files.append(
+                        {
+                            'type': 'data',
+                            'content': item,
+                        }
+                    )
+                    tool_result.remove(item)
+
+    if isinstance(tool_result, list):
+        tool_result = {'results': tool_result}
+
+    if isinstance(tool_result, dict) or isinstance(tool_result, list):
+        tool_result = json.dumps(tool_result, indent=2, ensure_ascii=False)
+
+    # Safety: ensure tool_result is always a string (or None) to prevent
+    # downstream TypeError when concatenating (e.g. if an upstream callable
+    # returned a tuple that was not unpacked by the branches above).
+    if tool_result is not None and not isinstance(tool_result, str):
+        if isinstance(tool_result, tuple):
+            # execute_tool_server returns (data, headers); unpack the data part
+            tool_result = json.dumps(tool_result[0], indent=2, ensure_ascii=False) if len(tool_result) > 0 else ''
+        else:
+            tool_result = str(tool_result)
+
+    return tool_result, tool_result_files, tool_result_embeds
+
+
+async def terminal_event_handler(
+    tool_function_name: str,
+    tool_function_params: dict,
+    tool_result,
+    event_emitter,
+):
+    """Emit terminal:* events for Open Terminal tools.
+
+    - display_file  → emits 'terminal:display_file' to open the file preview.
+    - write_file / replace_file_content → emits 'terminal:write_file' to refresh.
+    - run_command → emits 'terminal:run_command' with cwd to refresh if relevant.
+    """
+    if not event_emitter:
+        return
+
+    if tool_function_name == 'display_file':
+        path = tool_function_params.get('path', '')
+        if not path:
+            return
+        # Only emit if the file actually exists
+        parsed = tool_result
+        if isinstance(parsed, str):
+            try:
+                parsed = json.loads(parsed)
+            except (json.JSONDecodeError, TypeError):
+                pass
+        if isinstance(parsed, dict) and parsed.get('exists') is False:
+            return
+
+        await event_emitter(
+            {
+                'type': f'terminal:{tool_function_name}',
+                'data': {'path': path},
+            }
+        )
+    elif tool_function_name in ('write_file', 'replace_file_content'):
+        path = tool_function_params.get('path', '')
+        if not path:
+            return
+        await event_emitter(
+            {
+                'type': f'terminal:{tool_function_name}',
+                'data': {'path': path},
+            }
+        )
+    elif tool_function_name == 'run_command':
+        await event_emitter(
+            {
+                'type': 'terminal:run_command',
+                'data': {},
+            }
+        )
+
+
+async def chat_completion_tools_handler(
+    request: Request, body: dict, extra_params: dict, user: UserModel, models, tools
+) -> tuple[dict, dict]:
+    async def get_content_from_response(response) -> Optional[str]:
+        content = None
+        if hasattr(response, 'body_iterator'):
+            async for chunk in response.body_iterator:
+                data = json.loads(chunk.decode('utf-8', 'replace'))
+                content = data['choices'][0]['message']['content']
+
+            # Cleanup any remaining background tasks if necessary
+            if response.background is not None:
+                await response.background()
+        else:
+            content = response['choices'][0]['message']['content']
+        return content
+
+    def get_tools_function_calling_payload(messages, task_model_id, content):
+        user_message = get_last_user_message(messages)
+
+        if user_message and messages and messages[-1]['role'] == 'user':
+            # Remove the last user message to avoid duplication
+            messages = messages[:-1]
+
+        recent_messages = messages[-4:] if len(messages) > 4 else messages
+        chat_history = '\n'.join(
+            f'{message["role"].upper()}: """{get_content_from_message(message)}"""' for message in recent_messages
+        )
+
+        prompt = f'History:\n{chat_history}\nQuery: {user_message}' if chat_history else f'Query: {user_message}'
+
+        return {
+            'model': task_model_id,
+            'messages': [
+                {'role': 'system', 'content': content},
+                {'role': 'user', 'content': prompt},
+            ],
+            'stream': False,
+            'metadata': {'task': str(TASKS.FUNCTION_CALLING)},
+        }
+
+    event_caller = extra_params['__event_call__']
+    event_emitter = extra_params['__event_emitter__']
+    metadata = extra_params['__metadata__']
+
+    task_model_id = get_task_model_id(
+        body['model'],
+        request.app.state.config.TASK_MODEL,
+        request.app.state.config.TASK_MODEL_EXTERNAL,
+        models,
+    )
+
+    skip_files = False
+    sources = []
+
+    specs = [tool['spec'] for tool in tools.values()]
+    tools_specs = json.dumps(specs, ensure_ascii=False)
+
+    if request.app.state.config.TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE != '':
+        template = request.app.state.config.TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE
+    else:
+        template = DEFAULT_TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE
+
+    tools_function_calling_prompt = tools_function_calling_generation_template(template, tools_specs)
+    payload = get_tools_function_calling_payload(body['messages'], task_model_id, tools_function_calling_prompt)
+
+    try:
+        response = await generate_chat_completion(request, form_data=payload, user=user)
+        log.debug(f'{response=}')
+        content = await get_content_from_response(response)
+        log.debug(f'{content=}')
+
+        if not content:
+            return body, {}
+
+        try:
+            content = content[content.find('{') : content.rfind('}') + 1]
+            if not content:
+                raise Exception('No JSON object found in the response')
+
+            result = json.loads(content)
+
+            async def tool_call_handler(tool_call):
+                nonlocal skip_files
+
+                log.debug(f'{tool_call=}')
+
+                tool_function_name = tool_call.get('name', None)
+                if tool_function_name not in tools:
+                    log.warning(f'Tool "{tool_function_name}" not found')
+                    return
+
+                tool_function_params = tool_call.get('parameters', {})
+
+                tool = None
+                tool_type = ''
+                direct_tool = False
+
+                try:
+                    tool = tools[tool_function_name]
+                    tool_type = tool.get('type', '')
+                    direct_tool = tool.get('direct', False)
+
+                    spec = tool.get('spec', {})
+                    allowed_params = spec.get('parameters', {}).get('properties', {}).keys()
+                    tool_function_params = {k: v for k, v in tool_function_params.items() if k in allowed_params}
+
+                    if tool.get('direct', False):
+                        tool_result = await event_caller(
+                            {
+                                'type': 'execute:tool',
+                                'data': {
+                                    'id': str(uuid4()),
+                                    'name': tool_function_name,
+                                    'params': tool_function_params,
+                                    'server': tool.get('server', {}),
+                                    'session_id': metadata.get('session_id', None),
+                                },
+                            }
+                        )
+                    else:
+                        tool_function = tool['callable']
+                        tool_result = await tool_function(**tool_function_params)
+
+                except Exception as e:
+                    tool_result = str(e)
+
+                tool_result, tool_result_files, tool_result_embeds = await process_tool_result(
+                    request,
+                    tool_function_name,
+                    tool_result,
+                    tool_type,
+                    direct_tool,
+                    metadata,
+                    user,
+                )
+
+                if event_emitter:
+                    await terminal_event_handler(
+                        tool_function_name,
+                        tool_function_params,
+                        tool_result,
+                        event_emitter,
+                    )
+
+                    if tool_result_files:
+                        await event_emitter(
+                            {
+                                'type': 'files',
+                                'data': {
+                                    'files': tool_result_files,
+                                },
+                            }
+                        )
+
+                    if tool_result_embeds:
+                        await event_emitter(
+                            {
+                                'type': 'embeds',
+                                'data': {
+                                    'embeds': tool_result_embeds,
+                                },
+                            }
+                        )
+
+                if tool_result:
+                    tool = tools[tool_function_name]
+                    tool_id = tool.get('tool_id', '')
+
+                    tool_name = f'{tool_id}/{tool_function_name}' if tool_id else f'{tool_function_name}'
+
+                    # Citation is enabled for this tool
+                    sources.append(
+                        {
+                            'source': {
+                                'name': (f'{tool_name}'),
+                            },
+                            'document': [str(tool_result)],
+                            'metadata': [
+                                {
+                                    'source': (f'{tool_name}'),
+                                    'parameters': tool_function_params,
+                                }
+                            ],
+                            'tool_result': True,
+                        }
+                    )
+
+                    if tools[tool_function_name].get('metadata', {}).get('file_handler', False):
+                        skip_files = True
+
+            # check if "tool_calls" in result
+            if result.get('tool_calls'):
+                for tool_call in result.get('tool_calls'):
+                    await tool_call_handler(tool_call)
+            else:
+                await tool_call_handler(result)
+
+        except Exception as e:
+            log.debug(f'Error: {e}')
+            content = None
+    except Exception as e:
+        log.debug(f'Error: {e}')
+        content = None
+
+    log.debug(f'tool_contexts: {sources}')
+
+    if skip_files and 'files' in body.get('metadata', {}):
+        del body['metadata']['files']
+
+    return body, {'sources': sources}
+
+
+async def chat_memory_handler(request: Request, form_data: dict, extra_params: dict, user):
+    try:
+        results = await query_memory(
+            request,
+            QueryMemoryForm(
+                **{
+                    'content': get_last_user_message(form_data['messages']) or '',
+                    'k': 3,
+                }
+            ),
+            user,
+        )
+    except Exception as e:
+        log.debug(e)
+        results = None
+
+    user_context = ''
+    if results and hasattr(results, 'documents'):
+        if results.documents and len(results.documents) > 0:
+            for doc_idx, doc in enumerate(results.documents[0]):
+                created_at_date = 'Unknown Date'
+
+                if results.metadatas[0][doc_idx].get('created_at'):
+                    created_at_timestamp = results.metadatas[0][doc_idx]['created_at']
+                    created_at_date = time.strftime('%Y-%m-%d', time.localtime(created_at_timestamp))
+
+                user_context += f'{doc_idx + 1}. [{created_at_date}] {doc}\n'
+
+    form_data['messages'] = add_or_update_system_message(
+        f'User Context:\n{user_context}\n', form_data['messages'], append=True
+    )
+
+    return form_data
+
+
+async def chat_web_search_handler(request: Request, form_data: dict, extra_params: dict, user):
+    event_emitter = extra_params['__event_emitter__']
+    await event_emitter(
+        {
+            'type': 'status',
+            'data': {
+                'action': 'web_search',
+                'description': 'Searching the web',
+                'done': False,
+            },
+        }
+    )
+
+    messages = form_data['messages']
+    user_message = get_last_user_message(messages)
+
+    queries = []
+    try:
+        res = await generate_queries(
+            request,
+            {
+                'model': form_data['model'],
+                'messages': messages,
+                'prompt': user_message,
+                'type': 'web_search',
+                'chat_id': extra_params.get('__chat_id__'),
+            },
+            user,
+        )
+
+        # generate_queries returns a JSONResponse on error (e.g. model not
+        # found, chat completion failure).  Extract the error detail and
+        # re-raise so the outer except block falls back to using the raw
+        # user message as the search query.
+        if isinstance(res, JSONResponse):
+            try:
+                error_body = json.loads(res.body)
+                detail = error_body.get('detail', 'Query generation failed')
+            except Exception:
+                detail = 'Query generation failed'
+            raise Exception(detail)
+
+        response = res['choices'][0]['message']['content']
+
+        try:
+            bracket_start = response.rfind('{')
+            bracket_end = response.rfind('}') + 1
+
+            if bracket_start == -1 or bracket_end == -1:
+                raise Exception('No JSON object found in the response')
+
+            response = response[bracket_start:bracket_end]
+            queries = json.loads(response)
+            queries = queries.get('queries', [])
+        except Exception as e:
+            queries = [response]
+
+        if ENABLE_QUERIES_CACHE:
+            request.state.cached_queries = queries
+
+    except Exception as e:
+        log.exception(e)
+        queries = [user_message or '']
+
+    # Check if generated queries are empty
+    if len(queries) == 1 and queries[0].strip() == '':
+        queries = [user_message or '']
+
+    # Check if queries are not found
+    if len(queries) == 0:
+        await event_emitter(
+            {
+                'type': 'status',
+                'data': {
+                    'action': 'web_search',
+                    'description': 'No search query generated',
+                    'done': True,
+                },
+            }
+        )
+        return form_data
+
+    await event_emitter(
+        {
+            'type': 'status',
+            'data': {
+                'action': 'web_search_queries_generated',
+                'queries': queries,
+                'done': False,
+            },
+        }
+    )
+
+    try:
+        results = await process_web_search(
+            request,
+            SearchForm(queries=queries),
+            user=user,
+        )
+
+        if results:
+            files = form_data.get('files', [])
+
+            if results.get('collection_names'):
+                for col_idx, collection_name in enumerate(results.get('collection_names')):
+                    files.append(
+                        {
+                            'collection_name': collection_name,
+                            'name': ', '.join(queries),
+                            'type': 'web_search',
+                            'urls': results['filenames'],
+                            'queries': queries,
+                        }
+                    )
+            elif results.get('docs'):
+                # Invoked when bypass embedding and retrieval is set to True
+                docs = results['docs']
+                files.append(
+                    {
+                        'docs': docs,
+                        'name': ', '.join(queries),
+                        'type': 'web_search',
+                        'urls': results['filenames'],
+                        'queries': queries,
+                    }
+                )
+
+            form_data['files'] = files
+
+            await event_emitter(
+                {
+                    'type': 'status',
+                    'data': {
+                        'action': 'web_search',
+                        'description': 'Searched {{count}} sites',
+                        'urls': results['filenames'],
+                        'items': results.get('items', []),
+                        'done': True,
+                    },
+                }
+            )
+        else:
+            await event_emitter(
+                {
+                    'type': 'status',
+                    'data': {
+                        'action': 'web_search',
+                        'description': 'No search results found',
+                        'done': True,
+                        'error': True,
+                    },
+                }
+            )
+
+    except Exception as e:
+        log.exception(e)
+        await event_emitter(
+            {
+                'type': 'status',
+                'data': {
+                    'action': 'web_search',
+                    'description': 'An error occurred while searching the web',
+                    'queries': queries,
+                    'done': True,
+                    'error': True,
+                },
+            }
+        )
+
+    return form_data
+
+
+def get_images_from_messages(message_list):
+    images = []
+
+    for message in reversed(message_list):
+        message_images = []
+        for file in message.get('files', []):
+            if file.get('type') == 'image':
+                message_images.append(file.get('url'))
+            elif file.get('content_type', '').startswith('image/'):
+                message_images.append(file.get('url'))
+
+        if message_images:
+            images.append(message_images)
+
+    return images
+
+
+async def get_image_urls(delta_images, request, metadata, user) -> list[str]:
+    if not isinstance(delta_images, list):
+        return []
+
+    image_urls = []
+    for img in delta_images:
+        if not isinstance(img, dict) or img.get('type') != 'image_url':
+            continue
+
+        url = img.get('image_url', {}).get('url')
+        if not url:
+            continue
+
+        if url.startswith('data:image/png;base64'):
+            url = await get_image_url_from_base64(request, url, metadata, user)
+
+        image_urls.append(url)
+
+    return image_urls
+
+
+async def add_file_context(messages: list, chat_id: str, user) -> list:
+    """
+    Add file URLs to messages for native function calling.
+    """
+    if not chat_id or chat_id.startswith('local:') or chat_id.startswith('channel:'):
+        return messages
+
+    chat = await Chats.get_chat_by_id_and_user_id(chat_id, user.id)
+    if not chat:
+        return messages
+
+    history = chat.chat.get('history', {})
+    stored_messages = get_message_list(history.get('messages', {}), history.get('currentId'))
+
+    def format_file_tag(file):
+        attrs = f'type="{file.get("type", "file")}" url="{file["url"]}"'
+        if file.get('content_type'):
+            attrs += f' content_type="{file["content_type"]}"'
+        if file.get('name'):
+            attrs += f' name="{file["name"]}"'
+        return f'<file {attrs}/>'
+
+    # Pair only user-role messages from both lists to avoid misalignment.
+    # After process_messages_with_output(), assistant messages with tool calls
+    # are expanded into multiple messages (assistant + tool results), making
+    # the payload message list longer than the stored message list. A naive
+    # positional zip() would pair user messages with wrong stored messages,
+    # causing later images to lose their file context (see #21878).
+    user_messages = [m for m in messages if m.get('role') == 'user']
+    stored_user_messages = [m for m in stored_messages if m.get('role') == 'user']
+
+    for message, stored_message in zip(user_messages, stored_user_messages):
+        files_with_urls = [
+            file
+            for file in stored_message.get('files', [])
+            if file.get('url') and not file.get('url').startswith('data:')
+        ]
+        if not files_with_urls:
+            continue
+
+        file_tags = [format_file_tag(file) for file in files_with_urls]
+        file_context = '<attached_files>\n' + '\n'.join(file_tags) + '\n</attached_files>\n\n'
+
+        content = message.get('content', '')
+        if isinstance(content, list):
+            message['content'] = [{'type': 'text', 'text': file_context}] + content
+        else:
+            message['content'] = file_context + content
+
+    return messages
+
+
+async def chat_image_generation_handler(request: Request, form_data: dict, extra_params: dict, user):
+    metadata = extra_params.get('__metadata__', {})
+    chat_id = metadata.get('chat_id', None)
+    __event_emitter__ = extra_params.get('__event_emitter__', None)
+
+    if not chat_id or not isinstance(chat_id, str) or not __event_emitter__:
+        return form_data
+
+    if chat_id.startswith('local:') or chat_id.startswith('channel:'):
+        message_list = form_data.get('messages', [])
+    else:
+        chat = await Chats.get_chat_by_id_and_user_id(chat_id, user.id)
+        await __event_emitter__(
+            {
+                'type': 'status',
+                'data': {'description': 'Creating image', 'done': False},
+            }
+        )
+
+        messages_map = chat.chat.get('history', {}).get('messages', {})
+        message_id = chat.chat.get('history', {}).get('currentId')
+        message_list = get_message_list(messages_map, message_id)
+
+    user_message = get_last_user_message(message_list)
+
+    prompt = user_message
+    message_images = get_images_from_messages(message_list)
+
+    # Limit to first 2 sets of images
+    # We may want to change this in the future to allow more images
+    input_images = []
+    for idx, images in enumerate(message_images):
+        if idx >= 2:
+            break
+        for image in images:
+            input_images.append(image)
+
+    system_message_content = ''
+
+    if len(input_images) > 0 and request.app.state.config.ENABLE_IMAGE_EDIT:
+        # Edit image(s)
+        try:
+            images = await image_edits(
+                request=request,
+                form_data=EditImageForm(**{'prompt': prompt, 'image': input_images}),
+                metadata={
+                    'chat_id': metadata.get('chat_id', None),
+                    'message_id': metadata.get('message_id', None),
+                },
+                user=user,
+            )
+
+            await __event_emitter__(
+                {
+                    'type': 'status',
+                    'data': {'description': 'Image created', 'done': True},
+                }
+            )
+
+            await __event_emitter__(
+                {
+                    'type': 'files',
+                    'data': {
+                        'files': [
+                            {
+                                'type': 'image',
+                                'url': image['url'],
+                            }
+                            for image in images
+                        ]
+                    },
+                }
+            )
+
+            system_message_content = '<context>The requested image has been edited and created and is now being shown to the user. Let them know that it has been generated.</context>'
+        except Exception as e:
+            log.debug(e)
+
+            error_message = ''
+            if isinstance(e, HTTPException):
+                if e.detail and isinstance(e.detail, dict):
+                    error_message = e.detail.get('message', str(e.detail))
+                else:
+                    error_message = str(e.detail)
+
+            await __event_emitter__(
+                {
+                    'type': 'status',
+                    'data': {
+                        'description': f'An error occurred while generating an image',
+                        'done': True,
+                    },
+                }
+            )
+
+            system_message_content = f'<context>Image generation was attempted but failed. The system is currently unable to generate the image. Tell the user that the following error occurred: {error_message}</context>'
+
+    else:
+        # Create image(s)
+        if request.app.state.config.ENABLE_IMAGE_PROMPT_GENERATION:
+            try:
+                res = await generate_image_prompt(
+                    request,
+                    {
+                        'model': form_data['model'],
+                        'messages': form_data['messages'],
+                        'chat_id': metadata.get('chat_id'),
+                    },
+                    user,
+                )
+
+                # Handle JSONResponse from error paths
+                if isinstance(res, JSONResponse):
+                    try:
+                        error_body = json.loads(res.body)
+                        detail = error_body.get('detail', 'Image prompt generation failed')
+                    except Exception:
+                        detail = 'Image prompt generation failed'
+                    raise Exception(detail)
+
+                response = res['choices'][0]['message']['content']
+
+                try:
+                    bracket_start = response.rfind('{')
+                    bracket_end = response.rfind('}') + 1
+
+                    if bracket_start == -1 or bracket_end == -1:
+                        raise Exception('No JSON object found in the response')
+
+                    response = response[bracket_start:bracket_end]
+                    response = json.loads(response)
+                    prompt = response.get('prompt', [])
+                except Exception as e:
+                    prompt = user_message
+
+            except Exception as e:
+                log.exception(e)
+                prompt = user_message
+
+        try:
+            images = await image_generations(
+                request=request,
+                form_data=CreateImageForm(**{'prompt': prompt}),
+                metadata={
+                    'chat_id': metadata.get('chat_id', None),
+                    'message_id': metadata.get('message_id', None),
+                },
+                user=user,
+            )
+
+            await __event_emitter__(
+                {
+                    'type': 'status',
+                    'data': {'description': 'Image created', 'done': True},
+                }
+            )
+
+            await __event_emitter__(
+                {
+                    'type': 'files',
+                    'data': {
+                        'files': [
+                            {
+                                'type': 'image',
+                                'url': image['url'],
+                            }
+                            for image in images
+                        ]
+                    },
+                }
+            )
+
+            system_message_content = '<context>The requested image has been created by the system successfully and is now being shown to the user. Let the user know that the image they requested has been generated and is now shown in the chat.</context>'
+        except Exception as e:
+            log.debug(e)
+
+            error_message = ''
+            if isinstance(e, HTTPException):
+                if e.detail and isinstance(e.detail, dict):
+                    error_message = e.detail.get('message', str(e.detail))
+                else:
+                    error_message = str(e.detail)
+
+            await __event_emitter__(
+                {
+                    'type': 'status',
+                    'data': {
+                        'description': f'An error occurred while generating an image',
+                        'done': True,
+                    },
+                }
+            )
+
+            system_message_content = f'<context>Image generation was attempted but failed because of an error. The system is currently unable to generate the image. Tell the user that the following error occurred: {error_message}</context>'
+
+    if system_message_content:
+        form_data['messages'] = add_or_update_system_message(system_message_content, form_data['messages'])
+
+    return form_data
+
+
+async def chat_completion_files_handler(
+    request: Request, body: dict, extra_params: dict, user: UserModel
+) -> tuple[dict, dict[str, list]]:
+    __event_emitter__ = extra_params['__event_emitter__']
+    sources = []
+
+    if files := body.get('metadata', {}).get('files', None):
+        # Check if all files are in full context mode
+        all_full_context = all(item.get('context') == 'full' for item in files)
+
+        queries = []
+        if not all_full_context:
+            try:
+                queries_response = await generate_queries(
+                    request,
+                    {
+                        'model': body['model'],
+                        'messages': body['messages'],
+                        'type': 'retrieval',
+                        'chat_id': body.get('metadata', {}).get('chat_id'),
+                    },
+                    user,
+                )
+                queries_response = queries_response['choices'][0]['message']['content']
+
+                try:
+                    bracket_start = queries_response.rfind('{')
+                    bracket_end = queries_response.rfind('}') + 1
+
+                    if bracket_start == -1 or bracket_end == -1:
+                        raise Exception('No JSON object found in the response')
+
+                    queries_response = queries_response[bracket_start:bracket_end]
+                    queries_response = json.loads(queries_response)
+                except Exception as e:
+                    queries_response = {'queries': [queries_response]}
+
+                queries = queries_response.get('queries', [])
+            except Exception:
+                pass
+
+            await __event_emitter__(
+                {
+                    'type': 'status',
+                    'data': {
+                        'action': 'queries_generated',
+                        'queries': queries,
+                        'done': False,
+                    },
+                }
+            )
+
+        if len(queries) == 0:
+            queries = [get_last_user_message(body['messages']) or '']
+
+        try:
+            # Directly await async get_sources_from_items (no thread needed - fully async now)
+            sources = await get_sources_from_items(
+                request=request,
+                items=files,
+                queries=queries,
+                embedding_function=lambda query, prefix: request.app.state.EMBEDDING_FUNCTION(
+                    query, prefix=prefix, user=user
+                ),
+                k=request.app.state.config.TOP_K,
+                reranking_function=(
+                    (lambda query, documents: request.app.state.RERANKING_FUNCTION(query, documents, user=user))
+                    if request.app.state.RERANKING_FUNCTION
+                    else None
+                ),
+                k_reranker=request.app.state.config.TOP_K_RERANKER,
+                r=request.app.state.config.RELEVANCE_THRESHOLD,
+                hybrid_bm25_weight=request.app.state.config.HYBRID_BM25_WEIGHT,
+                hybrid_search=request.app.state.config.ENABLE_RAG_HYBRID_SEARCH,
+                full_context=all_full_context or request.app.state.config.RAG_FULL_CONTEXT,
+                user=user,
+            )
+        except Exception as e:
+            log.exception(e)
+
+        log.debug(f'rag_contexts:sources: {sources}')
+
+        unique_ids = set()
+        for source in sources or []:
+            if not source or len(source.keys()) == 0:
+                continue
+
+            documents = source.get('document') or []
+            metadatas = source.get('metadata') or []
+            src_info = source.get('source') or {}
+
+            for index, _ in enumerate(documents):
+                metadata = metadatas[index] if index < len(metadatas) else None
+                _id = (metadata or {}).get('source') or (src_info or {}).get('id') or 'N/A'
+                unique_ids.add(_id)
+
+        sources_count = len(unique_ids)
+        await __event_emitter__(
+            {
+                'type': 'status',
+                'data': {
+                    'action': 'sources_retrieved',
+                    'count': sources_count,
+                    'done': True,
+                },
+            }
+        )
+
+    return body, {'sources': sources}
+
+
+def apply_params_to_form_data(form_data, model):
+    params = form_data.pop('params', {})
+    custom_params = params.pop('custom_params', {})
+
+    open_webui_params = {
+        'stream_response': bool,
+        'stream_delta_chunk_size': int,
+        'function_calling': str,
+        'reasoning_tags': list,
+        'system': str,
+    }
+
+    for key in list(params.keys()):
+        if key in open_webui_params:
+            del params[key]
+
+    if custom_params:
+        # Attempt to parse custom_params if they are strings
+        for key, value in custom_params.items():
+            if isinstance(value, str):
+                try:
+                    # Attempt to parse the string as JSON
+                    custom_params[key] = json.loads(value)
+                except json.JSONDecodeError:
+                    # If it fails, keep the original string
+                    pass
+
+        # If custom_params are provided, merge them into params
+        params = deep_update(params, custom_params)
+
+    if model.get('owned_by') == 'ollama':
+        # Ollama specific parameters
+        form_data['options'] = params
+    else:
+        if isinstance(params, dict):
+            for key, value in params.items():
+                if value is not None:
+                    form_data[key] = value
+
+        if 'logit_bias' in params and params['logit_bias'] is not None:
+            try:
+                logit_bias = convert_logit_bias_input_to_json(params['logit_bias'])
+
+                if logit_bias:
+                    form_data['logit_bias'] = json.loads(logit_bias)
+            except Exception as e:
+                log.exception(f'Error parsing logit_bias: {e}')
+
+    return form_data
+
+
+async def convert_url_images_to_base64(form_data, user=None):
+    messages = form_data.get('messages', [])
+
+    for message in messages:
+        content = message.get('content')
+        if not isinstance(content, list):
+            continue
+
+        new_content = []
+
+        for item in content:
+            if not isinstance(item, dict) or item.get('type') != 'image_url':
+                new_content.append(item)
+                continue
+
+            image_url = item.get('image_url', {}).get('url', '')
+            if image_url.startswith('data:image/'):
+                new_content.append(item)
+                continue
+
+            try:
+                base64_data = await get_image_base64_from_url(image_url, user=user)
+                if base64_data:
+                    new_content.append(
+                        {
+                            'type': 'image_url',
+                            'image_url': {'url': base64_data},
+                        }
+                    )
+                else:
+                    new_content.append(item)
+            except Exception as e:
+                log.debug(f'Error converting image URL to base64: {e}')
+                new_content.append(item)
+
+        message['content'] = new_content
+
+    return form_data
+
+
+async def load_messages_from_db(chat_id: str, message_id: str) -> Optional[list[dict]]:
+    """
+    Load the message chain from DB up to message_id,
+    keeping only LLM-relevant fields (role, content, output).
+    """
+    messages_map = await Chats.get_messages_map_by_chat_id(chat_id)
+    if not messages_map:
+        return None
+
+    db_messages = get_message_list(messages_map, message_id)
+    if not db_messages:
+        return None
+
+    return [{k: v for k, v in msg.items() if k in ('role', 'content', 'output', 'files')} for msg in db_messages]
+
+
+def get_reasoning_format(model: dict) -> str | None:
+    """
+    Determine how reasoning should be included in reconstructed messages.
+
+    Returns:
+        'think_tags': Ollama expects <think> tags in content.
+        'reasoning_content': llama.cpp supports reasoning_content as a top-level field.
+        None: skip reasoning (safe default for strict providers).
+    """
+    provider = model.get('provider', '')
+    if provider == 'ollama':
+        return 'think_tags'
+    if provider == 'llama.cpp':
+        return 'reasoning_content'
+    return None
+
+
+def process_messages_with_output(
+    messages: list[dict],
+    reasoning_format: str | None = None,
+) -> list[dict]:
+    """
+    Process messages with OR-aligned output items for LLM consumption.
+
+    For assistant messages with 'output' field, produces properly formatted
+    OpenAI-style messages (tool_calls + tool results). Strips 'output' before LLM.
+    """
+    processed = []
+
+    for message in messages:
+        if message.get('role') == 'assistant' and message.get('output'):
+            # Use output items for clean OpenAI-format messages
+            output_messages = convert_output_to_messages(
+                message['output'],
+                raw=True,
+                reasoning_format=reasoning_format,
+            )
+            if output_messages:
+                processed.extend(output_messages)
+                continue
+
+        # Strip 'output' field before adding (LLM shouldn't see it)
+        clean_message = {k: v for k, v in message.items() if k != 'output'}
+        processed.append(clean_message)
+
+    return processed
+
+
+SKILL_MENTION_RE = re.compile(r'<\$([^|>]+)\|?[^>]*>')
+
+
+def _get_text_parts(message: dict) -> list[str]:
+    """Return all text segments from a message's content."""
+    content = message.get('content')
+    if isinstance(content, str):
+        return [content]
+    if isinstance(content, list):
+        return [p.get('text', '') for p in content if isinstance(p, dict) and p.get('type') == 'text']
+    return []
+
+
+def extract_skill_ids_from_messages(messages: list[dict]) -> set[str]:
+    """Extract skill IDs from <$skillId|label> mention tags in messages."""
+    ids: set[str] = set()
+    for message in messages:
+        for text in _get_text_parts(message):
+            ids.update(m.group(1) for m in SKILL_MENTION_RE.finditer(text))
+    return ids
+
+
+def strip_skill_mentions(messages: list[dict]) -> None:
+    """Replace <$skillId|label> mention tags with the label in message content in-place."""
+    strip_re = re.compile(r'<\$[^|>]+\|?([^>]*)>')
+    for message in messages:
+        content = message.get('content')
+        if isinstance(content, str) and strip_re.search(content):
+            message['content'] = strip_re.sub(r'\1', content).strip()
+        elif isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and part.get('type') == 'text':
+                    text = part.get('text', '')
+                    if strip_re.search(text):
+                        part['text'] = strip_re.sub(r'\1', text).strip()
+
+
+async def connect_mcp_server(
+    request,
+    server_id: str,
+    user,
+    metadata: dict,
+    extra_params: dict,
+) -> tuple[MCPClient, list[dict]] | None:
+    """Resolve an MCP server connection, authenticate, and return (client, tool_specs).
+
+    Returns None if the server is not found or access is denied.
+    """
+    mcp_server_connection = None
+    for server_connection in request.app.state.config.TOOL_SERVER_CONNECTIONS:
+        if server_connection.get('type', '') == 'mcp' and server_connection.get('info', {}).get('id') == server_id:
+            mcp_server_connection = server_connection
+            break
+
+    if not mcp_server_connection:
+        log.error(f'MCP server with id {server_id} not found')
+        return None
+
+    if not await has_connection_access(user, mcp_server_connection):
+        log.warning(f'Access denied to MCP server {server_id} for user {user.id}')
+        return None
+
+    headers, _ = await build_tool_server_headers(
+        mcp_server_connection,
+        request,
+        user,
+        server_id=server_id,
+        metadata=metadata,
+        extra_params=extra_params,
+    )
+
+    client = MCPClient()
+    await client.connect(
+        url=mcp_server_connection.get('url', ''),
+        headers=headers if headers else None,
+    )
+
+    function_name_filter_list = mcp_server_connection.get('config', {}).get('function_name_filter_list', '')
+    if isinstance(function_name_filter_list, str):
+        function_name_filter_list = function_name_filter_list.split(',')
+
+    tool_specs = await client.list_tool_specs()
+    if function_name_filter_list:
+        tool_specs = [spec for spec in tool_specs if is_string_allowed(spec['name'], function_name_filter_list)]
+
+    return client, tool_specs
+
+
+async def process_chat_payload(request, form_data, user, metadata, model):
+    # Ensure chat_id is always a string — external API clients may omit it.
+    if not isinstance(metadata.get('chat_id'), str):
+        metadata['chat_id'] = ''
+
+    # Pipeline Inlet -> Filter Inlet -> Chat Memory -> Chat Web Search -> Chat Image Generation
+    # -> Chat Code Interpreter (Form Data Update) -> (Default) Chat Tools Function Calling
+    # -> Chat Files
+
+    # Arena model resolution — pick the sub-model now so all downstream
+    # processing (knowledge, capabilities, tools, params) uses its settings
+    # instead of the empty arena wrapper.
+    if model.get('owned_by') == 'arena':
+        arena_model_ids = model.get('info', {}).get('meta', {}).get('model_ids')
+        arena_filter_mode = model.get('info', {}).get('meta', {}).get('filter_mode')
+        if arena_model_ids and arena_filter_mode == 'exclude':
+            arena_model_ids = [
+                available_model['id']
+                for available_model in request.app.state.MODELS.values()
+                if available_model.get('owned_by') != 'arena' and available_model['id'] not in arena_model_ids
+            ]
+
+        if isinstance(arena_model_ids, list) and arena_model_ids:
+            selected_model_id = random.choice(arena_model_ids)
+        else:
+            arena_model_ids = [
+                available_model['id']
+                for available_model in request.app.state.MODELS.values()
+                if available_model.get('owned_by') != 'arena'
+            ]
+            selected_model_id = random.choice(arena_model_ids)
+
+        selected_model = request.app.state.MODELS.get(selected_model_id)
+        if selected_model:
+            model = selected_model
+            form_data['model'] = selected_model_id
+            metadata['selected_model_id'] = selected_model_id
+
+    form_data = apply_params_to_form_data(form_data, model)
+    log.debug(f'form_data: {form_data}')
+
+    # Guided regeneration: extract before it reaches the LLM provider
+    regeneration_prompt = form_data.pop('regeneration_prompt', None)
+
+    # Load messages from DB when available — DB preserves structured 'output' items
+    # which the frontend strips, causing tool calls to be merged into content.
+    chat_id = metadata.get('chat_id')
+    user_message_id = metadata.get('user_message_id')
+
+    if chat_id and user_message_id and not chat_id.startswith('local:') and not chat_id.startswith('channel:'):
+        db_messages = await load_messages_from_db(chat_id, user_message_id)
+        if db_messages:
+            # Continue: frontend sends assistant_message_id when continuing
+            # an existing response. Load its content so the LLM sees prior output.
+            assistant_message_id = metadata.get('assistant_message_id')
+            if assistant_message_id:
+                assistant_message = await Chats.get_message_by_id_and_message_id(chat_id, assistant_message_id)
+                if assistant_message and (assistant_message.get('content') or assistant_message.get('output')):
+                    db_messages.append(
+                        {k: v for k, v in assistant_message.items() if k in ('role', 'content', 'output', 'files')}
+                    )
+
+            system_message = get_system_message(form_data.get('messages', []))
+            form_data['messages'] = [system_message, *db_messages] if system_message else db_messages
+
+            # Inject image files into content as image_url parts (mirrors frontend logic)
+            for message in form_data['messages']:
+                image_files = [
+                    f
+                    for f in message.get('files', [])
+                    if f.get('type') == 'image' or (f.get('content_type') or '').startswith('image/')
+                ]
+                if message.get('role') == 'user' and image_files:
+                    text_content = message.get('content', '')
+                    if isinstance(text_content, str):
+                        message['content'] = [
+                            {'type': 'text', 'text': text_content},
+                            *[
+                                {
+                                    'type': 'image_url',
+                                    'image_url': {'url': f['url']},
+                                }
+                                for f in image_files
+                                if f.get('url')
+                            ],
+                        ]
+                # Strip files field — it's been incorporated into content
+                message.pop('files', None)
+
+    if regeneration_prompt:
+        form_data['messages'].append({'role': 'user', 'content': regeneration_prompt})
+
+    # Process messages with OR-aligned output items for clean LLM messages
+    form_data['messages'] = process_messages_with_output(
+        form_data.get('messages', []),
+        reasoning_format=get_reasoning_format(model),
+    )
+
+    system_message = get_system_message(form_data.get('messages', []))
+    if system_message:  # Chat Controls/User Settings
+        try:
+            form_data = await apply_system_prompt_to_body(
+                system_message.get('content'), form_data, metadata, user, replace=True
+            )  # Required to handle system prompt variables
+        except Exception:
+            pass
+
+    form_data = await convert_url_images_to_base64(form_data, user=user)
+
+    event_emitter = await get_event_emitter(metadata)
+    event_caller = await get_event_call(metadata)
+
+    extra_params = {
+        '__event_emitter__': event_emitter,
+        '__event_call__': event_caller,
+        '__user__': user.model_dump() if isinstance(user, UserModel) else {},
+        '__metadata__': metadata,
+        '__oauth_token__': await get_system_oauth_token(request, user),
+        '__request__': request,
+        '__model__': model,
+        '__chat_id__': metadata.get('chat_id'),
+        '__message_id__': metadata.get('message_id'),
+    }
+    # Initialize events to store additional event to be sent to the client
+    # Initialize contexts and citation
+    if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
+        models = {
+            request.state.model['id']: request.state.model,
+        }
+    else:
+        models = request.app.state.MODELS
+
+    task_model_id = get_task_model_id(
+        form_data['model'],
+        request.app.state.config.TASK_MODEL,
+        request.app.state.config.TASK_MODEL_EXTERNAL,
+        models,
+    )
+
+    events = []
+    sources = []
+
+    # Folder "Project" handling
+    # Check if the request has chat_id and is inside of a folder
+    # Uses lightweight column query — only fetches folder_id, not the full chat JSON blob
+    chat_id = metadata.get('chat_id', None)
+    folder_id = None
+    if chat_id and user:
+        folder_id = await Chats.get_chat_folder_id(chat_id, user.id)
+
+    # Fallback: use folder_id from metadata (temporary chats have no DB record)
+    if not folder_id:
+        folder_id = metadata.get('folder_id', None)
+
+    if folder_id and user:
+        folder = await Folders.get_folder_by_id_and_user_id(folder_id, user.id)
+
+        if folder and folder.data:
+            if 'system_prompt' in folder.data:
+                form_data = await apply_system_prompt_to_body(folder.data['system_prompt'], form_data, metadata, user)
+            if 'files' in folder.data:
+                # Defensive: filter to entries the caller can still read.
+                allowed_files = await get_accessible_folder_files(folder.data['files'], user)
+                if metadata.get('params', {}).get('function_calling') != 'native':
+                    form_data['files'] = [
+                        *allowed_files,
+                        *form_data.get('files', []),
+                    ]
+                else:
+                    # Native FC: skip RAG injection, builtin tools
+                    # will read folder knowledge from metadata.
+                    metadata['folder_knowledge'] = allowed_files
+
+    # Model "Knowledge" handling
+    user_message = get_last_user_message(form_data['messages'])
+    model_knowledge = model.get('info', {}).get('meta', {}).get('knowledge', False)
+
+    if model_knowledge and metadata.get('params', {}).get('function_calling') != 'native':
+        await event_emitter(
+            {
+                'type': 'status',
+                'data': {
+                    'action': 'knowledge_search',
+                    'query': user_message,
+                    'done': False,
+                },
+            }
+        )
+
+        knowledge_files = []
+        for item in model_knowledge:
+            if item.get('collection_name'):
+                knowledge_files.append(
+                    {
+                        'id': item.get('collection_name'),
+                        'name': item.get('name'),
+                        'legacy': True,
+                    }
+                )
+            elif item.get('collection_names'):
+                knowledge_files.append(
+                    {
+                        'name': item.get('name'),
+                        'type': 'collection',
+                        'collection_names': item.get('collection_names'),
+                        'legacy': True,
+                    }
+                )
+            else:
+                knowledge_files.append(item)
+
+        files = form_data.get('files', [])
+        files.extend(knowledge_files)
+        form_data['files'] = files
+
+    variables = form_data.pop('variables', None)
+    payload_tools = form_data.get('tools', None)  # snapshot before filters
+
+    # Process the form_data through the pipeline
+    try:
+        form_data = await process_pipeline_inlet_filter(request, form_data, user, models)
+    except Exception as e:
+        raise e
+
+    try:
+        filter_ids = await get_sorted_filter_ids(request, model, metadata.get('filter_ids', []))
+        filter_functions = await Functions.get_functions_by_ids(filter_ids)
+
+        form_data, flags = await process_filter_functions(
+            request=request,
+            filter_functions=filter_functions,
+            filter_type='inlet',
+            form_data=form_data,
+            extra_params=extra_params,
+        )
+    except Exception as e:
+        raise Exception(f'{e}')
+
+    features = form_data.pop('features', None) or {}
+    extra_params['__features__'] = features
+    if features:
+        if 'voice' in features and features['voice']:
+            if getattr(request.app.state.config, 'ENABLE_VOICE_MODE_PROMPT', True):
+                if request.app.state.config.VOICE_MODE_PROMPT_TEMPLATE:
+                    template = request.app.state.config.VOICE_MODE_PROMPT_TEMPLATE
+                else:
+                    template = DEFAULT_VOICE_MODE_PROMPT_TEMPLATE
+
+                form_data['messages'] = add_or_update_system_message(
+                    template,
+                    form_data['messages'],
+                )
+
+        if 'memory' in features and features['memory']:
+            # Skip forced memory injection when native FC is enabled - model can use memory tools
+            if metadata.get('params', {}).get('function_calling') != 'native':
+                form_data = await chat_memory_handler(request, form_data, extra_params, user)
+
+        if 'web_search' in features and features['web_search']:
+            # Skip forced RAG web search when native FC is enabled - model can use web_search tool
+            if metadata.get('params', {}).get('function_calling') != 'native':
+                form_data = await chat_web_search_handler(request, form_data, extra_params, user)
+
+        if 'image_generation' in features and features['image_generation']:
+            # Skip forced image generation when native FC is enabled - model can use generate_image tool
+            if metadata.get('params', {}).get('function_calling') != 'native':
+                form_data = await chat_image_generation_handler(request, form_data, extra_params, user)
+
+        if 'code_interpreter' in features and features['code_interpreter']:
+            engine = getattr(request.app.state.config, 'CODE_INTERPRETER_ENGINE', 'pyodide')
+
+            # Skip XML-tag prompt injection when native FC is enabled —
+            # execute_code will be injected as a builtin tool instead
+            if metadata.get('params', {}).get('function_calling') != 'native':
+                prompt = (
+                    request.app.state.config.CODE_INTERPRETER_PROMPT_TEMPLATE
+                    if request.app.state.config.CODE_INTERPRETER_PROMPT_TEMPLATE != ''
+                    else DEFAULT_CODE_INTERPRETER_PROMPT
+                )
+
+                # Append filesystem awareness only for pyodide engine
+                if engine != 'jupyter':
+                    prompt += CODE_INTERPRETER_PYODIDE_PROMPT
+
+                form_data['messages'] = add_or_update_user_message(
+                    prompt,
+                    form_data['messages'],
+                )
+            else:
+                # Native FC: tool docstring can't be dynamic, so inject
+                # filesystem context into the system message for pyodide
+                # engine.  Appending to the system prompt (instead of the
+                # user message) keeps it in the stable cached prefix so
+                # providers with prefix caching don't re-bill the full
+                # conversation on every turn.
+                if engine != 'jupyter':
+                    form_data['messages'] = add_or_update_system_message(
+                        CODE_INTERPRETER_PYODIDE_PROMPT,
+                        form_data['messages'],
+                        append=True,
+                    )
+
+    tool_ids = form_data.pop('tool_ids', None)
+    terminal_id = form_data.pop('terminal_id', None)
+    files = form_data.pop('files', None)
+    form_data.pop('folder_id', None)
+
+    # If the original caller provided tools, use them as-is (skip resolution).
+    # Otherwise, save any tools that filter inlets added for merging later.
+    inlet_filter_tools = None if payload_tools else form_data.get('tools', None)
+
+    # Skills — extract IDs from message content (<$skillId|label> tags) so
+    # persisted chats work without relying on the frontend to send skill_ids.
+    user_skill_ids = set(form_data.pop('skill_ids', None) or [])
+    user_skill_ids |= extract_skill_ids_from_messages(form_data.get('messages', []))
+    model_skill_ids = set(model.get('info', {}).get('meta', {}).get('skillIds', []))
+
+    all_skill_ids = user_skill_ids | model_skill_ids
+    available_skills = []
+    if all_skill_ids:
+        from open_webui.models.skills import Skills as SkillsModel
+
+        accessible_skill_ids = {s.id for s in await SkillsModel.get_skills_by_user_id(user.id, 'read')}
+        available_skills = []
+        for sid in all_skill_ids:
+            if sid in accessible_skill_ids:
+                s = await SkillsModel.get_skill_by_id(sid)
+                if s and s.is_active:
+                    available_skills.append(s)
+
+        skill_descriptions = ''
+        for skill in available_skills:
+            if skill.id in user_skill_ids:
+                # User-selected: inject full content
+                form_data['messages'] = add_or_update_system_message(
+                    f'<skill name="{skill.name}">\n{skill.content}\n</skill>',
+                    form_data['messages'],
+                    append=True,
+                )
+            else:
+                # Model-attached: name+description only
+                skill_descriptions += f'<skill>\n<id>{skill.id}</id>\n<name>{skill.name}</name>\n<description>{skill.description or ""}</description>\n</skill>\n'
+
+        if skill_descriptions:
+            form_data['messages'] = add_or_update_system_message(
+                f'<available_skills>\n{skill_descriptions}</available_skills>',
+                form_data['messages'],
+                append=True,
+            )
+
+    # Strip <$skillId|label> mention tags so the model doesn't see raw markup.
+    strip_skill_mentions(form_data.get('messages', []))
+
+    prompt = get_last_user_message(form_data['messages'])
+
+    # Guard against empty user message after skill mention stripping.
+    # When a user selects a skill ($skill-name) without typing additional text,
+    # the stripped result is an empty string which causes 400 errors on providers
+    # that reject empty content blocks (e.g. AWS Bedrock ConverseStream).
+    if not prompt or not prompt.strip():
+        fallback = ', '.join(s.name for s in available_skills)
+        if fallback:
+            set_last_user_message_content(fallback, form_data['messages'])
+            prompt = fallback
+    # TODO: re-enable URL extraction from prompt
+    # urls = []
+    # if prompt and len(prompt or "") < 500 and (not files or len(files) == 0):
+    #     urls = extract_urls(prompt)
+
+    if files:
+        if not files:
+            files = []
+
+        for file_item in files:
+            if file_item.get('type', 'file') == 'folder':
+                # Get folder files
+                folder_id = file_item.get('id', None)
+                if folder_id:
+                    folder = await Folders.get_folder_by_id_and_user_id(folder_id, user.id)
+                    if folder and folder.data and 'files' in folder.data:
+                        files = [f for f in files if f.get('id', None) != folder_id]
+                        files = [*files, *await get_accessible_folder_files(folder.data['files'], user)]
+
+        # files = [*files, *[{"type": "url", "url": url, "name": url} for url in urls]]
+        # Remove duplicate files based on their content
+        files = list({json.dumps(f, sort_keys=True): f for f in files}.values())
+
+    metadata = {
+        **metadata,
+        'model_id': form_data.get('model'),
+        'tool_ids': tool_ids,
+        'terminal_id': terminal_id,
+        'files': files,
+    }
+    form_data['metadata'] = metadata
+
+    # When the caller provides an explicit OpenAI-style `tools` array in the
+    # request body, skip all server-side tool resolution and pass the caller's
+    # tools through to the model unchanged.
+    if not payload_tools:
+        # Server side tools
+        tool_ids = metadata.get('tool_ids', None)
+        # Client side tools
+        direct_tool_servers = metadata.get('tool_servers', None)
+
+        log.debug(f'{tool_ids=}')
+        log.debug(f'{direct_tool_servers=}')
+
+        tools_dict = {}
+
+        mcp_clients = {}
+        mcp_tools_dict = {}
+
+        if tool_ids:
+            for tool_id in tool_ids:
+                if tool_id.startswith('server:mcp:'):
+                    try:
+                        server_id = tool_id[len('server:mcp:') :]
+
+                        result = await connect_mcp_server(
+                            request,
+                            server_id,
+                            user,
+                            metadata,
+                            extra_params,
+                        )
+                        if result is None:
+                            continue
+
+                        client, tool_specs = result
+                        mcp_clients[server_id] = client
+
+                        for tool_spec in tool_specs:
+
+                            async def make_tool_function(client, function_name):
+                                async def tool_function(**kwargs):
+                                    return await client.call_tool(
+                                        function_name,
+                                        function_args=kwargs,
+                                    )
+
+                                return tool_function
+
+                            tool_function = await make_tool_function(client, tool_spec['name'])
+
+                            mcp_tools_dict[f'{server_id}_{tool_spec["name"]}'] = {
+                                'spec': {
+                                    **tool_spec,
+                                    'name': f'{server_id}_{tool_spec["name"]}',
+                                },
+                                'callable': tool_function,
+                                'type': 'mcp',
+                                'client': client,
+                                'direct': False,
+                            }
+                    except Exception as e:
+                        log.debug(e)
+                        if event_emitter:
+                            await event_emitter(
+                                {
+                                    'type': 'chat:message:error',
+                                    'data': {'error': {'content': f"Failed to connect to MCP server '{server_id}'"}},
+                                }
+                            )
+                        continue
+
+            tools_dict = await get_tools(
+                request,
+                tool_ids,
+                user,
+                {
+                    **extra_params,
+                    '__model__': models[task_model_id],
+                    '__messages__': form_data['messages'],
+                    '__files__': metadata.get('files', []),
+                },
+            )
+
+            if mcp_tools_dict:
+                tools_dict = {**tools_dict, **mcp_tools_dict}
+
+        # Resolve terminal tools if terminal_id is set (outside tool_ids check
+        # so system terminals work even when no other tools are selected)
+        terminal_capability = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get('terminal', True)
+        if terminal_id and terminal_capability:
+            try:
+                terminal_result = await get_terminal_tools(
+                    request,
+                    terminal_id,
+                    user,
+                    extra_params,
+                )
+                if isinstance(terminal_result, tuple):
+                    terminal_tools, system_prompt = terminal_result
+                else:
+                    terminal_tools = terminal_result
+                    system_prompt = None
+                if terminal_tools:
+                    tools_dict = {**tools_dict, **terminal_tools}
+                if system_prompt:
+                    form_data['messages'] = add_or_update_system_message(
+                        system_prompt,
+                        form_data['messages'],
+                        append=True,
+                    )
+            except Exception as e:
+                log.exception(e)
+
+        if direct_tool_servers:
+            for tool_server in direct_tool_servers:
+                system_prompt = tool_server.pop('system_prompt', None)
+                if system_prompt:
+                    form_data['messages'] = add_or_update_system_message(
+                        system_prompt,
+                        form_data['messages'],
+                        append=True,
+                    )
+
+                tool_specs = tool_server.pop('specs', [])
+
+                for tool in tool_specs:
+                    tools_dict[tool['name']] = {
+                        'spec': tool,
+                        'direct': True,
+                        'server': tool_server,
+                    }
+
+        if mcp_clients:
+            metadata['mcp_clients'] = mcp_clients
+
+        # Inject builtin tools for native function calling based on enabled features and model capability
+        # Check if builtin_tools capability is enabled for this model (defaults to True if not specified)
+        builtin_tools_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get(
+            'builtin_tools', True
+        )
+        if metadata.get('params', {}).get('function_calling') == 'native' and builtin_tools_enabled:
+            # Add file context to user messages
+            chat_id = metadata.get('chat_id')
+            form_data['messages'] = await add_file_context(form_data.get('messages', []), chat_id, user)
+            builtin_tools = await get_builtin_tools(
+                request,
+                {
+                    **extra_params,
+                    '__event_emitter__': event_emitter,
+                    '__skill_ids__': [s.id for s in available_skills if s.id not in user_skill_ids],
+                },
+                features,
+                model,
+            )
+            for name, tool_dict in builtin_tools.items():
+                if name not in tools_dict:
+                    tools_dict[name] = tool_dict
+
+        if tools_dict:
+            # Always store resolved tools in metadata so downstream consumers
+            # (e.g. pipe functions) can access all tools including MCP and builtins.
+            metadata['tools'] = tools_dict
+
+            if metadata.get('params', {}).get('function_calling') == 'native':
+                # If the function calling is native, then call the tools function calling handler
+                form_data['tools'] = [
+                    {'type': 'function', 'function': tool.get('spec', {})} for tool in tools_dict.values()
+                ]
+                if inlet_filter_tools:
+                    form_data['tools'].extend(inlet_filter_tools)
+            else:
+                # If the function calling is not native, then call the tools function calling handler
+                try:
+                    form_data, flags = await chat_completion_tools_handler(
+                        request, form_data, extra_params, user, models, tools_dict
+                    )
+                    sources.extend(flags.get('sources', []))
+                except Exception as e:
+                    log.exception(e)
+
+    # Check if file context extraction is enabled for this model (default True)
+    file_context_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get('file_context', True)
+
+    if file_context_enabled:
+        try:
+            form_data, flags = await chat_completion_files_handler(request, form_data, extra_params, user)
+            sources.extend(flags.get('sources', []))
+        except Exception as e:
+            log.exception(e)
+
+    # Save the pre-RAG message state so the native tool call loop can
+    # restore to the true original (before file-source injection) rather
+    # than a snapshot that already has the RAG template baked in.
+    system_message = get_system_message(form_data['messages'])
+    metadata['system_prompt'] = get_content_from_message(system_message) if system_message else None
+    metadata['user_prompt'] = get_last_user_message(form_data['messages'])
+    metadata['sources'] = sources[:] if sources else []
+
+    # If context is not empty, insert it into the messages
+    if sources and prompt:
+        form_data['messages'] = await apply_source_context_to_messages(request, form_data['messages'], sources, prompt)
+
+    # If there are citations, add them to the data_items
+    sources = [
+        source
+        for source in sources
+        if source.get('source', {}).get('name', '') or source.get('source', {}).get('id', '')
+    ]
+
+    if len(sources) > 0:
+        events.append({'sources': sources})
+
+    if model_knowledge:
+        await event_emitter(
+            {
+                'type': 'status',
+                'data': {
+                    'action': 'knowledge_search',
+                    'query': user_message,
+                    'done': True,
+                    'hidden': True,
+                },
+            }
+        )
+
+    # Strip empty text content blocks from multimodal messages
+    # to prevent errors from providers like Gemini and Claude
+    form_data['messages'] = strip_empty_content_blocks(form_data.get('messages', []))
+
+    # Merge any duplicate system messages into a single message at position 0
+    # to prevent template parsing errors with strict chat templates (e.g. Qwen)
+    form_data['messages'] = merge_system_messages(form_data.get('messages', []))
+
+    return form_data, metadata, events
+
+
+async def get_event_emitter_and_caller(metadata):
+    event_emitter = None
+    event_caller = None
+
+    # event_emitter only needs user_id + chat_id + message_id.
+    # It broadcasts to user:{user_id} room AND persists to DB,
+    # so it works for backend-initiated calls (automations, API).
+    if metadata.get('chat_id') and metadata.get('message_id'):
+        event_emitter = await get_event_emitter(metadata)
+
+    # event_caller needs session_id — it calls back to a specific
+    # websocket session (used by direct tools, pyodide code interpreter).
+    if metadata.get('session_id') and metadata.get('chat_id') and metadata.get('message_id'):
+        event_caller = await get_event_call(metadata)
+
+    return event_emitter, event_caller
+
+
+async def build_chat_response_context(request, form_data, user, model, metadata, tasks, events):
+    event_emitter, event_caller = await get_event_emitter_and_caller(metadata)
+    return {
+        'request': request,
+        'form_data': form_data,
+        'user': user,
+        'model': model,
+        'metadata': metadata,
+        'tasks': tasks,
+        'events': events,
+        'event_emitter': event_emitter,
+        'event_caller': event_caller,
+    }
+
+
+def get_response_data(response):
+    if isinstance(response, list) and len(response) == 1:
+        # If the response is a single-item list, unwrap it #17213
+        response = response[0]
+
+    if isinstance(response, JSONResponse):
+        if isinstance(response.body, bytes):
+            try:
+                response_data = json.loads(response.body.decode('utf-8', 'replace'))
+            except json.JSONDecodeError:
+                response_data = {'error': {'detail': 'Invalid JSON response'}}
+        else:
+            response_data = response
+    elif isinstance(response, dict):
+        response_data = response
+    else:
+        response_data = None
+
+    return response, response_data
+
+
+def merge_events_into_response(response_data, events):
+    if events and isinstance(events, list):
+        extra_response = {}
+        for event in events:
+            if isinstance(event, dict):
+                extra_response.update(event)
+            else:
+                extra_response[event] = True
+
+        return {
+            **extra_response,
+            **response_data,
+        }
+    return response_data
+
+
+def build_response_object(response, response_data):
+    if isinstance(response, dict):
+        return response_data
+    if isinstance(response, JSONResponse):
+        return JSONResponse(
+            content=response_data,
+            headers=response.headers,
+            status_code=response.status_code,
+        )
+    return response
+
+
+async def get_system_oauth_token(request, user):
+    """Get the system OAuth token for a user.
+
+    Primary path: use the oauth_session_id cookie (browser requests).
+    Fallback: look up the user's most recent OAuth session from the DB
+    (covers automations, API calls, and other cookie-less contexts).
+    """
+    oauth_token = None
+    try:
+        oauth_session_id = request.cookies.get('oauth_session_id', None)
+        if oauth_session_id:
+            oauth_token = await request.app.state.oauth_manager.get_oauth_token(
+                user.id,
+                oauth_session_id,
+            )
+
+        # Fallback: no cookie (automation, API key, etc.) — use most recent session
+        if oauth_token is None:
+            from open_webui.models.oauth_sessions import OAuthSessions
+
+            sessions = await OAuthSessions.get_sessions_by_user_id(user.id)
+            # Filter out MCP-provider sessions — their token refresh is handled
+            # separately by oauth_client_manager.  Passing them to the SSO
+            # oauth_manager causes a failed refresh and session deletion (#24618).
+            sessions = [s for s in sessions if not (s.provider or '').startswith('mcp:')]
+            if sessions:
+                best = max(sessions, key=lambda s: s.updated_at)
+                oauth_token = await request.app.state.oauth_manager.get_oauth_token(
+                    user.id,
+                    best.id,
+                )
+    except Exception as e:
+        log.error(f'Error getting OAuth token: {e}')
+    return oauth_token
+
+
+async def background_tasks_handler(ctx):
+    request = ctx['request']
+    form_data = ctx['form_data']
+    user = ctx['user']
+    metadata = ctx['metadata']
+    tasks = ctx['tasks']
+    event_emitter = ctx['event_emitter']
+
+    message = None
+    messages = []
+
+    if (
+        'chat_id' in metadata
+        and not metadata.get('chat_id', '').startswith('local:')
+        and not metadata.get('chat_id', '').startswith('channel:')
+    ):
+        messages_map = await Chats.get_messages_map_by_chat_id(metadata['chat_id'])
+        if not messages_map:
+            # Chat was deleted while the response was streaming — skip background tasks
+            return
+        message = messages_map.get(metadata['message_id'])
+
+        message_list = get_message_list(messages_map, metadata['message_id'])
+
+        # Remove details tags and files from the messages.
+        # as get_message_list creates a new list, it does not affect
+        # the original messages outside of this handler
+
+        messages = []
+        for message in message_list:
+            content = message.get('content', '')
+            if isinstance(content, list):
+                for item in content:
+                    if item.get('type') == 'text':
+                        content = item['text']
+                        break
+
+            if isinstance(content, str):
+                content = re.sub(
+                    r'<details\b[^>]*>.*?<\/details>|!\[.*?\]\(.*?\)',
+                    '',
+                    content,
+                    flags=re.S | re.I,
+                ).strip()
+
+            messages.append(
+                {
+                    **message,
+                    'role': message.get('role', 'assistant'),  # Safe fallback for missing role
+                    'content': content,
+                }
+            )
+    else:
+        # Local temp chat, get the model and message from the form_data
+        message = get_last_user_message_item(form_data.get('messages', []))
+        messages = form_data.get('messages', [])
+        if message:
+            message['model'] = form_data.get('model')
+
+    if message and 'model' in message:
+        if tasks and messages:
+            if TASKS.FOLLOW_UP_GENERATION in tasks and tasks[TASKS.FOLLOW_UP_GENERATION]:
+                res = await generate_follow_ups(
+                    request,
+                    {
+                        'model': message['model'],
+                        'messages': messages,
+                        'message_id': metadata['message_id'],
+                        'chat_id': metadata['chat_id'],
+                    },
+                    user,
+                )
+
+                if res and isinstance(res, dict):
+                    if len(res.get('choices', [])) == 1:
+                        response_message = res.get('choices', [])[0].get('message', {})
+
+                        follow_ups_string = response_message.get('content') or response_message.get(
+                            'reasoning_content', ''
+                        )
+                    else:
+                        follow_ups_string = ''
+
+                    follow_ups_string = follow_ups_string[
+                        follow_ups_string.find('{') : follow_ups_string.rfind('}') + 1
+                    ]
+
+                    try:
+                        follow_ups = json.loads(follow_ups_string).get('follow_ups', [])
+                        await event_emitter(
+                            {
+                                'type': 'chat:message:follow_ups',
+                                'data': {
+                                    'follow_ups': follow_ups,
+                                },
+                            }
+                        )
+
+                        if not metadata.get('chat_id', '').startswith('local:') and not metadata.get(
+                            'chat_id', ''
+                        ).startswith('channel:'):
+                            await Chats.upsert_message_to_chat_by_id_and_message_id(
+                                metadata['chat_id'],
+                                metadata['message_id'],
+                                {
+                                    'followUps': follow_ups,
+                                },
+                            )
+
+                    except Exception as e:
+                        pass
+
+            if not metadata.get('chat_id', '').startswith('local:') and not metadata.get('chat_id', '').startswith(
+                'channel:'
+            ):  # Only update titles and tags for non-temp chats
+                if TASKS.TITLE_GENERATION in tasks:
+                    user_message = get_last_user_message(messages)
+                    if user_message and len(user_message) > 100:
+                        user_message = user_message[:100] + '...'
+
+                    title = None
+                    if tasks[TASKS.TITLE_GENERATION]:
+                        res = await generate_title(
+                            request,
+                            {
+                                'model': message['model'],
+                                'messages': messages,
+                                'chat_id': metadata['chat_id'],
+                            },
+                            user,
+                        )
+
+                        if res and isinstance(res, dict):
+                            if len(res.get('choices', [])) == 1:
+                                response_message = res.get('choices', [])[0].get('message', {})
+
+                                title_string = (
+                                    response_message.get('content')
+                                    or response_message.get(
+                                        'reasoning_content',
+                                    )
+                                    or message.get('content', user_message)
+                                )
+                            else:
+                                title_string = ''
+
+                            title_string = title_string[title_string.find('{') : title_string.rfind('}') + 1]
+
+                            try:
+                                title = json.loads(title_string).get('title', user_message)
+                            except Exception as e:
+                                title = ''
+
+                            if not title:
+                                title = messages[0].get('content', user_message)
+
+                            await Chats.update_chat_title_by_id(metadata['chat_id'], title)
+
+                            await event_emitter(
+                                {
+                                    'type': 'chat:title',
+                                    'data': title,
+                                }
+                            )
+
+                    if title == None and len(messages) == 2 and (not messages_map or len(messages_map) <= 2):
+                        title = messages[0].get('content', user_message)
+
+                        await Chats.update_chat_title_by_id(metadata['chat_id'], title)
+
+                        await event_emitter(
+                            {
+                                'type': 'chat:title',
+                                'data': message.get('content', user_message),
+                            }
+                        )
+
+                if TASKS.TAGS_GENERATION in tasks and tasks[TASKS.TAGS_GENERATION]:
+                    res = await generate_chat_tags(
+                        request,
+                        {
+                            'model': message['model'],
+                            'messages': messages,
+                            'chat_id': metadata['chat_id'],
+                        },
+                        user,
+                    )
+
+                    if res and isinstance(res, dict):
+                        if len(res.get('choices', [])) == 1:
+                            response_message = res.get('choices', [])[0].get('message', {})
+
+                            tags_string = response_message.get('content') or response_message.get(
+                                'reasoning_content', ''
+                            )
+                        else:
+                            tags_string = ''
+
+                        tags_string = tags_string[tags_string.find('{') : tags_string.rfind('}') + 1]
+
+                        try:
+                            tags = json.loads(tags_string).get('tags', [])
+                            await Chats.update_chat_tags_by_id(metadata['chat_id'], tags, user)
+
+                            await event_emitter(
+                                {
+                                    'type': 'chat:tags',
+                                    'data': tags,
+                                }
+                            )
+                        except Exception as e:
+                            pass
+
+
+async def outlet_filter_handler(ctx):
+    """Run outlet filters inline after chat completion.
+
+    Replaces the separate POST /api/chat/completed round-trip.
+    Persists outlet-modified content to DB and emits a chat:outlet event
+    so the frontend can sync its in-memory state.
+
+    For temp chats (local: prefix), messages are built from form_data
+    plus the assistant response message stored in ctx['assistant_message'],
+    since temp chats have no DB-persisted history.
+    """
+    request = ctx['request']
+    user = ctx['user']
+    model = ctx['model']
+    metadata = ctx['metadata']
+    event_emitter = ctx.get('event_emitter')
+    event_caller = ctx.get('event_caller')
+
+    chat_id = metadata.get('chat_id', '')
+    message_id = metadata.get('message_id')
+
+    if not chat_id or not message_id:
+        return
+
+    is_temp_chat = chat_id.startswith('local:') or chat_id.startswith('channel:')
+
+    try:
+        messages_map = None
+
+        if is_temp_chat:
+            # Temp chats have no DB record — build message list from
+            # the in-memory form_data plus the assistant response.
+            form_messages = ctx.get('form_data', {}).get('messages', [])
+            assistant_message = ctx.get('assistant_message', {})
+
+            message_list = [
+                {
+                    'role': m.get('role'),
+                    'content': m.get('content', ''),
+                }
+                for m in form_messages
+            ]
+
+            # Append the full assistant message (content, output, usage, etc.)
+            if assistant_message:
+                message_list.append(
+                    {
+                        'id': message_id,
+                        'role': 'assistant',
+                        **assistant_message,
+                    }
+                )
+        else:
+            messages_map = await Chats.get_messages_map_by_chat_id(chat_id)
+            if not messages_map:
+                return
+
+            message_list = get_message_list(messages_map, message_id)
+            if not message_list:
+                return
+
+        model_id = model.get('id') if isinstance(model, dict) else model
+
+        outlet_data = {
+            'model': model_id,
+            'messages': [
+                {
+                    'id': m.get('id'),
+                    'role': m.get('role'),
+                    'content': m.get('content', ''),
+                    'info': m.get('info'),
+                    'timestamp': m.get('timestamp'),
+                    **({'output': m['output']} if m.get('output') else {}),
+                    **({'usage': m['usage']} if m.get('usage') else {}),
+                    **({'sources': m['sources']} if m.get('sources') else {}),
+                }
+                for m in message_list
+            ],
+            'filter_ids': metadata.get('filter_ids', []),
+            'chat_id': chat_id,
+            'session_id': metadata.get('session_id'),
+            'id': message_id,
+        }
+
+        # Pipeline outlet filters
+        models = request.app.state.MODELS
+        try:
+            outlet_data = await process_pipeline_outlet_filter(request, outlet_data, user, models)
+        except Exception as e:
+            log.debug(f'Pipeline outlet filter error: {e}')
+
+        # Function outlet filters
+        extra_params = {
+            '__event_emitter__': event_emitter,
+            '__event_call__': event_caller,
+            '__user__': user.model_dump() if isinstance(user, UserModel) else {},
+            '__metadata__': metadata,
+            '__request__': request,
+            '__model__': model,
+        }
+
+        filter_ids = await get_sorted_filter_ids(request, model, metadata.get('filter_ids', []))
+        filter_functions = await Functions.get_functions_by_ids(filter_ids)
+
+        outlet_result, _ = await process_filter_functions(
+            request=request,
+            filter_functions=filter_functions,
+            filter_type='outlet',
+            form_data=outlet_data,
+            extra_params=extra_params,
+        )
+
+        # Persist outlet-modified content and notify frontend
+        # (skip DB persistence for temp chats — they have no DB record)
+        if outlet_result and outlet_result.get('messages'):
+            if not is_temp_chat and messages_map:
+                for message in outlet_result['messages']:
+                    outlet_message_id = message.get('id')
+                    if outlet_message_id and outlet_message_id in messages_map:
+                        original_message = messages_map[outlet_message_id]
+                        content_changed = original_message.get('content') != message.get('content')
+                        output_changed = message.get('output') and message.get('output') != original_message.get(
+                            'output'
+                        )
+                        if content_changed or output_changed:
+                            # If output was modified, re-derive content from it
+                            new_content = message.get('content', original_message.get('content', ''))
+                            if output_changed:
+                                new_content = serialize_output(message['output'])
+                            await Chats.upsert_message_to_chat_by_id_and_message_id(
+                                chat_id,
+                                outlet_message_id,
+                                {
+                                    'content': new_content,
+                                    'originalContent': original_message.get('content'),
+                                    **({'output': message['output']} if output_changed else {}),
+                                },
+                            )
+
+            if event_emitter:
+                await event_emitter(
+                    {
+                        'type': 'chat:outlet',
+                        'data': {'messages': outlet_result['messages']},
+                    }
+                )
+    except Exception as e:
+        log.debug(f'Error running outlet filters: {e}')
+
+
+async def non_streaming_chat_response_handler(response, ctx):
+    request = ctx['request']
+
+    user = ctx['user']
+    metadata = ctx['metadata']
+    events = ctx['events']
+
+    event_emitter = ctx['event_emitter']
+
+    response, response_data = get_response_data(response)
+    if response_data is None:
+        return response
+
+    if event_emitter:
+        try:
+            if 'error' in response_data:
+                error = response_data.get('error')
+
+                if isinstance(error, dict):
+                    error = error.get('detail', error)
+                else:
+                    error = str(error)
+
+                log.error('Provider returned error (non-streaming): %s', error)
+
+                if not metadata.get('chat_id', '').startswith('channel:'):
+                    await Chats.upsert_message_to_chat_by_id_and_message_id(
+                        metadata['chat_id'],
+                        metadata['message_id'],
+                        {
+                            'error': {'content': error},
+                        },
+                    )
+                if isinstance(error, str) or isinstance(error, dict):
+                    await event_emitter(
+                        {
+                            'type': 'chat:message:error',
+                            'data': {'error': {'content': error}},
+                        }
+                    )
+
+            if 'selected_model_id' in response_data and not metadata.get('chat_id', '').startswith('channel:'):
+                await Chats.upsert_message_to_chat_by_id_and_message_id(
+                    metadata['chat_id'],
+                    metadata['message_id'],
+                    {
+                        'selectedModelId': response_data['selected_model_id'],
+                    },
+                )
+
+            choices = response_data.get('choices', [])
+            if choices and choices[0].get('message', {}).get('content'):
+                content = response_data['choices'][0]['message']['content']
+
+                if content:
+                    await event_emitter(
+                        {
+                            'type': 'chat:completion',
+                            'data': response_data,
+                        }
+                    )
+
+                    title = (
+                        await Chats.get_chat_title_by_id(metadata['chat_id'])
+                        if not metadata.get('chat_id', '').startswith('channel:')
+                        else ''
+                    )
+
+                    # Use output from backend if provided (OR-compliant backends),
+                    # otherwise generate from response content
+                    response_output = response_data.get('output')
+                    if not response_output:
+                        response_output = [
+                            {
+                                'type': 'message',
+                                'id': output_id('msg'),
+                                'status': 'completed',
+                                'role': 'assistant',
+                                'content': [{'type': 'output_text', 'text': content}],
+                            }
+                        ]
+
+                    await event_emitter(
+                        {
+                            'type': 'chat:completion',
+                            'data': {
+                                'done': True,
+                                'content': content,
+                                'output': response_output,
+                                'title': title,
+                            },
+                        }
+                    )
+
+                    # Save message in the database
+                    usage = normalize_usage(response_data.get('usage', {}) or {})
+
+                    if not metadata.get('chat_id', '').startswith('channel:'):
+                        await Chats.upsert_message_to_chat_by_id_and_message_id(
+                            metadata['chat_id'],
+                            metadata['message_id'],
+                            {
+                                'done': True,
+                                'role': 'assistant',
+                                'content': content,
+                                'output': response_output,
+                                **({'usage': usage} if usage else {}),
+                            },
+                        )
+
+                    # Send a webhook notification if the user is not active
+                    if request.app.state.config.ENABLE_USER_WEBHOOKS and not await Users.is_user_active(user.id):
+                        webhook_url = await Users.get_user_webhook_url_by_id(user.id)
+                        if webhook_url:
+                            await post_webhook(
+                                request.app.state.WEBUI_NAME,
+                                webhook_url,
+                                f'{content}\n\n{title} - {request.app.state.config.WEBUI_URL}/c/{metadata["chat_id"]}',
+                                {
+                                    'action': 'chat',
+                                    'message': content,
+                                    'title': title,
+                                    'url': f'{request.app.state.config.WEBUI_URL}/c/{metadata["chat_id"]}',
+                                },
+                            )
+
+                    ctx['assistant_message'] = {
+                        'content': content,
+                        'output': response_output,
+                        **({'usage': usage} if usage else {}),
+                    }
+                    await outlet_filter_handler(ctx)
+                    await background_tasks_handler(ctx)
+
+            response = build_response_object(response, merge_events_into_response(response_data, events))
+        except Exception as e:
+            log.debug(f'Error occurred while processing request: {e}')
+            pass
+
+        return response
+
+    if isinstance(response, dict):
+        response = merge_events_into_response(response_data, events)
+
+    return response
+
+
+async def streaming_chat_response_handler(response, ctx):
+    request = ctx['request']
+
+    form_data = ctx['form_data']
+
+    user = ctx['user']
+    model = ctx['model']
+
+    metadata = ctx['metadata']
+    events = ctx['events']
+
+    event_emitter = ctx['event_emitter']
+    event_caller = ctx['event_caller']
+
+    extra_params = {
+        '__event_emitter__': event_emitter,
+        '__event_call__': event_caller,
+        '__user__': user.model_dump() if isinstance(user, UserModel) else {},
+        '__metadata__': metadata,
+        '__oauth_token__': await get_system_oauth_token(request, user),
+        '__request__': request,
+        '__model__': model,
+    }
+
+    filter_functions = [
+        await Functions.get_function_by_id(filter_id)
+        for filter_id in await get_sorted_filter_ids(request, model, metadata.get('filter_ids', []))
+    ]
+
+    # Standard streaming response handler
+    # event_caller is optional — only needed for direct (client-side) tools
+    # and pyodide code interpreter. Server-side tools work without it.
+    if event_emitter:
+        task_id = str(uuid4())  # Create a unique task ID.
+        model_id = form_data.get('model', '')
+
+        # Handle as a background task
+        async def response_handler(response, events):
+            def tag_output_handler(content_type, tags, output):
+                """
+                Detect special tags (reasoning, solution, code_interpreter) in streaming
+                content and create corresponding OR-aligned output items directly.
+                Operates on output items instead of content_blocks.
+
+                Uses the text from the output items themselves for tag detection,
+                eliminating state divergence between accumulated content and items.
+                """
+                end_flag = False
+
+                def extract_attributes(tag_content):
+                    """Extract attributes from a tag if they exist."""
+                    attributes = {}
+                    if not tag_content:
+                        return attributes
+                    matches = re.findall(r'(\w+)\s*=\s*"([^"]+)"', tag_content)
+                    for key, value in matches:
+                        attributes[key] = value
+                    return attributes
+
+                def get_last_text(out):
+                    """Get text from last message item, or empty string."""
+                    if out and out[-1].get('type') == 'message':
+                        parts = out[-1].get('content', [])
+                        if parts and parts[-1].get('type') == 'output_text':
+                            return parts[-1].get('text', '')
+                    return ''
+
+                def set_last_text(out, text):
+                    """Set text on last message item's output_text."""
+                    if out and out[-1].get('type') == 'message':
+                        parts = out[-1].get('content', [])
+                        if parts and parts[-1].get('type') == 'output_text':
+                            parts[-1]['text'] = text
+
+                # Map content_type to output item type
+                output_type_map = {
+                    'reasoning': 'reasoning',
+                    'solution': 'message',  # solution tags just produce text
+                    'code_interpreter': 'open_webui:code_interpreter',
+                }
+                output_item_type = output_type_map.get(content_type, content_type)
+
+                last_type = output[-1].get('type', '') if output else ''
+
+                if last_type == 'message':
+                    # Use the output item's own text for tag detection
+                    item_text = get_last_text(output)
+                    for start_tag, end_tag in tags:
+                        start_tag_pattern = rf'{re.escape(start_tag)}'
+                        if start_tag.startswith('<') and start_tag.endswith('>'):
+                            start_tag_pattern = rf'<{re.escape(start_tag[1:-1])}(\s.*?)?>'
+
+                        match = re.search(start_tag_pattern, item_text)
+                        if match:
+                            try:
+                                attr_content = match.group(1) if match.group(1) else ''
+                            except Exception:
+                                attr_content = ''
+
+                            attributes = extract_attributes(attr_content)
+
+                            before_tag = item_text[: match.start()]
+                            after_tag = item_text[match.end() :]
+
+                            # Keep only text before the tag in the message
+                            set_last_text(output, before_tag)
+
+                            if not before_tag.strip():
+                                # Remove empty message item
+                                if output and output[-1].get('type') == 'message':
+                                    output.pop()
+
+                            # Append the new output item
+                            if output_item_type == 'reasoning':
+                                output.append(
+                                    {
+                                        'type': 'reasoning',
+                                        'id': output_id('r'),
+                                        'status': 'in_progress',
+                                        'start_tag': start_tag,
+                                        'end_tag': end_tag,
+                                        'attributes': attributes,
+                                        'content': [],
+                                        'summary': None,
+                                        'started_at': time.time(),
+                                    }
+                                )
+                            elif output_item_type == 'open_webui:code_interpreter':
+                                output.append(
+                                    {
+                                        'type': 'open_webui:code_interpreter',
+                                        'id': output_id('ci'),
+                                        'status': 'in_progress',
+                                        'start_tag': start_tag,
+                                        'end_tag': end_tag,
+                                        'attributes': attributes,
+                                        'lang': attributes.get('lang', 'python'),
+                                        'code': '',
+                                        'output': None,
+                                        'started_at': time.time(),
+                                    }
+                                )
+                            else:
+                                # solution or other text-producing tag
+                                output.append(
+                                    {
+                                        'type': 'message',
+                                        'id': output_id('msg'),
+                                        'status': 'in_progress',
+                                        'role': 'assistant',
+                                        'content': [{'type': 'output_text', 'text': ''}],
+                                        '_tag_type': content_type,
+                                        'start_tag': start_tag,
+                                        'end_tag': end_tag,
+                                        'attributes': attributes,
+                                        'started_at': time.time(),
+                                    }
+                                )
+
+                            if after_tag:
+                                # Set the after_tag content on the new item
+                                if output_item_type == 'reasoning':
+                                    output[-1]['content'] = [{'type': 'output_text', 'text': after_tag}]
+                                elif output_item_type == 'open_webui:code_interpreter':
+                                    output[-1]['code'] = after_tag
+                                else:
+                                    set_last_text(output, after_tag)
+
+                                _, recursive_end = tag_output_handler(content_type, tags, output)
+                                if recursive_end:
+                                    end_flag = True
+
+                            break
+
+                elif (
+                    (last_type == 'reasoning' and content_type == 'reasoning')
+                    or (last_type == 'open_webui:code_interpreter' and content_type == 'code_interpreter')
+                    or (last_type == 'message' and output[-1].get('_tag_type') == content_type)
+                ):
+                    item = output[-1]
+                    start_tag = item.get('start_tag', '')
+                    end_tag = item.get('end_tag', '')
+
+                    end_tag_pattern = rf'{re.escape(end_tag)}'
+
+                    # Get the block content from the item itself
+                    if last_type == 'reasoning':
+                        parts = item.get('content', [])
+                        block_content = ''
+                        if parts and parts[-1].get('type') == 'output_text':
+                            block_content = parts[-1].get('text', '')
+                    elif last_type == 'open_webui:code_interpreter':
+                        block_content = item.get('code', '')
+                    else:
+                        block_content = get_last_text(output)
+
+                    if re.search(end_tag_pattern, block_content):
+                        end_flag = True
+
+                        # Strip start and end tags from content
+                        start_tag_pattern = rf'{re.escape(start_tag)}'
+                        if start_tag.startswith('<') and start_tag.endswith('>'):
+                            start_tag_pattern = rf'<{re.escape(start_tag[1:-1])}(\s.*?)?>'
+                        block_content = re.sub(start_tag_pattern, '', block_content).strip()
+
+                        end_tag_regex = re.compile(end_tag_pattern, re.DOTALL)
+                        split_content = end_tag_regex.split(block_content, maxsplit=1)
+
+                        block_content = split_content[0].strip() if split_content else ''
+                        leftover_content = split_content[1].strip() if len(split_content) > 1 else ''
+
+                        if block_content:
+                            # Update the item with final content
+                            if last_type == 'reasoning':
+                                item['content'] = [{'type': 'output_text', 'text': block_content}]
+                                item['ended_at'] = time.time()
+                                item['duration'] = int(item['ended_at'] - item['started_at'])
+                                item['status'] = 'completed'
+                            elif last_type == 'open_webui:code_interpreter':
+                                item['code'] = block_content
+                                item['ended_at'] = time.time()
+                                item['duration'] = int(item['ended_at'] - item['started_at'])
+                            else:
+                                set_last_text(output, block_content)
+                                item['ended_at'] = time.time()
+
+                            # Reset by appending a new message item for leftover
+                            output.append(
+                                {
+                                    'type': 'message',
+                                    'id': output_id('msg'),
+                                    'status': 'in_progress',
+                                    'role': 'assistant',
+                                    'content': [
+                                        {
+                                            'type': 'output_text',
+                                            'text': leftover_content,
+                                        }
+                                    ],
+                                }
+                            )
+                        else:
+                            # Remove the block if content is empty
+                            output.pop()
+                            output.append(
+                                {
+                                    'type': 'message',
+                                    'id': output_id('msg'),
+                                    'status': 'in_progress',
+                                    'role': 'assistant',
+                                    'content': [
+                                        {
+                                            'type': 'output_text',
+                                            'text': leftover_content,
+                                        }
+                                    ],
+                                }
+                            )
+
+                return output, end_flag
+
+            message = await Chats.get_message_by_id_and_message_id(metadata['chat_id'], metadata['message_id'])
+
+            tool_calls = []
+
+            last_assistant_message = None
+            try:
+                if form_data['messages'][-1]['role'] == 'assistant':
+                    last_assistant_message = get_last_assistant_message(form_data['messages'])
+            except Exception as e:
+                pass
+
+            content = (
+                message.get('content', '') if message else last_assistant_message if last_assistant_message else ''
+            )
+
+            # Initialize output: use existing from message if continuing, else create new
+            existing_output = message.get('output') if message else None
+            if existing_output:
+                output = existing_output
+            else:
+                # Only create an initial message item if there is content to initialize with
+                if content:
+                    output = [
+                        {
+                            'type': 'message',
+                            'id': output_id('msg'),
+                            'status': 'in_progress',
+                            'role': 'assistant',
+                            'content': [{'type': 'output_text', 'text': content}],
+                        }
+                    ]
+                else:
+                    output = []
+
+            usage = None
+            prior_output = []
+            last_response_id = None
+
+            def full_output():
+                return prior_output + output if prior_output else output
+
+            reasoning_tags_param = metadata.get('params', {}).get('reasoning_tags')
+            DETECT_REASONING_TAGS = reasoning_tags_param is not False
+
+            # Mirror the five gates from utils/tools.py get_builtin_tools so the
+            # legacy XML-tag path enforces the same authz as native FC.
+            features = metadata.get('features', {}) or {}
+            model_capabilities = model.get('info', {}).get('meta', {}).get('capabilities') or {}
+            builtin_tools_meta = model.get('info', {}).get('meta', {}).get('builtinTools', {})
+            DETECT_CODE_INTERPRETER = (
+                bool(features.get('code_interpreter'))
+                and builtin_tools_meta.get('code_interpreter', True)
+                and getattr(request.app.state.config, 'ENABLE_CODE_INTERPRETER', True)
+                and model_capabilities.get('code_interpreter', True)
+                and (
+                    getattr(user, 'role', None) == 'admin'
+                    or await has_permission(
+                        getattr(user, 'id', ''),
+                        'features.code_interpreter',
+                        request.app.state.config.USER_PERMISSIONS,
+                    )
+                )
+            )
+
+            reasoning_tags = []
+            if DETECT_REASONING_TAGS:
+                if isinstance(reasoning_tags_param, list) and len(reasoning_tags_param) == 2:
+                    reasoning_tags = [(reasoning_tags_param[0], reasoning_tags_param[1])]
+                else:
+                    reasoning_tags = DEFAULT_REASONING_TAGS
+
+            try:
+                for event in events:
+                    await event_emitter(
+                        {
+                            'type': 'chat:completion',
+                            'data': event,
+                        }
+                    )
+
+                    # Save message in the database
+                    await Chats.upsert_message_to_chat_by_id_and_message_id(
+                        metadata['chat_id'],
+                        metadata['message_id'],
+                        {
+                            **event,
+                        },
+                    )
+
+                async def stream_body_handler(response, form_data):
+                    nonlocal content
+                    nonlocal usage
+                    nonlocal output
+                    nonlocal prior_output
+                    nonlocal last_response_id
+
+                    response_tool_calls = []
+
+                    delta_count = 0
+                    delta_chunk_size = max(
+                        CHAT_RESPONSE_STREAM_DELTA_CHUNK_SIZE,
+                        int(metadata.get('params', {}).get('stream_delta_chunk_size') or 1),
+                    )
+                    last_delta_data = None
+
+                    async def flush_pending_delta_data(threshold: int = 0):
+                        nonlocal delta_count
+                        nonlocal last_delta_data
+
+                        if delta_count >= threshold and last_delta_data:
+                            await event_emitter(
+                                {
+                                    'type': 'chat:completion',
+                                    'data': last_delta_data,
+                                }
+                            )
+                            delta_count = 0
+                            last_delta_data = None
+
+                    async for line in response.body_iterator:
+                        line = line.decode('utf-8', 'replace') if isinstance(line, bytes) else line
+                        data = line
+
+                        # Skip empty lines
+                        if not data.strip():
+                            continue
+
+                        # "data:" is the prefix for each event
+                        if not data.startswith('data:'):
+                            continue
+
+                        # Remove the prefix
+                        data = data[len('data:') :].strip()
+
+                        try:
+                            data = json.loads(data)
+
+                            data, _ = await process_filter_functions(
+                                request=request,
+                                filter_functions=filter_functions,
+                                filter_type='stream',
+                                form_data=data,
+                                extra_params={'__body__': form_data, **extra_params},
+                            )
+
+                            if data:
+                                if 'event' in data and not getattr(request.state, 'direct', False):
+                                    await event_emitter(data.get('event', {}))
+
+                                if 'selected_model_id' in data:
+                                    model_id = data['selected_model_id']
+                                    await Chats.upsert_message_to_chat_by_id_and_message_id(
+                                        metadata['chat_id'],
+                                        metadata['message_id'],
+                                        {
+                                            'selectedModelId': model_id,
+                                        },
+                                    )
+                                    await event_emitter(
+                                        {
+                                            'type': 'chat:completion',
+                                            'data': data,
+                                        }
+                                    )
+                                # Check for Responses API events (type field starts with "response.")
+                                elif data.get('type', '').startswith('response.'):
+                                    output, response_metadata = handle_responses_streaming_event(data, output)
+
+                                    # Emit citation sources from finalized output items
+                                    # (mirrors Chat Completions annotation handling at delta level)
+                                    if data.get('type') == 'response.output_item.done':
+                                        item = data.get('item', {})
+                                        if item.get('type') == 'message':
+                                            for part in item.get('content', []):
+                                                for annotation in part.get('annotations', []):
+                                                    if annotation.get('type') == 'url_citation':
+                                                        # Handle both flat (Responses API) and nested (Chat Completions) formats
+                                                        url_citation = annotation.get('url_citation', annotation)
+
+                                                        url = url_citation.get('url', '')
+                                                        title = url_citation.get('title', url)
+
+                                                        if url:
+                                                            await event_emitter(
+                                                                {
+                                                                    'type': 'source',
+                                                                    'data': {
+                                                                        'source': {
+                                                                            'name': title,
+                                                                            'url': url,
+                                                                        },
+                                                                        'document': [title],
+                                                                        'metadata': [
+                                                                            {
+                                                                                'source': url,
+                                                                                'name': title,
+                                                                            }
+                                                                        ],
+                                                                    },
+                                                                }
+                                                            )
+
+                                    processed_data = {
+                                        'output': full_output(),
+                                        'content': serialize_output(full_output()),
+                                    }
+
+                                    # print(data)
+                                    # print(processed_data)
+
+                                    # Merge any metadata (usage, etc.)
+                                    # Strip 'done' — response.completed emits
+                                    # it but we may still need to execute tool
+                                    # calls. The outer middleware manages the
+                                    # actual completion signal.
+                                    if response_metadata:
+                                        if ENABLE_RESPONSES_API_STATEFUL:
+                                            response_id = response_metadata.pop('response_id', None)
+                                            if response_id:
+                                                last_response_id = response_id
+
+                                        # Normalize and capture usage for DB persistence
+                                        if response_metadata.get('usage'):
+                                            response_metadata['usage'] = normalize_usage(response_metadata['usage'])
+                                            usage = response_metadata['usage']
+
+                                        processed_data.update(response_metadata)
+                                        processed_data.pop('done', None)
+
+                                    await event_emitter(
+                                        {
+                                            'type': 'chat:completion',
+                                            'data': processed_data,
+                                        }
+                                    )
+                                    continue
+                                else:
+                                    choices = data.get('choices', [])
+
+                                    # Normalize usage data to standard format
+                                    raw_usage = data.get('usage', {}) or {}
+                                    raw_usage.update(data.get('timings', {}))  # llama.cpp
+                                    if raw_usage:
+                                        usage = normalize_usage(raw_usage)
+                                        await event_emitter(
+                                            {
+                                                'type': 'chat:completion',
+                                                'data': {
+                                                    'usage': usage,
+                                                },
+                                            }
+                                        )
+
+                                    if not choices:
+                                        error = data.get('error', {})
+                                        if error:
+                                            log.error('Provider returned error (streaming): %s', error)
+                                            try:
+                                                await Chats.upsert_message_to_chat_by_id_and_message_id(
+                                                    metadata['chat_id'],
+                                                    metadata['message_id'],
+                                                    {
+                                                        'error': {'content': error},
+                                                    },
+                                                )
+                                            except Exception:
+                                                pass
+                                            await event_emitter(
+                                                {
+                                                    'type': 'chat:completion',
+                                                    'data': {
+                                                        'error': error,
+                                                    },
+                                                }
+                                            )
+                                        continue
+
+                                    delta = choices[0].get('delta', {})
+
+                                    # Handle delta annotations
+                                    annotations = delta.get('annotations')
+                                    if annotations:
+                                        for annotation in annotations:
+                                            if (
+                                                annotation.get('type') == 'url_citation'
+                                                and 'url_citation' in annotation
+                                            ):
+                                                url_citation = annotation['url_citation']
+
+                                                url = url_citation.get('url', '')
+                                                title = url_citation.get('title', url)
+
+                                                await event_emitter(
+                                                    {
+                                                        'type': 'source',
+                                                        'data': {
+                                                            'source': {
+                                                                'name': title,
+                                                                'url': url,
+                                                            },
+                                                            'document': [title],
+                                                            'metadata': [
+                                                                {
+                                                                    'source': url,
+                                                                    'name': title,
+                                                                }
+                                                            ],
+                                                        },
+                                                    }
+                                                )
+
+                                    delta_tool_calls = delta.get('tool_calls', None)
+                                    if delta_tool_calls:
+                                        for delta_tool_call in delta_tool_calls:
+                                            tool_call_index = delta_tool_call.get('index')
+
+                                            if tool_call_index is not None:
+                                                # Check if the tool call already exists
+                                                current_response_tool_call = None
+                                                for response_tool_call in response_tool_calls:
+                                                    if response_tool_call.get('index') == tool_call_index:
+                                                        current_response_tool_call = response_tool_call
+                                                        break
+
+                                                if current_response_tool_call is None:
+                                                    # Add the new tool call
+                                                    delta_tool_call.setdefault('function', {})
+                                                    delta_tool_call['function'].setdefault('name', '')
+                                                    delta_tool_call['function'].setdefault('arguments', '')
+                                                    response_tool_calls.append(delta_tool_call)
+                                                else:
+                                                    # Update the existing tool call
+                                                    delta_name = delta_tool_call.get('function', {}).get('name')
+                                                    delta_arguments = delta_tool_call.get('function', {}).get(
+                                                        'arguments'
+                                                    )
+
+                                                    if delta_name:
+                                                        current_response_tool_call['function']['name'] = delta_name
+
+                                                    if delta_arguments:
+                                                        current_response_tool_call['function']['arguments'] += (
+                                                            delta_arguments
+                                                        )
+
+                                        # Emit pending tool calls in real-time
+                                        if response_tool_calls:
+                                            # Flush any pending text first
+                                            await flush_pending_delta_data()
+
+                                            # Build pending function_call output items for display
+                                            pending_fc_items = []
+                                            for tc in response_tool_calls:
+                                                call_id = tc.get('id', '')
+                                                func = tc.get('function', {})
+                                                pending_fc_items.append(
+                                                    {
+                                                        'type': 'function_call',
+                                                        'id': call_id or output_id('fc'),
+                                                        'call_id': call_id,
+                                                        'name': func.get('name', ''),
+                                                        'arguments': func.get('arguments', '{}'),
+                                                        'status': 'in_progress',
+                                                    }
+                                                )
+
+                                            await event_emitter(
+                                                {
+                                                    'type': 'chat:completion',
+                                                    'data': {
+                                                        'content': serialize_output(full_output() + pending_fc_items),
+                                                    },
+                                                }
+                                            )
+
+                                    image_urls = await get_image_urls(delta.get('images', []), request, metadata, user)
+                                    if image_urls:
+                                        image_file_list = [{'type': 'image', 'url': url} for url in image_urls]
+                                        message_files = await Chats.add_message_files_by_id_and_message_id(
+                                            metadata['chat_id'],
+                                            metadata['message_id'],
+                                            image_file_list,
+                                        )
+                                        if message_files is None:
+                                            message_files = image_file_list
+
+                                        await event_emitter(
+                                            {
+                                                'type': 'files',
+                                                'data': {'files': message_files},
+                                            }
+                                        )
+
+                                    value = delta.get('content')
+
+                                    reasoning_content = (
+                                        delta.get('reasoning_content')
+                                        or delta.get('reasoning')
+                                        or delta.get('thinking')
+                                    )
+                                    if reasoning_content:
+                                        if not output or output[-1].get('type') != 'reasoning':
+                                            reasoning_item = {
+                                                'type': 'reasoning',
+                                                'id': output_id('r'),
+                                                'status': 'in_progress',
+                                                'start_tag': '<think>',
+                                                'end_tag': '</think>',
+                                                'attributes': {'type': 'reasoning_content'},
+                                                'content': [],
+                                                'summary': None,
+                                                'started_at': time.time(),
+                                            }
+                                            output.append(reasoning_item)
+                                        else:
+                                            reasoning_item = output[-1]
+
+                                        # Append to reasoning content
+                                        parts = reasoning_item.get('content', [])
+                                        if parts and parts[-1].get('type') == 'output_text':
+                                            parts[-1]['text'] += reasoning_content
+                                        else:
+                                            reasoning_item['content'] = [
+                                                {
+                                                    'type': 'output_text',
+                                                    'text': reasoning_content,
+                                                }
+                                            ]
+
+                                        data = {'content': serialize_output(full_output())}
+
+                                    if value:
+                                        if (
+                                            output
+                                            and output[-1].get('type') == 'reasoning'
+                                            and output[-1].get('attributes', {}).get('type') == 'reasoning_content'
+                                        ):
+                                            reasoning_item = output[-1]
+                                            reasoning_item['ended_at'] = time.time()
+                                            reasoning_item['duration'] = int(
+                                                reasoning_item['ended_at'] - reasoning_item['started_at']
+                                            )
+                                            reasoning_item['status'] = 'completed'
+
+                                            output.append(
+                                                {
+                                                    'type': 'message',
+                                                    'id': output_id('msg'),
+                                                    'status': 'in_progress',
+                                                    'role': 'assistant',
+                                                    'content': [
+                                                        {
+                                                            'type': 'output_text',
+                                                            'text': '',
+                                                        }
+                                                    ],
+                                                }
+                                            )
+
+                                        if ENABLE_CHAT_RESPONSE_BASE64_IMAGE_URL_CONVERSION:
+                                            value = await convert_markdown_base64_images(
+                                                request,
+                                                value,
+                                                {
+                                                    'chat_id': metadata.get('chat_id', None),
+                                                    'message_id': metadata.get('message_id', None),
+                                                },
+                                                user,
+                                            )
+
+                                        content = f'{content}{value}'
+
+                                        # Check if we're inside a tag-based block
+                                        # (reasoning, code_interpreter, or solution).
+                                        # If so, append to the existing in-progress
+                                        # item instead of creating a new message —
+                                        # otherwise tag_output_handler re-detects the
+                                        # start tag on every chunk and fragments the
+                                        # output.
+                                        last_item = output[-1] if output else None
+                                        last_item_type = last_item.get('type', '') if last_item else ''
+                                        inside_tag_block = (
+                                            last_item is not None
+                                            and last_item.get('status') == 'in_progress'
+                                            and last_item.get('attributes', {}).get('type') != 'reasoning_content'
+                                            and (
+                                                last_item_type == 'reasoning'
+                                                or last_item_type == 'open_webui:code_interpreter'
+                                                or (
+                                                    last_item_type == 'message'
+                                                    and last_item.get('_tag_type') is not None
+                                                )
+                                            )
+                                        )
+
+                                        if inside_tag_block:
+                                            # Append to the existing tag-based item
+                                            if last_item_type == 'open_webui:code_interpreter':
+                                                last_item['code'] = last_item.get('code', '') + value
+                                            elif last_item_type == 'reasoning':
+                                                parts = last_item.get('content', [])
+                                                if parts and parts[-1].get('type') == 'output_text':
+                                                    parts[-1]['text'] += value
+                                                else:
+                                                    last_item['content'] = [
+                                                        {
+                                                            'type': 'output_text',
+                                                            'text': value,
+                                                        }
+                                                    ]
+                                            else:
+                                                # solution or other _tag_type message
+                                                msg_parts = last_item.get('content', [])
+                                                if msg_parts and msg_parts[-1].get('type') == 'output_text':
+                                                    msg_parts[-1]['text'] += value
+                                                else:
+                                                    last_item['content'] = [
+                                                        {
+                                                            'type': 'output_text',
+                                                            'text': value,
+                                                        }
+                                                    ]
+                                        else:
+                                            if not output or output[-1].get('type') != 'message':
+                                                output.append(
+                                                    {
+                                                        'type': 'message',
+                                                        'id': output_id('msg'),
+                                                        'status': 'in_progress',
+                                                        'role': 'assistant',
+                                                        'content': [
+                                                            {
+                                                                'type': 'output_text',
+                                                                'text': '',
+                                                            }
+                                                        ],
+                                                    }
+                                                )
+
+                                            # Append value to last message item's text
+                                            msg_parts = output[-1].get('content', [])
+                                            if msg_parts and msg_parts[-1].get('type') == 'output_text':
+                                                msg_parts[-1]['text'] += value
+                                            else:
+                                                output[-1]['content'] = [
+                                                    {
+                                                        'type': 'output_text',
+                                                        'text': value,
+                                                    }
+                                                ]
+
+                                        if DETECT_REASONING_TAGS:
+                                            output, _ = tag_output_handler(
+                                                'reasoning',
+                                                reasoning_tags,
+                                                output,
+                                            )
+
+                                            output, _ = tag_output_handler(
+                                                'solution',
+                                                DEFAULT_SOLUTION_TAGS,
+                                                output,
+                                            )
+
+                                        if DETECT_CODE_INTERPRETER:
+                                            output, end = tag_output_handler(
+                                                'code_interpreter',
+                                                DEFAULT_CODE_INTERPRETER_TAGS,
+                                                output,
+                                            )
+
+                                            if end:
+                                                break
+
+                                        if ENABLE_REALTIME_CHAT_SAVE and not metadata.get('chat_id', '').startswith(
+                                            'channel:'
+                                        ):
+                                            # Save message in the database
+                                            await Chats.upsert_message_to_chat_by_id_and_message_id(
+                                                metadata['chat_id'],
+                                                metadata['message_id'],
+                                                {
+                                                    'content': serialize_output(full_output()),
+                                                    'output': full_output(),
+                                                },
+                                            )
+                                        else:
+                                            data = {
+                                                'content': serialize_output(full_output()),
+                                            }
+
+                                if delta:
+                                    delta_count += 1
+                                    last_delta_data = data
+                                    if delta_count >= delta_chunk_size:
+                                        await flush_pending_delta_data(delta_chunk_size)
+                                else:
+                                    await event_emitter(
+                                        {
+                                            'type': 'chat:completion',
+                                            'data': data,
+                                        }
+                                    )
+                        except (asyncio.CancelledError, KeyboardInterrupt):
+                            raise
+                        except Exception as e:
+                            done = 'data: [DONE]' in line
+                            if done:
+                                pass
+                            else:
+                                log.debug(f'Error: {e}')
+                                continue
+                    await flush_pending_delta_data()
+
+                    if output:
+                        # Clean up the last message item
+                        if output[-1].get('type') == 'message':
+                            parts = output[-1].get('content', [])
+                            if parts and parts[-1].get('type') == 'output_text':
+                                parts[-1]['text'] = parts[-1]['text'].strip()
+
+                                if not parts[-1]['text']:
+                                    output.pop()
+
+                                    if not output:
+                                        output.append(
+                                            {
+                                                'type': 'message',
+                                                'id': output_id('msg'),
+                                                'status': 'in_progress',
+                                                'role': 'assistant',
+                                                'content': [{'type': 'output_text', 'text': ''}],
+                                            }
+                                        )
+
+                        if output[-1].get('type') == 'reasoning':
+                            reasoning_item = output[-1]
+                            if reasoning_item.get('ended_at') is None:
+                                reasoning_item['ended_at'] = time.time()
+                                reasoning_item['duration'] = int(
+                                    reasoning_item['ended_at'] - reasoning_item['started_at']
+                                )
+                                reasoning_item['status'] = 'completed'
+
+                    if response_tool_calls:
+                        tool_calls.append(_split_tool_calls(response_tool_calls))
+
+                    # Responses API path: extract function_call items from output
+                    if not response_tool_calls and output:
+                        # Collect call_ids that already have results,
+                        # including those from prior_output so we don't
+                        # re-process tool calls from a previous turn.
+                        handled_call_ids = {
+                            item.get('call_id')
+                            for item in (prior_output + output)
+                            if item.get('type') == 'function_call_output'
+                        }
+                        responses_api_tool_calls = []
+                        for item in output:
+                            if item.get('type') == 'function_call' and item.get('call_id') not in handled_call_ids:
+                                arguments = item.get('arguments', '{}')
+                                responses_api_tool_calls.append(
+                                    {
+                                        'id': item.get('call_id', ''),
+                                        'index': len(responses_api_tool_calls),
+                                        'function': {
+                                            'name': item.get('name', ''),
+                                            'arguments': (
+                                                arguments if isinstance(arguments, str) else json.dumps(arguments)
+                                            ),
+                                        },
+                                    }
+                                )
+                        if responses_api_tool_calls:
+                            tool_calls.append(_split_tool_calls(responses_api_tool_calls))
+
+                try:
+                    await stream_body_handler(response, form_data)
+                finally:
+                    if response.background:
+                        await response.background()
+
+                tool_call_iterations = 0
+                tool_call_sources = []  # Track citation sources from tool results
+                all_tool_call_sources = []  # Accumulated sources across all iterations
+                user_message = get_last_user_message(form_data['messages'])
+
+                # Check if citations are enabled for this model
+                citations_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get(
+                    'citations', True
+                )
+
+                # Use the pre-RAG system content captured before the
+                # initial file-source injection in process_chat_payload.
+                # This ensures restore truly undoes the RAG template.
+                original_system_content = metadata.get('system_prompt')
+                if original_system_content is None:
+                    original_system_message = get_system_message(form_data['messages'])
+                    original_system_content = (
+                        get_content_from_message(original_system_message) if original_system_message else None
+                    )
+
+                while tool_calls and (
+                    CHAT_RESPONSE_MAX_TOOL_CALL_ITERATIONS is None
+                    or tool_call_iterations < CHAT_RESPONSE_MAX_TOOL_CALL_ITERATIONS
+                ):
+                    tool_call_iterations += 1
+
+                    response_tool_calls = tool_calls.pop(0)
+
+                    # Append function_call items for each tool call
+                    # (Responses API already has them from streaming, so skip duplicates)
+                    existing_call_ids = {item.get('call_id') for item in output if item.get('type') == 'function_call'}
+                    for tc in response_tool_calls:
+                        call_id = tc.get('id', '')
+                        if call_id not in existing_call_ids:
+                            func = tc.get('function', {})
+                            output.append(
+                                {
+                                    'type': 'function_call',
+                                    'id': call_id or output_id('fc'),
+                                    'call_id': call_id,
+                                    'name': func.get('name', ''),
+                                    'arguments': func.get('arguments', '{}'),
+                                    'status': 'in_progress',
+                                }
+                            )
+
+                    await event_emitter(
+                        {
+                            'type': 'chat:completion',
+                            'data': {
+                                'content': serialize_output(full_output()),
+                                'output': full_output(),
+                            },
+                        }
+                    )
+
+                    tools = metadata.get('tools', {})
+
+                    results = []
+
+                    for tool_call in response_tool_calls:
+                        tool_call_id = tool_call.get('id', '')
+                        tool_function_name = tool_call.get('function', {}).get('name', '')
+                        tool_args = tool_call.get('function', {}).get('arguments', '{}')
+
+                        tool_function_params = {}
+                        if tool_args and tool_args.strip():
+                            try:
+                                # json.loads cannot be used because some models do not produce valid JSON
+                                tool_function_params = ast.literal_eval(tool_args)
+                            except Exception as e:
+                                log.debug(e)
+                                # Fallback to JSON parsing
+                                try:
+                                    tool_function_params = json.loads(tool_args)
+                                except Exception as e:
+                                    log.error(f'Error parsing tool call arguments: {tool_args}')
+                                    results.append(
+                                        {
+                                            'tool_call_id': tool_call_id,
+                                            'content': f'Error: Tool call arguments could not be parsed. The model generated malformed or incomplete JSON for `{tool_function_name}`. Please try again.',
+                                        }
+                                    )
+                                    continue
+
+                        # Ensure arguments are valid JSON for downstream LLM integrations
+                        log.debug(f'Parsed args from {tool_args} to {tool_function_params}')
+                        tool_call.setdefault('function', {})['arguments'] = json.dumps(tool_function_params)
+
+                        tool_result = None
+                        tool = None
+                        tool_type = None
+                        direct_tool = False
+
+                        if tool_function_name in tools:
+                            tool = tools[tool_function_name]
+                            spec = tool.get('spec', {})
+
+                            tool_type = tool.get('type', '')
+                            direct_tool = tool.get('direct', False)
+
+                            try:
+                                allowed_params = spec.get('parameters', {}).get('properties', {}).keys()
+
+                                tool_function_params = {
+                                    k: v for k, v in tool_function_params.items() if k in allowed_params
+                                }
+
+                                if direct_tool:
+                                    tool_result = await event_caller(
+                                        {
+                                            'type': 'execute:tool',
+                                            'data': {
+                                                'id': str(uuid4()),
+                                                'name': tool_function_name,
+                                                'params': tool_function_params,
+                                                'server': tool.get('server', {}),
+                                                'session_id': metadata.get('session_id', None),
+                                            },
+                                        }
+                                    )
+
+                                else:
+                                    tool_function = await get_updated_tool_function(
+                                        function=tool['callable'],
+                                        extra_params={
+                                            '__messages__': form_data.get('messages', []),
+                                            '__files__': metadata.get('files', []),
+                                        },
+                                    )
+
+                                    tool_result = await tool_function(**tool_function_params)
+
+                            except Exception as e:
+                                tool_result = str(e)
+                        else:
+                            tool_result = f'Error: Tool "{tool_function_name}" not found.'
+
+                        tool_result, tool_result_files, tool_result_embeds = await process_tool_result(
+                            request,
+                            tool_function_name,
+                            tool_result,
+                            tool_type,
+                            direct_tool,
+                            metadata,
+                            user,
+                        )
+
+                        await terminal_event_handler(
+                            tool_function_name,
+                            tool_function_params,
+                            tool_result,
+                            event_emitter,
+                        )
+
+                        # Extract citation sources from tool results
+                        if (
+                            citations_enabled
+                            and tool_function_name
+                            in [
+                                'search_web',
+                                'fetch_url',
+                                'view_file',
+                                'view_knowledge_file',
+                                'query_knowledge_files',
+                            ]
+                            and tool_result
+                        ):
+                            try:
+                                citation_sources = get_citation_source_from_tool_result(
+                                    tool_name=tool_function_name,
+                                    tool_params=tool_function_params,
+                                    tool_result=tool_result,
+                                    tool_id=tool.get('tool_id', '') if tool else '',
+                                )
+                                tool_call_sources.extend(citation_sources)
+                            except Exception as e:
+                                log.exception(f'Error extracting citation source: {e}')
+
+                        results.append(
+                            {
+                                'tool_call_id': tool_call_id,
+                                'content': str(tool_result) if tool_result else '',
+                                **({'files': tool_result_files} if tool_result_files else {}),
+                                **({'embeds': tool_result_embeds} if tool_result_embeds else {}),
+                            }
+                        )
+
+                    # Update function_call statuses and append function_call_output items
+                    for tc in response_tool_calls:
+                        call_id = tc.get('id', '')
+                        # Mark function_call as completed
+                        for item in output:
+                            if item.get('type') == 'function_call' and item.get('call_id') == call_id:
+                                item['status'] = 'completed'
+                                # Update arguments with parsed/sanitized version
+                                item['arguments'] = tc.get('function', {}).get('arguments', '{}')
+                                break
+
+                    for result in results:
+                        output_parts = [{'type': 'input_text', 'text': result.get('content', '')}]
+
+                        # Separate image data URIs (for LLM via input_image) from
+                        # other files (for frontend display via files attribute).
+                        display_files = []
+                        for file_item in result.get('files', []):
+                            if file_item.get('type') == 'image' and file_item.get('url', '').startswith('data:'):
+                                # LLM-only: add as input_image part (invisible to serialize_output)
+                                output_parts.append({'type': 'input_image', 'image_url': file_item['url']})
+                            else:
+                                # Frontend display (MCP images, audio, etc.)
+                                display_files.append(file_item)
+
+                        output.append(
+                            {
+                                'type': 'function_call_output',
+                                'id': output_id('fco'),
+                                'call_id': result.get('tool_call_id', ''),
+                                'output': output_parts,
+                                'status': 'completed',
+                                **({'files': display_files} if display_files else {}),
+                                **({'embeds': result.get('embeds')} if result.get('embeds') else {}),
+                            }
+                        )
+
+                    # Append a new empty message item for the next response
+                    output.append(
+                        {
+                            'type': 'message',
+                            'id': output_id('msg'),
+                            'status': 'in_progress',
+                            'role': 'assistant',
+                            'content': [{'type': 'output_text', 'text': ''}],
+                        }
+                    )
+
+                    # Emit citation sources to the frontend for display
+                    if citations_enabled:
+                        for source in tool_call_sources:
+                            await event_emitter({'type': 'source', 'data': source})
+
+                        # Apply tool source context to messages for the model.
+                        # Restoring to pre-RAG original prevents duplicating
+                        # the RAG template across file and tool sources.
+                        all_tool_call_sources.extend(tool_call_sources)
+                        if all_tool_call_sources and user_message:
+                            # Restore pre-RAG message state before re-applying
+                            # to prevent RAG template duplication.
+                            original_user_message = metadata.get('user_prompt') or user_message
+                            set_last_user_message_content(
+                                original_user_message,
+                                form_data['messages'],
+                            )
+                            replace_system_message_content(
+                                original_system_content or '',
+                                form_data['messages'],
+                            )
+
+                            # Build context: file sources with content,
+                            # tool sources as citation markers only.
+                            source_ids = {}
+                            source_context = get_source_context(
+                                metadata.get('sources', []), source_ids
+                            ) + get_source_context(
+                                all_tool_call_sources,
+                                source_ids,
+                                include_content=False,
+                            )
+                            source_context = source_context.strip()
+                            if source_context:
+                                rag_content = await rag_template(
+                                    request.app.state.config.RAG_TEMPLATE,
+                                    source_context,
+                                    user_message,
+                                )
+                                if RAG_SYSTEM_CONTEXT:
+                                    form_data['messages'] = add_or_update_system_message(
+                                        rag_content,
+                                        form_data['messages'],
+                                        append=True,
+                                    )
+                                else:
+                                    form_data['messages'] = add_or_update_user_message(
+                                        rag_content,
+                                        form_data['messages'],
+                                        append=False,
+                                    )
+                        tool_call_sources.clear()
+
+                    # Strip input_image parts (large base64 data URIs) from the
+                    # output sent to the frontend — they're only for LLM consumption
+                    # via convert_output_to_messages.
+                    frontend_output = []
+                    for item in output:
+                        if item.get('type') == 'function_call_output':
+                            parts = item.get('output', [])
+                            if any(p.get('type') == 'input_image' for p in parts):
+                                item = {**item, 'output': [p for p in parts if p.get('type') != 'input_image']}
+                        frontend_output.append(item)
+
+                    await event_emitter(
+                        {
+                            'type': 'chat:completion',
+                            'data': {
+                                'content': serialize_output(output),
+                                'output': frontend_output,
+                            },
+                        }
+                    )
+
+                    try:
+                        new_form_data = {
+                            **form_data,
+                            'model': model_id,
+                            'stream': True,
+                            'metadata': metadata,
+                        }
+
+                        if ENABLE_RESPONSES_API_STATEFUL and last_response_id:
+                            system_message = get_system_message(form_data['messages'])
+                            new_form_data['messages'] = (
+                                [system_message] if system_message else []
+                            ) + convert_output_to_messages(
+                                output, raw=True, reasoning_format=get_reasoning_format(model)
+                            )
+                            new_form_data['previous_response_id'] = last_response_id
+                        else:
+                            tool_messages = convert_output_to_messages(
+                                output, raw=True, reasoning_format=get_reasoning_format(model)
+                            )
+
+                            # Chat Completions providers don't support multimodal
+                            # tool messages.  Extract images into a user message.
+                            image_urls = []
+                            for message in tool_messages:
+                                if message.get('role') == 'tool' and isinstance(message.get('content'), list):
+                                    text_parts = []
+                                    for part in message['content']:
+                                        if part.get('type') == 'input_text':
+                                            text_parts.append(part.get('text', ''))
+                                        elif part.get('type') == 'input_image':
+                                            image_urls.append(part.get('image_url', ''))
+                                    message['content'] = ''.join(text_parts)
+
+                            new_form_data['messages'] = [
+                                *form_data['messages'],
+                                *tool_messages,
+                            ]
+
+                            if image_urls:
+                                new_form_data['messages'].append(
+                                    {
+                                        'role': 'user',
+                                        'content': [
+                                            {
+                                                'type': 'text',
+                                                'text': 'Here are the images from the tool results above. Please analyze them.',
+                                            },
+                                            *[{'type': 'image_url', 'image_url': {'url': url}} for url in image_urls],
+                                        ],
+                                    }
+                                )
+
+                        res = await generate_chat_completion(
+                            request,
+                            new_form_data,
+                            user,
+                            bypass_system_prompt=True,
+                        )
+
+                        if isinstance(res, StreamingResponse):
+                            # Save accumulated output and start fresh.
+                            # Responses API output_index values are relative
+                            # to the current response — a clean output list
+                            # keeps indices aligned. The display prefix
+                            # ensures the UI shows tool history during
+                            # streaming.
+                            prior_output = list(output)
+                            # Trim the trailing empty placeholder message
+                            # so it doesn't persist as a ghost item once
+                            # the new stream produces real content.
+                            if (
+                                prior_output
+                                and prior_output[-1].get('type') == 'message'
+                                and prior_output[-1].get('status') == 'in_progress'
+                            ):
+                                msg_parts = prior_output[-1].get('content', [])
+                                if not msg_parts or (len(msg_parts) == 1 and not msg_parts[0].get('text', '').strip()):
+                                    prior_output.pop()
+                            output = []
+                            await stream_body_handler(res, new_form_data)
+                            output[:0] = prior_output
+                            prior_output = []
+                        else:
+                            break
+                    except Exception as e:
+                        log.debug(e)
+                        break
+
+                if (
+                    CHAT_RESPONSE_MAX_TOOL_CALL_ITERATIONS is not None
+                    and tool_calls
+                    and tool_call_iterations >= CHAT_RESPONSE_MAX_TOOL_CALL_ITERATIONS
+                ):
+                    log.warning('Tool-call iteration limit reached (%s)', CHAT_RESPONSE_MAX_TOOL_CALL_ITERATIONS)
+                    error_content = f'Tool-call limit reached ({CHAT_RESPONSE_MAX_TOOL_CALL_ITERATIONS} iterations).'
+                    if not metadata.get('chat_id', '').startswith('channel:'):
+                        await Chats.upsert_message_to_chat_by_id_and_message_id(
+                            metadata['chat_id'],
+                            metadata['message_id'],
+                            {'error': {'content': error_content}},
+                        )
+                    await event_emitter(
+                        {
+                            'type': 'chat:message:error',
+                            'data': {'error': {'content': error_content}},
+                        }
+                    )
+
+                if DETECT_CODE_INTERPRETER:
+                    MAX_RETRIES = 5
+                    retries = 0
+
+                    while output and output[-1].get('type') == 'open_webui:code_interpreter' and retries < MAX_RETRIES:
+                        await event_emitter(
+                            {
+                                'type': 'chat:completion',
+                                'data': {
+                                    'content': serialize_output(output),
+                                    'output': output,
+                                },
+                            }
+                        )
+
+                        retries += 1
+                        log.debug(f'Attempt count: {retries}')
+
+                        ci_item = output[-1]
+                        ci_output = ''
+                        try:
+                            if ci_item.get('attributes', {}).get('type') == 'code':
+                                code = ci_item.get('code', '')
+                                # Sanitize code (strips ANSI codes and markdown fences)
+                                code = sanitize_code(code)
+
+                                if CODE_INTERPRETER_BLOCKED_MODULES:
+                                    blocking_code = textwrap.dedent(f"""
+                                        import builtins
+    
+                                        BLOCKED_MODULES = {CODE_INTERPRETER_BLOCKED_MODULES}
+    
+                                        _real_import = builtins.__import__
+                                        async def restricted_import(name, globals=None, locals=None, fromlist=(), level=0):
+                                            if name.split('.')[0] in BLOCKED_MODULES:
+                                                importer_name = globals.get('__name__') if globals else None
+                                                if importer_name == '__main__':
+                                                    raise ImportError(
+                                                        f"Direct import of module {{name}} is restricted."
+                                                    )
+                                            return _real_import(name, globals, locals, fromlist, level)
+    
+                                        builtins.__import__ = restricted_import
+                                    """)
+                                    code = blocking_code + '\n' + code
+
+                                if request.app.state.config.CODE_INTERPRETER_ENGINE == 'pyodide':
+                                    ci_output = await event_caller(
+                                        {
+                                            'type': 'execute:python',
+                                            'data': {
+                                                'id': str(uuid4()),
+                                                'code': code,
+                                                'session_id': metadata.get('session_id', None),
+                                                'files': metadata.get('files', []),
+                                            },
+                                        }
+                                    )
+                                elif request.app.state.config.CODE_INTERPRETER_ENGINE == 'jupyter':
+                                    ci_output = await execute_code_jupyter(
+                                        request.app.state.config.CODE_INTERPRETER_JUPYTER_URL,
+                                        code,
+                                        (
+                                            request.app.state.config.CODE_INTERPRETER_JUPYTER_AUTH_TOKEN
+                                            if request.app.state.config.CODE_INTERPRETER_JUPYTER_AUTH == 'token'
+                                            else None
+                                        ),
+                                        (
+                                            request.app.state.config.CODE_INTERPRETER_JUPYTER_AUTH_PASSWORD
+                                            if request.app.state.config.CODE_INTERPRETER_JUPYTER_AUTH == 'password'
+                                            else None
+                                        ),
+                                        request.app.state.config.CODE_INTERPRETER_JUPYTER_TIMEOUT,
+                                    )
+                                else:
+                                    ci_output = {'stdout': 'Code interpreter engine not configured.'}
+
+                                log.debug(f'Code interpreter output: {ci_output}')
+
+                                # Handle error responses from event_caller
+                                # (e.g. session disconnected, timeout)
+                                if isinstance(ci_output, dict) and ci_output.get('error'):
+                                    ci_output = {'stderr': ci_output['error']}
+
+                                if isinstance(ci_output, dict):
+                                    stdout = ci_output.get('stdout', '')
+
+                                    if isinstance(stdout, str):
+                                        stdoutLines = stdout.split('\n')
+                                        for idx, line in enumerate(stdoutLines):
+                                            if re.match(r'data:image/\w+;base64', line):
+                                                image_url = await get_image_url_from_base64(
+                                                    request,
+                                                    line,
+                                                    metadata,
+                                                    user,
+                                                )
+                                                if image_url:
+                                                    stdoutLines[idx] = f'![Output Image]({image_url})'
+
+                                        ci_output['stdout'] = '\n'.join(stdoutLines)
+
+                                    result = ci_output.get('result', '')
+
+                                    if isinstance(result, str):
+                                        resultLines = result.split('\n')
+                                        for idx, line in enumerate(resultLines):
+                                            if re.match(r'data:image/\w+;base64', line):
+                                                image_url = await get_image_url_from_base64(
+                                                    request,
+                                                    line,
+                                                    metadata,
+                                                    user,
+                                                )
+                                                resultLines[idx] = f'![Output Image]({image_url})'
+                                        ci_output['result'] = '\n'.join(resultLines)
+                        except Exception as e:
+                            ci_output = str(e)
+
+                        ci_item['output'] = ci_output
+                        ci_item['status'] = 'completed'
+
+                        output.append(
+                            {
+                                'type': 'message',
+                                'id': output_id('msg'),
+                                'status': 'in_progress',
+                                'role': 'assistant',
+                                'content': [{'type': 'output_text', 'text': ''}],
+                            }
+                        )
+
+                        await event_emitter(
+                            {
+                                'type': 'chat:completion',
+                                'data': {
+                                    'content': serialize_output(output),
+                                    'output': output,
+                                },
+                            }
+                        )
+
+                        try:
+                            new_form_data = {
+                                **form_data,
+                                'model': model_id,
+                                'stream': True,
+                                'metadata': metadata,
+                                'messages': [
+                                    *form_data['messages'],
+                                    *convert_output_to_messages(
+                                        output, raw=True, reasoning_format=get_reasoning_format(model)
+                                    ),
+                                ],
+                            }
+
+                            res = await generate_chat_completion(
+                                request,
+                                new_form_data,
+                                user,
+                                bypass_system_prompt=True,
+                            )
+
+                            if isinstance(res, StreamingResponse):
+                                await stream_body_handler(res, new_form_data)
+                            else:
+                                break
+                        except Exception as e:
+                            log.debug(e)
+                            break
+
+                # Mark all in-progress items as completed
+                for item in output:
+                    if item.get('status') == 'in_progress':
+                        item['status'] = 'completed'
+
+                title = (
+                    await Chats.get_chat_title_by_id(metadata['chat_id'])
+                    if not metadata.get('chat_id', '').startswith('channel:')
+                    else ''
+                )
+                data = {
+                    'done': True,
+                    'content': serialize_output(output),
+                    'output': output,
+                    'title': title,
+                    **({'usage': usage} if usage else {}),
+                }
+
+                if not metadata.get('chat_id', '').startswith('channel:'):
+                    if not ENABLE_REALTIME_CHAT_SAVE:
+                        # Save message in the database
+                        await Chats.upsert_message_to_chat_by_id_and_message_id(
+                            metadata['chat_id'],
+                            metadata['message_id'],
+                            {
+                                'done': True,
+                                'content': serialize_output(output),
+                                'output': output,
+                                **({'usage': usage} if usage else {}),
+                            },
+                        )
+                    elif usage:
+                        await Chats.upsert_message_to_chat_by_id_and_message_id(
+                            metadata['chat_id'],
+                            metadata['message_id'],
+                            {'done': True, 'usage': usage},
+                        )
+                    else:
+                        await Chats.upsert_message_to_chat_by_id_and_message_id(
+                            metadata['chat_id'],
+                            metadata['message_id'],
+                            {'done': True},
+                        )
+
+                # Send a webhook notification if the user is not active
+                if request.app.state.config.ENABLE_USER_WEBHOOKS and not await Users.is_user_active(user.id):
+                    webhook_url = await Users.get_user_webhook_url_by_id(user.id)
+                    if webhook_url:
+                        await post_webhook(
+                            request.app.state.WEBUI_NAME,
+                            webhook_url,
+                            f'{content}\n\n{title} - {request.app.state.config.WEBUI_URL}/c/{metadata["chat_id"]}',
+                            {
+                                'action': 'chat',
+                                'message': content,
+                                'title': title,
+                                'url': f'{request.app.state.config.WEBUI_URL}/c/{metadata["chat_id"]}',
+                            },
+                        )
+
+                await event_emitter(
+                    {
+                        'type': 'chat:completion',
+                        'data': data,
+                    }
+                )
+
+                ctx['assistant_message'] = {
+                    'content': serialize_output(output),
+                    'output': output,
+                    **({'usage': usage} if usage else {}),
+                }
+                await outlet_filter_handler(ctx)
+                await background_tasks_handler(ctx)
+            except asyncio.CancelledError:
+                log.warning('Task was cancelled!')
+
+                # Close the response body iterator to trigger cleanup
+                # in stream_wrapper's finally block and release the
+                # upstream connection.  Without this, the async
+                # generator is orphaned and may spin in anyio internals.
+                if hasattr(response, 'body_iterator') and hasattr(response.body_iterator, 'aclose'):
+                    try:
+                        await asyncio.shield(response.body_iterator.aclose())
+                    except (asyncio.CancelledError, Exception):
+                        pass
+
+                async def save_cancelled_state():
+                    await event_emitter({'type': 'chat:tasks:cancel'})
+                    if not metadata.get('chat_id', '').startswith('channel:'):
+                        if not ENABLE_REALTIME_CHAT_SAVE:
+                            await Chats.upsert_message_to_chat_by_id_and_message_id(
+                                metadata['chat_id'],
+                                metadata['message_id'],
+                                {
+                                    'done': True,
+                                    'content': serialize_output(output),
+                                    'output': output,
+                                },
+                            )
+                        else:
+                            await Chats.upsert_message_to_chat_by_id_and_message_id(
+                                metadata['chat_id'],
+                                metadata['message_id'],
+                                {'done': True},
+                            )
+
+                try:
+                    await asyncio.shield(save_cancelled_state())
+                except (asyncio.CancelledError, Exception):
+                    pass
+                raise  # re-raise CancelledError for proper propagation
+
+            if response.background is not None:
+                await response.background()
+
+        return await response_handler(response, events)
+
+    else:
+        # Fallback to the original response
+        async def stream_wrapper(original_generator, events):
+            def wrap_item(item):
+                return f'data: {item}\n\n'
+
+            for event in events:
+                event, _ = await process_filter_functions(
+                    request=request,
+                    filter_functions=filter_functions,
+                    filter_type='stream',
+                    form_data=event,
+                    extra_params=extra_params,
+                )
+
+                if event:
+                    yield wrap_item(json.dumps(event))
+
+            async for data in original_generator:
+                data, _ = await process_filter_functions(
+                    request=request,
+                    filter_functions=filter_functions,
+                    filter_type='stream',
+                    form_data=data,
+                    extra_params=extra_params,
+                )
+
+                if data:
+                    yield data
+
+        return StreamingResponse(
+            stream_wrapper(response.body_iterator, events),
+            headers=dict(response.headers),
+            background=response.background,
+        )
+
+
+async def process_chat_response(response, ctx):
+    # Non-streaming response
+    if not isinstance(response, StreamingResponse):
+        return await non_streaming_chat_response_handler(response, ctx)
+
+    # Non standard response
+    if not any(
+        content_type in response.headers['Content-Type']
+        for content_type in ['text/event-stream', 'application/x-ndjson']
+    ):
+        return response
+
+    # Streaming response
+    return await streaming_chat_response_handler(response, ctx)

--- a/tests/patches/fixtures/retrieval_v0.9.6.py
+++ b/tests/patches/fixtures/retrieval_v0.9.6.py
@@ -1,0 +1,2730 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import mimetypes
+import os
+import re
+import shutil
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Iterator, Optional, Sequence, Union
+
+import tiktoken
+from fastapi import (
+    APIRouter,
+    Depends,
+    FastAPI,
+    File,
+    Form,
+    HTTPException,
+    Query,
+    Request,
+    UploadFile,
+    status,
+)
+from fastapi.concurrency import run_in_threadpool
+from fastapi.middleware.cors import CORSMiddleware
+from langchain_core.documents import Document
+from langchain_text_splitters import (
+    MarkdownHeaderTextSplitter,
+    RecursiveCharacterTextSplitter,
+    TokenTextSplitter,
+)
+from open_webui.config import (
+    DEFAULT_LOCALE,
+    ENV,
+    RAG_EMBEDDING_CONTENT_PREFIX,
+    RAG_EMBEDDING_MODEL_AUTO_UPDATE,
+    RAG_EMBEDDING_MODEL_TRUST_REMOTE_CODE,
+    RAG_EMBEDDING_QUERY_PREFIX,
+    RAG_RERANKING_MODEL_AUTO_UPDATE,
+    RAG_RERANKING_MODEL_TRUST_REMOTE_CODE,
+    UPLOAD_DIR,
+)
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.env import (
+    DEVICE_TYPE,
+    DOCKER,
+    RAG_EMBEDDING_TIMEOUT,
+    SENTENCE_TRANSFORMERS_BACKEND,
+    SENTENCE_TRANSFORMERS_CROSS_ENCODER_BACKEND,
+    SENTENCE_TRANSFORMERS_CROSS_ENCODER_MODEL_KWARGS,
+    SENTENCE_TRANSFORMERS_CROSS_ENCODER_SIGMOID_ACTIVATION_FUNCTION,
+    SENTENCE_TRANSFORMERS_MODEL_KWARGS,
+)
+from open_webui.internal.db import get_async_db, get_async_session
+from open_webui.models.files import FileModel, Files, FileUpdateForm
+from open_webui.models.knowledge import Knowledges
+
+# Document loaders
+from open_webui.retrieval.loaders.youtube import YoutubeLoader
+from open_webui.retrieval.utils import (
+    build_loader_from_config,
+    filter_accessible_collections,
+    get_content_from_url,
+    get_embedding_function,
+    get_model_path,
+    get_reranking_function,
+    query_collection,
+    query_collection_with_hybrid_search,
+    query_doc,
+    query_doc_with_hybrid_search,
+)
+from open_webui.retrieval.vector.async_client import ASYNC_VECTOR_DB_CLIENT
+from open_webui.retrieval.vector.factory import VECTOR_DB_CLIENT
+from open_webui.retrieval.vector.utils import filter_metadata
+from open_webui.retrieval.web.azure import search_azure
+from open_webui.retrieval.web.bing import search_bing
+from open_webui.retrieval.web.bocha import search_bocha
+from open_webui.retrieval.web.brave import search_brave
+from open_webui.retrieval.web.brave_llm_context import search_brave_llm_context
+from open_webui.retrieval.web.duckduckgo import search_duckduckgo
+from open_webui.retrieval.web.exa import search_exa
+from open_webui.retrieval.web.external import search_external
+from open_webui.retrieval.web.firecrawl import search_firecrawl
+from open_webui.retrieval.web.google_pse import search_google_pse
+from open_webui.retrieval.web.jina_search import search_jina
+from open_webui.retrieval.web.kagi import search_kagi
+
+# Web search engines
+from open_webui.retrieval.web.main import SearchResult
+from open_webui.retrieval.web.mojeek import search_mojeek
+from open_webui.retrieval.web.ollama import search_ollama_cloud
+from open_webui.retrieval.web.perplexity import search_perplexity
+from open_webui.retrieval.web.perplexity_search import search_perplexity_search
+from open_webui.retrieval.web.searchapi import search_searchapi
+from open_webui.retrieval.web.searxng import search_searxng
+from open_webui.retrieval.web.serpapi import search_serpapi
+from open_webui.retrieval.web.serper import search_serper
+from open_webui.retrieval.web.serply import search_serply
+from open_webui.retrieval.web.serpstack import search_serpstack
+from open_webui.retrieval.web.sougou import search_sougou
+from open_webui.retrieval.web.tavily import search_tavily
+from open_webui.retrieval.web.utils import get_web_loader
+from open_webui.retrieval.web.yacy import search_yacy
+from open_webui.retrieval.web.yandex import search_yandex
+from open_webui.retrieval.web.ydc import search_youcom
+from open_webui.retrieval.web.linkup import search_linkup
+from open_webui.storage.provider import Storage
+from open_webui.utils.access_control import has_permission
+from open_webui.utils.access_control.files import has_access_to_file
+from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.misc import (
+    calculate_sha256_string,
+    sanitize_text_for_db,
+)
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+log = logging.getLogger(__name__)
+
+##########################################
+#
+# Utility functions
+# Give us this day our relevant chunks, and lead us
+# not into hallucination, but deliver us from noise.
+#
+##########################################
+
+
+def get_ef(
+    engine: str,
+    embedding_model: str,
+    auto_update: bool = RAG_EMBEDDING_MODEL_AUTO_UPDATE,
+):
+    ef = None
+    if embedding_model and engine == '':
+        from sentence_transformers import SentenceTransformer
+
+        try:
+            ef = SentenceTransformer(
+                get_model_path(embedding_model, auto_update),
+                device=DEVICE_TYPE,
+                trust_remote_code=RAG_EMBEDDING_MODEL_TRUST_REMOTE_CODE,
+                backend=SENTENCE_TRANSFORMERS_BACKEND,
+                model_kwargs=SENTENCE_TRANSFORMERS_MODEL_KWARGS,
+            )
+        except Exception as e:
+            log.error(f'Error loading SentenceTransformer: {e}')
+
+    return ef
+
+
+def get_rf(
+    engine: str = '',
+    reranking_model: str | None = None,
+    external_reranker_url: str = '',
+    external_reranker_api_key: str = '',
+    external_reranker_timeout: str = '',
+    auto_update: bool = RAG_RERANKING_MODEL_AUTO_UPDATE,
+):
+    rf = None
+    # Convert timeout string to int or None (system default)
+    timeout_value = int(external_reranker_timeout) if external_reranker_timeout else None
+    if reranking_model:
+        if any(model in reranking_model for model in ['jinaai/jina-colbert-v2']):
+            try:
+                from open_webui.retrieval.models.colbert import ColBERT
+
+                rf = ColBERT(
+                    get_model_path(reranking_model, auto_update),
+                    env='docker' if DOCKER else None,
+                )
+
+            except Exception as e:
+                log.error(f'ColBERT: {e}')
+                raise Exception(ERROR_MESSAGES.DEFAULT(e))
+        else:
+            if engine == 'external':
+                try:
+                    from open_webui.retrieval.models.external import ExternalReranker
+
+                    rf = ExternalReranker(
+                        url=external_reranker_url,
+                        api_key=external_reranker_api_key,
+                        model=reranking_model,
+                        timeout=timeout_value,
+                    )
+                except Exception as e:
+                    log.error(f'ExternalReranking: {e}')
+                    raise Exception(ERROR_MESSAGES.DEFAULT(e))
+            else:
+                import sentence_transformers
+                import torch
+
+                try:
+                    rf = sentence_transformers.CrossEncoder(
+                        get_model_path(reranking_model, auto_update),
+                        device=DEVICE_TYPE,
+                        trust_remote_code=RAG_RERANKING_MODEL_TRUST_REMOTE_CODE,
+                        backend=SENTENCE_TRANSFORMERS_CROSS_ENCODER_BACKEND,
+                        model_kwargs=SENTENCE_TRANSFORMERS_CROSS_ENCODER_MODEL_KWARGS,
+                        activation_fn=(
+                            torch.nn.Sigmoid()
+                            if SENTENCE_TRANSFORMERS_CROSS_ENCODER_SIGMOID_ACTIVATION_FUNCTION
+                            else None
+                        ),
+                    )
+                except Exception as e:
+                    log.error(f'CrossEncoder: {e}')
+                    raise Exception(ERROR_MESSAGES.DEFAULT('CrossEncoder error'))
+
+                # Safely adjust pad_token_id if missing as some models do not have this in config
+                try:
+                    model_cfg = getattr(rf, 'model', None)
+                    if model_cfg and hasattr(model_cfg, 'config'):
+                        cfg = model_cfg.config
+                        if getattr(cfg, 'pad_token_id', None) is None:
+                            # Fallback to eos_token_id when available
+                            eos = getattr(cfg, 'eos_token_id', None)
+                            if eos is not None:
+                                cfg.pad_token_id = eos
+                                log.debug(f'Missing pad_token_id detected; set to eos_token_id={eos}')
+                            else:
+                                log.warning('Neither pad_token_id nor eos_token_id present in model config')
+                except Exception as e2:
+                    log.warning(f'Failed to adjust pad_token_id on CrossEncoder: {e2}')
+
+    return rf
+
+
+##########################################
+#
+# API routes
+#
+##########################################
+
+
+router = APIRouter()
+
+
+class CollectionNameForm(BaseModel):
+    collection_name: str | None = None
+
+
+class ProcessUrlForm(CollectionNameForm):
+    url: str
+
+
+class SearchForm(BaseModel):
+    queries: list[str]
+
+
+@router.get('/embedding')
+async def get_embedding_config(request: Request, user=Depends(get_admin_user)):
+    return {
+        'status': True,
+        'RAG_EMBEDDING_ENGINE': request.app.state.config.RAG_EMBEDDING_ENGINE,
+        'RAG_EMBEDDING_MODEL': request.app.state.config.RAG_EMBEDDING_MODEL,
+        'RAG_EMBEDDING_BATCH_SIZE': request.app.state.config.RAG_EMBEDDING_BATCH_SIZE,
+        'ENABLE_ASYNC_EMBEDDING': request.app.state.config.ENABLE_ASYNC_EMBEDDING,
+        'RAG_EMBEDDING_CONCURRENT_REQUESTS': request.app.state.config.RAG_EMBEDDING_CONCURRENT_REQUESTS,
+        'openai_config': {
+            'url': request.app.state.config.RAG_OPENAI_API_BASE_URL,
+            'key': request.app.state.config.RAG_OPENAI_API_KEY,
+        },
+        'ollama_config': {
+            'url': request.app.state.config.RAG_OLLAMA_BASE_URL,
+            'key': request.app.state.config.RAG_OLLAMA_API_KEY,
+        },
+        'azure_openai_config': {
+            'url': request.app.state.config.RAG_AZURE_OPENAI_BASE_URL,
+            'key': request.app.state.config.RAG_AZURE_OPENAI_API_KEY,
+            'version': request.app.state.config.RAG_AZURE_OPENAI_API_VERSION,
+        },
+    }
+
+
+class OpenAIConfigForm(BaseModel):
+    url: str
+    key: str
+
+
+class OllamaConfigForm(BaseModel):
+    url: str
+    key: str
+
+
+class AzureOpenAIConfigForm(BaseModel):
+    url: str
+    key: str
+    version: str
+
+
+class EmbeddingModelUpdateForm(BaseModel):
+    openai_config: OpenAIConfigForm | None = None
+    ollama_config: OllamaConfigForm | None = None
+    azure_openai_config: AzureOpenAIConfigForm | None = None
+    RAG_EMBEDDING_ENGINE: str
+    RAG_EMBEDDING_MODEL: str
+    RAG_EMBEDDING_BATCH_SIZE: int | None = 1
+    ENABLE_ASYNC_EMBEDDING: bool | None = True
+    RAG_EMBEDDING_CONCURRENT_REQUESTS: int | None = 0
+
+
+def unload_embedding_model(request: Request):
+    if request.app.state.config.RAG_EMBEDDING_ENGINE == '':
+        # unloads current internal embedding model and clears VRAM cache
+        request.app.state.ef = None
+        request.app.state.EMBEDDING_FUNCTION = None
+        import gc
+
+        gc.collect()
+        if DEVICE_TYPE == 'cuda':
+            import torch
+
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+
+@router.post('/embedding/update')
+async def update_embedding_config(request: Request, form_data: EmbeddingModelUpdateForm, user=Depends(get_admin_user)):
+    log.info(
+        f'Updating embedding model: {request.app.state.config.RAG_EMBEDDING_MODEL} to {form_data.RAG_EMBEDDING_MODEL}'
+    )
+    unload_embedding_model(request)
+    try:
+        request.app.state.config.RAG_EMBEDDING_ENGINE = form_data.RAG_EMBEDDING_ENGINE
+        request.app.state.config.RAG_EMBEDDING_MODEL = form_data.RAG_EMBEDDING_MODEL.strip()
+        request.app.state.config.RAG_EMBEDDING_BATCH_SIZE = form_data.RAG_EMBEDDING_BATCH_SIZE
+        request.app.state.config.ENABLE_ASYNC_EMBEDDING = form_data.ENABLE_ASYNC_EMBEDDING
+        request.app.state.config.RAG_EMBEDDING_CONCURRENT_REQUESTS = form_data.RAG_EMBEDDING_CONCURRENT_REQUESTS
+
+        if request.app.state.config.RAG_EMBEDDING_ENGINE in [
+            'ollama',
+            'openai',
+            'azure_openai',
+        ]:
+            if form_data.openai_config is not None:
+                request.app.state.config.RAG_OPENAI_API_BASE_URL = form_data.openai_config.url
+                request.app.state.config.RAG_OPENAI_API_KEY = form_data.openai_config.key
+
+            if form_data.ollama_config is not None:
+                request.app.state.config.RAG_OLLAMA_BASE_URL = form_data.ollama_config.url
+                request.app.state.config.RAG_OLLAMA_API_KEY = form_data.ollama_config.key
+
+            if form_data.azure_openai_config is not None:
+                request.app.state.config.RAG_AZURE_OPENAI_BASE_URL = form_data.azure_openai_config.url
+                request.app.state.config.RAG_AZURE_OPENAI_API_KEY = form_data.azure_openai_config.key
+                request.app.state.config.RAG_AZURE_OPENAI_API_VERSION = form_data.azure_openai_config.version
+
+        request.app.state.ef = get_ef(
+            request.app.state.config.RAG_EMBEDDING_ENGINE,
+            request.app.state.config.RAG_EMBEDDING_MODEL,
+        )
+
+        request.app.state.EMBEDDING_FUNCTION = get_embedding_function(
+            request.app.state.config.RAG_EMBEDDING_ENGINE,
+            request.app.state.config.RAG_EMBEDDING_MODEL,
+            request.app.state.ef,
+            (
+                request.app.state.config.RAG_OPENAI_API_BASE_URL
+                if request.app.state.config.RAG_EMBEDDING_ENGINE == 'openai'
+                else (
+                    request.app.state.config.RAG_OLLAMA_BASE_URL
+                    if request.app.state.config.RAG_EMBEDDING_ENGINE == 'ollama'
+                    else request.app.state.config.RAG_AZURE_OPENAI_BASE_URL
+                )
+            ),
+            (
+                request.app.state.config.RAG_OPENAI_API_KEY
+                if request.app.state.config.RAG_EMBEDDING_ENGINE == 'openai'
+                else (
+                    request.app.state.config.RAG_OLLAMA_API_KEY
+                    if request.app.state.config.RAG_EMBEDDING_ENGINE == 'ollama'
+                    else request.app.state.config.RAG_AZURE_OPENAI_API_KEY
+                )
+            ),
+            request.app.state.config.RAG_EMBEDDING_BATCH_SIZE,
+            azure_api_version=(
+                request.app.state.config.RAG_AZURE_OPENAI_API_VERSION
+                if request.app.state.config.RAG_EMBEDDING_ENGINE == 'azure_openai'
+                else None
+            ),
+            enable_async=request.app.state.config.ENABLE_ASYNC_EMBEDDING,
+            concurrent_requests=request.app.state.config.RAG_EMBEDDING_CONCURRENT_REQUESTS,
+        )
+
+        return {
+            'status': True,
+            'RAG_EMBEDDING_ENGINE': request.app.state.config.RAG_EMBEDDING_ENGINE,
+            'RAG_EMBEDDING_MODEL': request.app.state.config.RAG_EMBEDDING_MODEL,
+            'RAG_EMBEDDING_BATCH_SIZE': request.app.state.config.RAG_EMBEDDING_BATCH_SIZE,
+            'ENABLE_ASYNC_EMBEDDING': request.app.state.config.ENABLE_ASYNC_EMBEDDING,
+            'RAG_EMBEDDING_CONCURRENT_REQUESTS': request.app.state.config.RAG_EMBEDDING_CONCURRENT_REQUESTS,
+            'openai_config': {
+                'url': request.app.state.config.RAG_OPENAI_API_BASE_URL,
+                'key': request.app.state.config.RAG_OPENAI_API_KEY,
+            },
+            'ollama_config': {
+                'url': request.app.state.config.RAG_OLLAMA_BASE_URL,
+                'key': request.app.state.config.RAG_OLLAMA_API_KEY,
+            },
+            'azure_openai_config': {
+                'url': request.app.state.config.RAG_AZURE_OPENAI_BASE_URL,
+                'key': request.app.state.config.RAG_AZURE_OPENAI_API_KEY,
+                'version': request.app.state.config.RAG_AZURE_OPENAI_API_VERSION,
+            },
+        }
+    except Exception as e:
+        log.exception(f'Problem updating embedding model: {e}')
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=ERROR_MESSAGES.DEFAULT(e),
+        )
+
+
+@router.get('/config')
+async def get_rag_config(request: Request, user=Depends(get_admin_user)):
+    return {
+        'status': True,
+        # RAG settings
+        'RAG_TEMPLATE': request.app.state.config.RAG_TEMPLATE,
+        'TOP_K': request.app.state.config.TOP_K,
+        'BYPASS_EMBEDDING_AND_RETRIEVAL': request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL,
+        'RAG_FULL_CONTEXT': request.app.state.config.RAG_FULL_CONTEXT,
+        # Hybrid search settings
+        'ENABLE_RAG_HYBRID_SEARCH': request.app.state.config.ENABLE_RAG_HYBRID_SEARCH,
+        'ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS': request.app.state.config.ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS,
+        'TOP_K_RERANKER': request.app.state.config.TOP_K_RERANKER,
+        'RELEVANCE_THRESHOLD': request.app.state.config.RELEVANCE_THRESHOLD,
+        'HYBRID_BM25_WEIGHT': request.app.state.config.HYBRID_BM25_WEIGHT,
+        # Content extraction settings
+        'CONTENT_EXTRACTION_ENGINE': request.app.state.config.CONTENT_EXTRACTION_ENGINE,
+        'PDF_EXTRACT_IMAGES': request.app.state.config.PDF_EXTRACT_IMAGES,
+        'PDF_LOADER_MODE': request.app.state.config.PDF_LOADER_MODE,
+        'DATALAB_MARKER_API_KEY': request.app.state.config.DATALAB_MARKER_API_KEY,
+        'DATALAB_MARKER_API_BASE_URL': request.app.state.config.DATALAB_MARKER_API_BASE_URL,
+        'DATALAB_MARKER_ADDITIONAL_CONFIG': request.app.state.config.DATALAB_MARKER_ADDITIONAL_CONFIG,
+        'DATALAB_MARKER_SKIP_CACHE': request.app.state.config.DATALAB_MARKER_SKIP_CACHE,
+        'DATALAB_MARKER_FORCE_OCR': request.app.state.config.DATALAB_MARKER_FORCE_OCR,
+        'DATALAB_MARKER_PAGINATE': request.app.state.config.DATALAB_MARKER_PAGINATE,
+        'DATALAB_MARKER_STRIP_EXISTING_OCR': request.app.state.config.DATALAB_MARKER_STRIP_EXISTING_OCR,
+        'DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION': request.app.state.config.DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION,
+        'DATALAB_MARKER_FORMAT_LINES': request.app.state.config.DATALAB_MARKER_FORMAT_LINES,
+        'DATALAB_MARKER_USE_LLM': request.app.state.config.DATALAB_MARKER_USE_LLM,
+        'DATALAB_MARKER_OUTPUT_FORMAT': request.app.state.config.DATALAB_MARKER_OUTPUT_FORMAT,
+        'EXTERNAL_DOCUMENT_LOADER_URL': request.app.state.config.EXTERNAL_DOCUMENT_LOADER_URL,
+        'EXTERNAL_DOCUMENT_LOADER_API_KEY': request.app.state.config.EXTERNAL_DOCUMENT_LOADER_API_KEY,
+        'TIKA_SERVER_URL': request.app.state.config.TIKA_SERVER_URL,
+        'DOCLING_SERVER_URL': request.app.state.config.DOCLING_SERVER_URL,
+        'DOCLING_API_KEY': request.app.state.config.DOCLING_API_KEY,
+        'DOCLING_PARAMS': request.app.state.config.DOCLING_PARAMS,
+        'DOCUMENT_INTELLIGENCE_ENDPOINT': request.app.state.config.DOCUMENT_INTELLIGENCE_ENDPOINT,
+        'DOCUMENT_INTELLIGENCE_KEY': request.app.state.config.DOCUMENT_INTELLIGENCE_KEY,
+        'DOCUMENT_INTELLIGENCE_MODEL': request.app.state.config.DOCUMENT_INTELLIGENCE_MODEL,
+        'MISTRAL_OCR_API_BASE_URL': request.app.state.config.MISTRAL_OCR_API_BASE_URL,
+        'MISTRAL_OCR_API_KEY': request.app.state.config.MISTRAL_OCR_API_KEY,
+        'PADDLEOCR_VL_BASE_URL': request.app.state.config.PADDLEOCR_VL_BASE_URL,
+        'PADDLEOCR_VL_TOKEN': request.app.state.config.PADDLEOCR_VL_TOKEN,
+        # MinerU settings
+        'MINERU_API_MODE': request.app.state.config.MINERU_API_MODE,
+        'MINERU_API_URL': request.app.state.config.MINERU_API_URL,
+        'MINERU_API_KEY': request.app.state.config.MINERU_API_KEY,
+        'MINERU_API_TIMEOUT': request.app.state.config.MINERU_API_TIMEOUT,
+        'MINERU_PARAMS': request.app.state.config.MINERU_PARAMS,
+        'MINERU_FILE_EXTENSIONS': request.app.state.config.MINERU_FILE_EXTENSIONS,
+        # Reranking settings
+        'RAG_RERANKING_MODEL': request.app.state.config.RAG_RERANKING_MODEL,
+        'RAG_RERANKING_ENGINE': request.app.state.config.RAG_RERANKING_ENGINE,
+        'RAG_RERANKING_BATCH_SIZE': request.app.state.config.RAG_RERANKING_BATCH_SIZE,
+        'RAG_EXTERNAL_RERANKER_URL': request.app.state.config.RAG_EXTERNAL_RERANKER_URL,
+        'RAG_EXTERNAL_RERANKER_API_KEY': request.app.state.config.RAG_EXTERNAL_RERANKER_API_KEY,
+        'RAG_EXTERNAL_RERANKER_TIMEOUT': request.app.state.config.RAG_EXTERNAL_RERANKER_TIMEOUT,
+        # Chunking settings
+        'TEXT_SPLITTER': request.app.state.config.TEXT_SPLITTER,
+        'ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER': request.app.state.config.ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER,
+        'CHUNK_SIZE': request.app.state.config.CHUNK_SIZE,
+        'CHUNK_MIN_SIZE_TARGET': request.app.state.config.CHUNK_MIN_SIZE_TARGET,
+        'CHUNK_OVERLAP': request.app.state.config.CHUNK_OVERLAP,
+        # File upload settings
+        'FILE_MAX_SIZE': request.app.state.config.FILE_MAX_SIZE,
+        'FILE_MAX_COUNT': request.app.state.config.FILE_MAX_COUNT,
+        'FILE_IMAGE_COMPRESSION_WIDTH': request.app.state.config.FILE_IMAGE_COMPRESSION_WIDTH,
+        'FILE_IMAGE_COMPRESSION_HEIGHT': request.app.state.config.FILE_IMAGE_COMPRESSION_HEIGHT,
+        'ALLOWED_FILE_EXTENSIONS': request.app.state.config.ALLOWED_FILE_EXTENSIONS,
+        # Integration settings
+        'ENABLE_GOOGLE_DRIVE_INTEGRATION': request.app.state.config.ENABLE_GOOGLE_DRIVE_INTEGRATION,
+        'ENABLE_ONEDRIVE_INTEGRATION': request.app.state.config.ENABLE_ONEDRIVE_INTEGRATION,
+        # Web search settings
+        'web': {
+            'ENABLE_WEB_SEARCH': request.app.state.config.ENABLE_WEB_SEARCH,
+            'WEB_SEARCH_ENGINE': request.app.state.config.WEB_SEARCH_ENGINE,
+            'WEB_SEARCH_TRUST_ENV': request.app.state.config.WEB_SEARCH_TRUST_ENV,
+            'WEB_SEARCH_RESULT_COUNT': request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+            'WEB_SEARCH_CONCURRENT_REQUESTS': request.app.state.config.WEB_SEARCH_CONCURRENT_REQUESTS,
+            'WEB_FETCH_MAX_CONTENT_LENGTH': request.app.state.config.WEB_FETCH_MAX_CONTENT_LENGTH,
+            'WEB_LOADER_CONCURRENT_REQUESTS': request.app.state.config.WEB_LOADER_CONCURRENT_REQUESTS,
+            'WEB_SEARCH_DOMAIN_FILTER_LIST': request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            'BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL': request.app.state.config.BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL,
+            'BYPASS_WEB_SEARCH_WEB_LOADER': request.app.state.config.BYPASS_WEB_SEARCH_WEB_LOADER,
+            'OLLAMA_CLOUD_WEB_SEARCH_API_KEY': request.app.state.config.OLLAMA_CLOUD_WEB_SEARCH_API_KEY,
+            'SEARXNG_QUERY_URL': request.app.state.config.SEARXNG_QUERY_URL,
+            'SEARXNG_LANGUAGE': request.app.state.config.SEARXNG_LANGUAGE,
+            'YACY_QUERY_URL': request.app.state.config.YACY_QUERY_URL,
+            'YACY_USERNAME': request.app.state.config.YACY_USERNAME,
+            'YACY_PASSWORD': request.app.state.config.YACY_PASSWORD,
+            'GOOGLE_PSE_API_KEY': request.app.state.config.GOOGLE_PSE_API_KEY,
+            'GOOGLE_PSE_ENGINE_ID': request.app.state.config.GOOGLE_PSE_ENGINE_ID,
+            'BRAVE_SEARCH_API_KEY': request.app.state.config.BRAVE_SEARCH_API_KEY,
+            'BRAVE_SEARCH_CONTEXT_TOKENS': request.app.state.config.BRAVE_SEARCH_CONTEXT_TOKENS,
+            'KAGI_SEARCH_API_KEY': request.app.state.config.KAGI_SEARCH_API_KEY,
+            'MOJEEK_SEARCH_API_KEY': request.app.state.config.MOJEEK_SEARCH_API_KEY,
+            'BOCHA_SEARCH_API_KEY': request.app.state.config.BOCHA_SEARCH_API_KEY,
+            'SERPSTACK_API_KEY': request.app.state.config.SERPSTACK_API_KEY,
+            'SERPSTACK_HTTPS': request.app.state.config.SERPSTACK_HTTPS,
+            'SERPER_API_KEY': request.app.state.config.SERPER_API_KEY,
+            'SERPLY_API_KEY': request.app.state.config.SERPLY_API_KEY,
+            'DDGS_BACKEND': request.app.state.config.DDGS_BACKEND,
+            'TAVILY_API_KEY': request.app.state.config.TAVILY_API_KEY,
+            'SEARCHAPI_API_KEY': request.app.state.config.SEARCHAPI_API_KEY,
+            'SEARCHAPI_ENGINE': request.app.state.config.SEARCHAPI_ENGINE,
+            'SERPAPI_API_KEY': request.app.state.config.SERPAPI_API_KEY,
+            'SERPAPI_ENGINE': request.app.state.config.SERPAPI_ENGINE,
+            'JINA_API_KEY': request.app.state.config.JINA_API_KEY,
+            'JINA_API_BASE_URL': request.app.state.config.JINA_API_BASE_URL,
+            'BING_SEARCH_V7_ENDPOINT': request.app.state.config.BING_SEARCH_V7_ENDPOINT,
+            'BING_SEARCH_V7_SUBSCRIPTION_KEY': request.app.state.config.BING_SEARCH_V7_SUBSCRIPTION_KEY,
+            'EXA_API_KEY': request.app.state.config.EXA_API_KEY,
+            'PERPLEXITY_API_KEY': request.app.state.config.PERPLEXITY_API_KEY,
+            'PERPLEXITY_MODEL': request.app.state.config.PERPLEXITY_MODEL,
+            'PERPLEXITY_SEARCH_CONTEXT_USAGE': request.app.state.config.PERPLEXITY_SEARCH_CONTEXT_USAGE,
+            'PERPLEXITY_SEARCH_API_URL': request.app.state.config.PERPLEXITY_SEARCH_API_URL,
+            'SOUGOU_API_SID': request.app.state.config.SOUGOU_API_SID,
+            'SOUGOU_API_SK': request.app.state.config.SOUGOU_API_SK,
+            'WEB_LOADER_ENGINE': request.app.state.config.WEB_LOADER_ENGINE,
+            'WEB_LOADER_TIMEOUT': request.app.state.config.WEB_LOADER_TIMEOUT,
+            'ENABLE_WEB_LOADER_SSL_VERIFICATION': request.app.state.config.ENABLE_WEB_LOADER_SSL_VERIFICATION,
+            'PLAYWRIGHT_WS_URL': request.app.state.config.PLAYWRIGHT_WS_URL,
+            'PLAYWRIGHT_TIMEOUT': request.app.state.config.PLAYWRIGHT_TIMEOUT,
+            'FIRECRAWL_API_KEY': request.app.state.config.FIRECRAWL_API_KEY,
+            'FIRECRAWL_API_BASE_URL': request.app.state.config.FIRECRAWL_API_BASE_URL,
+            'FIRECRAWL_TIMEOUT': request.app.state.config.FIRECRAWL_TIMEOUT,
+            'TAVILY_EXTRACT_DEPTH': request.app.state.config.TAVILY_EXTRACT_DEPTH,
+            'EXTERNAL_WEB_SEARCH_URL': request.app.state.config.EXTERNAL_WEB_SEARCH_URL,
+            'EXTERNAL_WEB_SEARCH_API_KEY': request.app.state.config.EXTERNAL_WEB_SEARCH_API_KEY,
+            'EXTERNAL_WEB_LOADER_URL': request.app.state.config.EXTERNAL_WEB_LOADER_URL,
+            'EXTERNAL_WEB_LOADER_API_KEY': request.app.state.config.EXTERNAL_WEB_LOADER_API_KEY,
+            'YOUTUBE_LOADER_LANGUAGE': request.app.state.config.YOUTUBE_LOADER_LANGUAGE,
+            'YOUTUBE_LOADER_PROXY_URL': request.app.state.config.YOUTUBE_LOADER_PROXY_URL,
+            'YOUTUBE_LOADER_TRANSLATION': request.app.state.YOUTUBE_LOADER_TRANSLATION,
+            'YANDEX_WEB_SEARCH_URL': request.app.state.config.YANDEX_WEB_SEARCH_URL,
+            'YANDEX_WEB_SEARCH_API_KEY': request.app.state.config.YANDEX_WEB_SEARCH_API_KEY,
+            'YANDEX_WEB_SEARCH_CONFIG': request.app.state.config.YANDEX_WEB_SEARCH_CONFIG,
+            'YOUCOM_API_KEY': request.app.state.config.YOUCOM_API_KEY,
+            'LINKUP_API_KEY': request.app.state.config.LINKUP_API_KEY,
+            'LINKUP_SEARCH_PARAMS': request.app.state.config.LINKUP_SEARCH_PARAMS,
+        },
+    }
+
+
+class WebConfig(BaseModel):
+    ENABLE_WEB_SEARCH: bool | None = None
+    WEB_SEARCH_ENGINE: str | None = None
+    WEB_SEARCH_TRUST_ENV: bool | None = None
+    WEB_SEARCH_RESULT_COUNT: int | None = None
+    WEB_SEARCH_CONCURRENT_REQUESTS: int | None = None
+    WEB_SEARCH_DOMAIN_FILTER_LIST: list[str | None] = []
+    WEB_FETCH_MAX_CONTENT_LENGTH: int | None = None
+    WEB_LOADER_CONCURRENT_REQUESTS: int | None = None
+    BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL: bool | None = None
+    BYPASS_WEB_SEARCH_WEB_LOADER: bool | None = None
+    OLLAMA_CLOUD_WEB_SEARCH_API_KEY: str | None = None
+    SEARXNG_QUERY_URL: str | None = None
+    SEARXNG_LANGUAGE: str | None = None
+    YACY_QUERY_URL: str | None = None
+    YACY_USERNAME: str | None = None
+    YACY_PASSWORD: str | None = None
+    GOOGLE_PSE_API_KEY: str | None = None
+    GOOGLE_PSE_ENGINE_ID: str | None = None
+    BRAVE_SEARCH_API_KEY: str | None = None
+    BRAVE_SEARCH_CONTEXT_TOKENS: int | None = None
+    KAGI_SEARCH_API_KEY: str | None = None
+    MOJEEK_SEARCH_API_KEY: str | None = None
+    BOCHA_SEARCH_API_KEY: str | None = None
+    SERPSTACK_API_KEY: str | None = None
+    SERPSTACK_HTTPS: bool | None = None
+    SERPER_API_KEY: str | None = None
+    SERPLY_API_KEY: str | None = None
+    DDGS_BACKEND: str | None = None
+    TAVILY_API_KEY: str | None = None
+    SEARCHAPI_API_KEY: str | None = None
+    SEARCHAPI_ENGINE: str | None = None
+    SERPAPI_API_KEY: str | None = None
+    SERPAPI_ENGINE: str | None = None
+    JINA_API_KEY: str | None = None
+    JINA_API_BASE_URL: str | None = None
+    BING_SEARCH_V7_ENDPOINT: str | None = None
+    BING_SEARCH_V7_SUBSCRIPTION_KEY: str | None = None
+    EXA_API_KEY: str | None = None
+    PERPLEXITY_API_KEY: str | None = None
+    PERPLEXITY_MODEL: str | None = None
+    PERPLEXITY_SEARCH_CONTEXT_USAGE: str | None = None
+    PERPLEXITY_SEARCH_API_URL: str | None = None
+    SOUGOU_API_SID: str | None = None
+    SOUGOU_API_SK: str | None = None
+    WEB_LOADER_ENGINE: str | None = None
+    WEB_LOADER_TIMEOUT: str | None = None
+    ENABLE_WEB_LOADER_SSL_VERIFICATION: bool | None = None
+    PLAYWRIGHT_WS_URL: str | None = None
+    PLAYWRIGHT_TIMEOUT: int | None = None
+    FIRECRAWL_API_KEY: str | None = None
+    FIRECRAWL_API_BASE_URL: str | None = None
+    FIRECRAWL_TIMEOUT: str | None = None
+    TAVILY_EXTRACT_DEPTH: str | None = None
+    EXTERNAL_WEB_SEARCH_URL: str | None = None
+    EXTERNAL_WEB_SEARCH_API_KEY: str | None = None
+    EXTERNAL_WEB_LOADER_URL: str | None = None
+    EXTERNAL_WEB_LOADER_API_KEY: str | None = None
+    YOUTUBE_LOADER_LANGUAGE: list[str | None] = None
+    YOUTUBE_LOADER_PROXY_URL: str | None = None
+    YOUTUBE_LOADER_TRANSLATION: str | None = None
+    YANDEX_WEB_SEARCH_URL: str | None = None
+    YANDEX_WEB_SEARCH_API_KEY: str | None = None
+    YANDEX_WEB_SEARCH_CONFIG: str | None = None
+    YOUCOM_API_KEY: str | None = None
+    LINKUP_API_KEY: str | None = None
+    LINKUP_SEARCH_PARAMS: dict | None = None
+
+
+class ConfigForm(BaseModel):
+    # RAG settings
+    RAG_TEMPLATE: str | None = None
+    TOP_K: int | None = None
+    BYPASS_EMBEDDING_AND_RETRIEVAL: bool | None = None
+    RAG_FULL_CONTEXT: bool | None = None
+
+    # Hybrid search settings
+    ENABLE_RAG_HYBRID_SEARCH: bool | None = None
+    ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS: bool | None = None
+    TOP_K_RERANKER: int | None = None
+    RELEVANCE_THRESHOLD: float | None = None
+    HYBRID_BM25_WEIGHT: float | None = None
+
+    # Content extraction settings
+    CONTENT_EXTRACTION_ENGINE: str | None = None
+    PDF_EXTRACT_IMAGES: bool | None = None
+    PDF_LOADER_MODE: str | None = None
+
+    DATALAB_MARKER_API_KEY: str | None = None
+    DATALAB_MARKER_API_BASE_URL: str | None = None
+    DATALAB_MARKER_ADDITIONAL_CONFIG: str | None = None
+    DATALAB_MARKER_SKIP_CACHE: bool | None = None
+    DATALAB_MARKER_FORCE_OCR: bool | None = None
+    DATALAB_MARKER_PAGINATE: bool | None = None
+    DATALAB_MARKER_STRIP_EXISTING_OCR: bool | None = None
+    DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION: bool | None = None
+    DATALAB_MARKER_FORMAT_LINES: bool | None = None
+    DATALAB_MARKER_USE_LLM: bool | None = None
+    DATALAB_MARKER_OUTPUT_FORMAT: str | None = None
+
+    EXTERNAL_DOCUMENT_LOADER_URL: str | None = None
+    EXTERNAL_DOCUMENT_LOADER_API_KEY: str | None = None
+
+    TIKA_SERVER_URL: str | None = None
+    DOCLING_SERVER_URL: str | None = None
+    DOCLING_API_KEY: str | None = None
+    DOCLING_PARAMS: dict | None = None
+    DOCUMENT_INTELLIGENCE_ENDPOINT: str | None = None
+    DOCUMENT_INTELLIGENCE_KEY: str | None = None
+    DOCUMENT_INTELLIGENCE_MODEL: str | None = None
+    MISTRAL_OCR_API_BASE_URL: str | None = None
+    MISTRAL_OCR_API_KEY: str | None = None
+    PADDLEOCR_VL_BASE_URL: str | None = None
+    PADDLEOCR_VL_TOKEN: str | None = None
+
+    # MinerU settings
+    MINERU_API_MODE: str | None = None
+    MINERU_API_URL: str | None = None
+    MINERU_API_KEY: str | None = None
+    MINERU_API_TIMEOUT: str | None = None
+    MINERU_PARAMS: dict | None = None
+    MINERU_FILE_EXTENSIONS: list[str] | None = None
+
+    # Reranking settings
+    RAG_RERANKING_MODEL: str | None = None
+    RAG_RERANKING_ENGINE: str | None = None
+    RAG_RERANKING_BATCH_SIZE: int | None = None
+    RAG_EXTERNAL_RERANKER_URL: str | None = None
+    RAG_EXTERNAL_RERANKER_API_KEY: str | None = None
+    RAG_EXTERNAL_RERANKER_TIMEOUT: str | None = None
+
+    # Chunking settings
+    TEXT_SPLITTER: str | None = None
+    ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER: bool | None = None
+    CHUNK_SIZE: int | None = None
+    CHUNK_MIN_SIZE_TARGET: int | None = None
+    CHUNK_OVERLAP: int | None = None
+
+    # File upload settings
+    FILE_MAX_SIZE: Union[int, str | None] = None
+    FILE_MAX_COUNT: Union[int, str | None] = None
+    FILE_IMAGE_COMPRESSION_WIDTH: Union[int, str | None] = None
+    FILE_IMAGE_COMPRESSION_HEIGHT: Union[int, str | None] = None
+    ALLOWED_FILE_EXTENSIONS: list[str | None] = None
+
+    # Integration settings
+    ENABLE_GOOGLE_DRIVE_INTEGRATION: bool | None = None
+    ENABLE_ONEDRIVE_INTEGRATION: bool | None = None
+
+    # Web search settings
+    web: WebConfig | None = None
+
+
+@router.post('/config/update')
+async def update_rag_config(request: Request, form_data: ConfigForm, user=Depends(get_admin_user)):
+    # RAG settings
+    request.app.state.config.RAG_TEMPLATE = (
+        form_data.RAG_TEMPLATE if form_data.RAG_TEMPLATE is not None else request.app.state.config.RAG_TEMPLATE
+    )
+    request.app.state.config.TOP_K = form_data.TOP_K if form_data.TOP_K is not None else request.app.state.config.TOP_K
+    request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL = (
+        form_data.BYPASS_EMBEDDING_AND_RETRIEVAL
+        if form_data.BYPASS_EMBEDDING_AND_RETRIEVAL is not None
+        else request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL
+    )
+    request.app.state.config.RAG_FULL_CONTEXT = (
+        form_data.RAG_FULL_CONTEXT
+        if form_data.RAG_FULL_CONTEXT is not None
+        else request.app.state.config.RAG_FULL_CONTEXT
+    )
+
+    # Hybrid search settings
+    request.app.state.config.ENABLE_RAG_HYBRID_SEARCH = (
+        form_data.ENABLE_RAG_HYBRID_SEARCH
+        if form_data.ENABLE_RAG_HYBRID_SEARCH is not None
+        else request.app.state.config.ENABLE_RAG_HYBRID_SEARCH
+    )
+    request.app.state.config.ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS = (
+        form_data.ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS
+        if form_data.ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS is not None
+        else request.app.state.config.ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS
+    )
+
+    request.app.state.config.TOP_K_RERANKER = (
+        form_data.TOP_K_RERANKER if form_data.TOP_K_RERANKER is not None else request.app.state.config.TOP_K_RERANKER
+    )
+    request.app.state.config.RELEVANCE_THRESHOLD = (
+        form_data.RELEVANCE_THRESHOLD
+        if form_data.RELEVANCE_THRESHOLD is not None
+        else request.app.state.config.RELEVANCE_THRESHOLD
+    )
+    request.app.state.config.HYBRID_BM25_WEIGHT = (
+        form_data.HYBRID_BM25_WEIGHT
+        if form_data.HYBRID_BM25_WEIGHT is not None
+        else request.app.state.config.HYBRID_BM25_WEIGHT
+    )
+
+    # Content extraction settings
+    request.app.state.config.CONTENT_EXTRACTION_ENGINE = (
+        form_data.CONTENT_EXTRACTION_ENGINE
+        if form_data.CONTENT_EXTRACTION_ENGINE is not None
+        else request.app.state.config.CONTENT_EXTRACTION_ENGINE
+    )
+    request.app.state.config.PDF_EXTRACT_IMAGES = (
+        form_data.PDF_EXTRACT_IMAGES
+        if form_data.PDF_EXTRACT_IMAGES is not None
+        else request.app.state.config.PDF_EXTRACT_IMAGES
+    )
+    request.app.state.config.PDF_LOADER_MODE = (
+        form_data.PDF_LOADER_MODE if form_data.PDF_LOADER_MODE is not None else request.app.state.config.PDF_LOADER_MODE
+    )
+    request.app.state.config.DATALAB_MARKER_API_KEY = (
+        form_data.DATALAB_MARKER_API_KEY
+        if form_data.DATALAB_MARKER_API_KEY is not None
+        else request.app.state.config.DATALAB_MARKER_API_KEY
+    )
+    request.app.state.config.DATALAB_MARKER_API_BASE_URL = (
+        form_data.DATALAB_MARKER_API_BASE_URL
+        if form_data.DATALAB_MARKER_API_BASE_URL is not None
+        else request.app.state.config.DATALAB_MARKER_API_BASE_URL
+    )
+    request.app.state.config.DATALAB_MARKER_ADDITIONAL_CONFIG = (
+        form_data.DATALAB_MARKER_ADDITIONAL_CONFIG
+        if form_data.DATALAB_MARKER_ADDITIONAL_CONFIG is not None
+        else request.app.state.config.DATALAB_MARKER_ADDITIONAL_CONFIG
+    )
+    request.app.state.config.DATALAB_MARKER_SKIP_CACHE = (
+        form_data.DATALAB_MARKER_SKIP_CACHE
+        if form_data.DATALAB_MARKER_SKIP_CACHE is not None
+        else request.app.state.config.DATALAB_MARKER_SKIP_CACHE
+    )
+    request.app.state.config.DATALAB_MARKER_FORCE_OCR = (
+        form_data.DATALAB_MARKER_FORCE_OCR
+        if form_data.DATALAB_MARKER_FORCE_OCR is not None
+        else request.app.state.config.DATALAB_MARKER_FORCE_OCR
+    )
+    request.app.state.config.DATALAB_MARKER_PAGINATE = (
+        form_data.DATALAB_MARKER_PAGINATE
+        if form_data.DATALAB_MARKER_PAGINATE is not None
+        else request.app.state.config.DATALAB_MARKER_PAGINATE
+    )
+    request.app.state.config.DATALAB_MARKER_STRIP_EXISTING_OCR = (
+        form_data.DATALAB_MARKER_STRIP_EXISTING_OCR
+        if form_data.DATALAB_MARKER_STRIP_EXISTING_OCR is not None
+        else request.app.state.config.DATALAB_MARKER_STRIP_EXISTING_OCR
+    )
+    request.app.state.config.DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION = (
+        form_data.DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION
+        if form_data.DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION is not None
+        else request.app.state.config.DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION
+    )
+    request.app.state.config.DATALAB_MARKER_FORMAT_LINES = (
+        form_data.DATALAB_MARKER_FORMAT_LINES
+        if form_data.DATALAB_MARKER_FORMAT_LINES is not None
+        else request.app.state.config.DATALAB_MARKER_FORMAT_LINES
+    )
+    request.app.state.config.DATALAB_MARKER_OUTPUT_FORMAT = (
+        form_data.DATALAB_MARKER_OUTPUT_FORMAT
+        if form_data.DATALAB_MARKER_OUTPUT_FORMAT is not None
+        else request.app.state.config.DATALAB_MARKER_OUTPUT_FORMAT
+    )
+    request.app.state.config.DATALAB_MARKER_USE_LLM = (
+        form_data.DATALAB_MARKER_USE_LLM
+        if form_data.DATALAB_MARKER_USE_LLM is not None
+        else request.app.state.config.DATALAB_MARKER_USE_LLM
+    )
+    request.app.state.config.EXTERNAL_DOCUMENT_LOADER_URL = (
+        form_data.EXTERNAL_DOCUMENT_LOADER_URL
+        if form_data.EXTERNAL_DOCUMENT_LOADER_URL is not None
+        else request.app.state.config.EXTERNAL_DOCUMENT_LOADER_URL
+    )
+    request.app.state.config.EXTERNAL_DOCUMENT_LOADER_API_KEY = (
+        form_data.EXTERNAL_DOCUMENT_LOADER_API_KEY
+        if form_data.EXTERNAL_DOCUMENT_LOADER_API_KEY is not None
+        else request.app.state.config.EXTERNAL_DOCUMENT_LOADER_API_KEY
+    )
+    request.app.state.config.TIKA_SERVER_URL = (
+        form_data.TIKA_SERVER_URL if form_data.TIKA_SERVER_URL is not None else request.app.state.config.TIKA_SERVER_URL
+    )
+    request.app.state.config.DOCLING_SERVER_URL = (
+        form_data.DOCLING_SERVER_URL
+        if form_data.DOCLING_SERVER_URL is not None
+        else request.app.state.config.DOCLING_SERVER_URL
+    )
+    request.app.state.config.DOCLING_API_KEY = (
+        form_data.DOCLING_API_KEY if form_data.DOCLING_API_KEY is not None else request.app.state.config.DOCLING_API_KEY
+    )
+    request.app.state.config.DOCLING_PARAMS = (
+        form_data.DOCLING_PARAMS if form_data.DOCLING_PARAMS is not None else request.app.state.config.DOCLING_PARAMS
+    )
+    request.app.state.config.DOCUMENT_INTELLIGENCE_ENDPOINT = (
+        form_data.DOCUMENT_INTELLIGENCE_ENDPOINT
+        if form_data.DOCUMENT_INTELLIGENCE_ENDPOINT is not None
+        else request.app.state.config.DOCUMENT_INTELLIGENCE_ENDPOINT
+    )
+    request.app.state.config.DOCUMENT_INTELLIGENCE_KEY = (
+        form_data.DOCUMENT_INTELLIGENCE_KEY
+        if form_data.DOCUMENT_INTELLIGENCE_KEY is not None
+        else request.app.state.config.DOCUMENT_INTELLIGENCE_KEY
+    )
+    request.app.state.config.DOCUMENT_INTELLIGENCE_MODEL = (
+        form_data.DOCUMENT_INTELLIGENCE_MODEL
+        if form_data.DOCUMENT_INTELLIGENCE_MODEL is not None
+        else request.app.state.config.DOCUMENT_INTELLIGENCE_MODEL
+    )
+
+    request.app.state.config.MISTRAL_OCR_API_BASE_URL = (
+        form_data.MISTRAL_OCR_API_BASE_URL
+        if form_data.MISTRAL_OCR_API_BASE_URL is not None
+        else request.app.state.config.MISTRAL_OCR_API_BASE_URL
+    )
+    request.app.state.config.MISTRAL_OCR_API_KEY = (
+        form_data.MISTRAL_OCR_API_KEY
+        if form_data.MISTRAL_OCR_API_KEY is not None
+        else request.app.state.config.MISTRAL_OCR_API_KEY
+    )
+    request.app.state.config.PADDLEOCR_VL_BASE_URL = (
+        form_data.PADDLEOCR_VL_BASE_URL
+        if form_data.PADDLEOCR_VL_BASE_URL is not None
+        else request.app.state.config.PADDLEOCR_VL_BASE_URL
+    )
+    request.app.state.config.PADDLEOCR_VL_TOKEN = (
+        form_data.PADDLEOCR_VL_TOKEN
+        if form_data.PADDLEOCR_VL_TOKEN is not None
+        else request.app.state.config.PADDLEOCR_VL_TOKEN
+    )
+
+    # MinerU settings
+    request.app.state.config.MINERU_API_MODE = (
+        form_data.MINERU_API_MODE if form_data.MINERU_API_MODE is not None else request.app.state.config.MINERU_API_MODE
+    )
+    request.app.state.config.MINERU_API_URL = (
+        form_data.MINERU_API_URL if form_data.MINERU_API_URL is not None else request.app.state.config.MINERU_API_URL
+    )
+    request.app.state.config.MINERU_API_KEY = (
+        form_data.MINERU_API_KEY if form_data.MINERU_API_KEY is not None else request.app.state.config.MINERU_API_KEY
+    )
+    request.app.state.config.MINERU_API_TIMEOUT = (
+        form_data.MINERU_API_TIMEOUT
+        if form_data.MINERU_API_TIMEOUT is not None
+        else request.app.state.config.MINERU_API_TIMEOUT
+    )
+    request.app.state.config.MINERU_PARAMS = (
+        form_data.MINERU_PARAMS if form_data.MINERU_PARAMS is not None else request.app.state.config.MINERU_PARAMS
+    )
+    request.app.state.config.MINERU_FILE_EXTENSIONS = (
+        form_data.MINERU_FILE_EXTENSIONS
+        if form_data.MINERU_FILE_EXTENSIONS is not None
+        else request.app.state.config.MINERU_FILE_EXTENSIONS
+    )
+
+    # Reranking settings
+    if request.app.state.config.RAG_RERANKING_ENGINE == '':
+        # Unloading the internal reranker and clear VRAM memory
+        request.app.state.rf = None
+        request.app.state.RERANKING_FUNCTION = None
+        import gc
+
+        gc.collect()
+        if DEVICE_TYPE == 'cuda':
+            import torch
+
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+    request.app.state.config.RAG_RERANKING_ENGINE = (
+        form_data.RAG_RERANKING_ENGINE
+        if form_data.RAG_RERANKING_ENGINE is not None
+        else request.app.state.config.RAG_RERANKING_ENGINE
+    )
+
+    request.app.state.config.RAG_EXTERNAL_RERANKER_URL = (
+        form_data.RAG_EXTERNAL_RERANKER_URL
+        if form_data.RAG_EXTERNAL_RERANKER_URL is not None
+        else request.app.state.config.RAG_EXTERNAL_RERANKER_URL
+    )
+
+    request.app.state.config.RAG_EXTERNAL_RERANKER_API_KEY = (
+        form_data.RAG_EXTERNAL_RERANKER_API_KEY
+        if form_data.RAG_EXTERNAL_RERANKER_API_KEY is not None
+        else request.app.state.config.RAG_EXTERNAL_RERANKER_API_KEY
+    )
+
+    request.app.state.config.RAG_EXTERNAL_RERANKER_TIMEOUT = (
+        form_data.RAG_EXTERNAL_RERANKER_TIMEOUT
+        if form_data.RAG_EXTERNAL_RERANKER_TIMEOUT is not None
+        else request.app.state.config.RAG_EXTERNAL_RERANKER_TIMEOUT
+    )
+
+    request.app.state.config.RAG_RERANKING_BATCH_SIZE = (
+        form_data.RAG_RERANKING_BATCH_SIZE
+        if form_data.RAG_RERANKING_BATCH_SIZE is not None
+        else request.app.state.config.RAG_RERANKING_BATCH_SIZE
+    )
+
+    log.info(
+        f'Updating reranking model: {request.app.state.config.RAG_RERANKING_MODEL} to {form_data.RAG_RERANKING_MODEL}'
+    )
+    try:
+        request.app.state.config.RAG_RERANKING_MODEL = (
+            form_data.RAG_RERANKING_MODEL
+            if form_data.RAG_RERANKING_MODEL is not None
+            else request.app.state.config.RAG_RERANKING_MODEL
+        )
+
+        try:
+            if (
+                request.app.state.config.ENABLE_RAG_HYBRID_SEARCH
+                and not request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL
+            ):
+                request.app.state.rf = get_rf(
+                    request.app.state.config.RAG_RERANKING_ENGINE,
+                    request.app.state.config.RAG_RERANKING_MODEL,
+                    request.app.state.config.RAG_EXTERNAL_RERANKER_URL,
+                    request.app.state.config.RAG_EXTERNAL_RERANKER_API_KEY,
+                    request.app.state.config.RAG_EXTERNAL_RERANKER_TIMEOUT,
+                )
+
+                request.app.state.RERANKING_FUNCTION = get_reranking_function(
+                    request.app.state.config.RAG_RERANKING_ENGINE,
+                    request.app.state.config.RAG_RERANKING_MODEL,
+                    request.app.state.rf,
+                    reranking_batch_size=request.app.state.config.RAG_RERANKING_BATCH_SIZE,
+                )
+        except Exception as e:
+            log.error(f'Error loading reranking model: {e}')
+            request.app.state.config.ENABLE_RAG_HYBRID_SEARCH = False
+    except Exception as e:
+        log.exception(f'Problem updating reranking model: {e}')
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=ERROR_MESSAGES.DEFAULT(e),
+        )
+
+    # Chunking settings
+    request.app.state.config.TEXT_SPLITTER = (
+        form_data.TEXT_SPLITTER if form_data.TEXT_SPLITTER is not None else request.app.state.config.TEXT_SPLITTER
+    )
+    request.app.state.config.ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER = (
+        form_data.ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER
+        if form_data.ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER is not None
+        else request.app.state.config.ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER
+    )
+    request.app.state.config.CHUNK_SIZE = (
+        form_data.CHUNK_SIZE if form_data.CHUNK_SIZE is not None else request.app.state.config.CHUNK_SIZE
+    )
+    request.app.state.config.CHUNK_MIN_SIZE_TARGET = (
+        form_data.CHUNK_MIN_SIZE_TARGET
+        if form_data.CHUNK_MIN_SIZE_TARGET is not None
+        else request.app.state.config.CHUNK_MIN_SIZE_TARGET
+    )
+    request.app.state.config.CHUNK_OVERLAP = (
+        form_data.CHUNK_OVERLAP if form_data.CHUNK_OVERLAP is not None else request.app.state.config.CHUNK_OVERLAP
+    )
+
+    # File upload settings
+    # Empty string means "clear to None" (unlimited/no compression),
+    # None means "don't change", int means "set to this value"
+    if form_data.FILE_MAX_SIZE is not None:
+        request.app.state.config.FILE_MAX_SIZE = None if form_data.FILE_MAX_SIZE == '' else form_data.FILE_MAX_SIZE
+    if form_data.FILE_MAX_COUNT is not None:
+        request.app.state.config.FILE_MAX_COUNT = None if form_data.FILE_MAX_COUNT == '' else form_data.FILE_MAX_COUNT
+    if form_data.FILE_IMAGE_COMPRESSION_WIDTH is not None:
+        request.app.state.config.FILE_IMAGE_COMPRESSION_WIDTH = (
+            None if form_data.FILE_IMAGE_COMPRESSION_WIDTH == '' else form_data.FILE_IMAGE_COMPRESSION_WIDTH
+        )
+    if form_data.FILE_IMAGE_COMPRESSION_HEIGHT is not None:
+        request.app.state.config.FILE_IMAGE_COMPRESSION_HEIGHT = (
+            None if form_data.FILE_IMAGE_COMPRESSION_HEIGHT == '' else form_data.FILE_IMAGE_COMPRESSION_HEIGHT
+        )
+
+    request.app.state.config.ALLOWED_FILE_EXTENSIONS = (
+        form_data.ALLOWED_FILE_EXTENSIONS
+        if form_data.ALLOWED_FILE_EXTENSIONS is not None
+        else request.app.state.config.ALLOWED_FILE_EXTENSIONS
+    )
+
+    # Integration settings
+    request.app.state.config.ENABLE_GOOGLE_DRIVE_INTEGRATION = (
+        form_data.ENABLE_GOOGLE_DRIVE_INTEGRATION
+        if form_data.ENABLE_GOOGLE_DRIVE_INTEGRATION is not None
+        else request.app.state.config.ENABLE_GOOGLE_DRIVE_INTEGRATION
+    )
+    request.app.state.config.ENABLE_ONEDRIVE_INTEGRATION = (
+        form_data.ENABLE_ONEDRIVE_INTEGRATION
+        if form_data.ENABLE_ONEDRIVE_INTEGRATION is not None
+        else request.app.state.config.ENABLE_ONEDRIVE_INTEGRATION
+    )
+
+    if form_data.web is not None:
+        # Web search settings
+        request.app.state.config.ENABLE_WEB_SEARCH = form_data.web.ENABLE_WEB_SEARCH
+        request.app.state.config.WEB_SEARCH_ENGINE = form_data.web.WEB_SEARCH_ENGINE
+        request.app.state.config.WEB_SEARCH_TRUST_ENV = form_data.web.WEB_SEARCH_TRUST_ENV
+        request.app.state.config.WEB_SEARCH_RESULT_COUNT = form_data.web.WEB_SEARCH_RESULT_COUNT
+        request.app.state.config.WEB_SEARCH_CONCURRENT_REQUESTS = form_data.web.WEB_SEARCH_CONCURRENT_REQUESTS
+        request.app.state.config.WEB_FETCH_MAX_CONTENT_LENGTH = form_data.web.WEB_FETCH_MAX_CONTENT_LENGTH
+        request.app.state.config.WEB_LOADER_CONCURRENT_REQUESTS = form_data.web.WEB_LOADER_CONCURRENT_REQUESTS
+        request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST = form_data.web.WEB_SEARCH_DOMAIN_FILTER_LIST
+        request.app.state.config.BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL = (
+            form_data.web.BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL
+        )
+        request.app.state.config.BYPASS_WEB_SEARCH_WEB_LOADER = form_data.web.BYPASS_WEB_SEARCH_WEB_LOADER
+        request.app.state.config.OLLAMA_CLOUD_WEB_SEARCH_API_KEY = form_data.web.OLLAMA_CLOUD_WEB_SEARCH_API_KEY
+        request.app.state.config.SEARXNG_QUERY_URL = form_data.web.SEARXNG_QUERY_URL
+        request.app.state.config.SEARXNG_LANGUAGE = form_data.web.SEARXNG_LANGUAGE
+        request.app.state.config.YACY_QUERY_URL = form_data.web.YACY_QUERY_URL
+        request.app.state.config.YACY_USERNAME = form_data.web.YACY_USERNAME
+        request.app.state.config.YACY_PASSWORD = form_data.web.YACY_PASSWORD
+        request.app.state.config.GOOGLE_PSE_API_KEY = form_data.web.GOOGLE_PSE_API_KEY
+        request.app.state.config.GOOGLE_PSE_ENGINE_ID = form_data.web.GOOGLE_PSE_ENGINE_ID
+        request.app.state.config.BRAVE_SEARCH_API_KEY = form_data.web.BRAVE_SEARCH_API_KEY
+        if form_data.web.BRAVE_SEARCH_CONTEXT_TOKENS is not None:
+            request.app.state.config.BRAVE_SEARCH_CONTEXT_TOKENS = form_data.web.BRAVE_SEARCH_CONTEXT_TOKENS
+        request.app.state.config.KAGI_SEARCH_API_KEY = form_data.web.KAGI_SEARCH_API_KEY
+        request.app.state.config.MOJEEK_SEARCH_API_KEY = form_data.web.MOJEEK_SEARCH_API_KEY
+        request.app.state.config.BOCHA_SEARCH_API_KEY = form_data.web.BOCHA_SEARCH_API_KEY
+        request.app.state.config.SERPSTACK_API_KEY = form_data.web.SERPSTACK_API_KEY
+        request.app.state.config.SERPSTACK_HTTPS = form_data.web.SERPSTACK_HTTPS
+        request.app.state.config.SERPER_API_KEY = form_data.web.SERPER_API_KEY
+        request.app.state.config.SERPLY_API_KEY = form_data.web.SERPLY_API_KEY
+        request.app.state.config.DDGS_BACKEND = form_data.web.DDGS_BACKEND
+        request.app.state.config.TAVILY_API_KEY = form_data.web.TAVILY_API_KEY
+        request.app.state.config.SEARCHAPI_API_KEY = form_data.web.SEARCHAPI_API_KEY
+        request.app.state.config.SEARCHAPI_ENGINE = form_data.web.SEARCHAPI_ENGINE
+        request.app.state.config.SERPAPI_API_KEY = form_data.web.SERPAPI_API_KEY
+        request.app.state.config.SERPAPI_ENGINE = form_data.web.SERPAPI_ENGINE
+        request.app.state.config.JINA_API_KEY = form_data.web.JINA_API_KEY
+        request.app.state.config.JINA_API_BASE_URL = form_data.web.JINA_API_BASE_URL
+        request.app.state.config.BING_SEARCH_V7_ENDPOINT = form_data.web.BING_SEARCH_V7_ENDPOINT
+        request.app.state.config.BING_SEARCH_V7_SUBSCRIPTION_KEY = form_data.web.BING_SEARCH_V7_SUBSCRIPTION_KEY
+        request.app.state.config.EXA_API_KEY = form_data.web.EXA_API_KEY
+        request.app.state.config.PERPLEXITY_API_KEY = form_data.web.PERPLEXITY_API_KEY
+        request.app.state.config.PERPLEXITY_MODEL = form_data.web.PERPLEXITY_MODEL
+        request.app.state.config.PERPLEXITY_SEARCH_CONTEXT_USAGE = form_data.web.PERPLEXITY_SEARCH_CONTEXT_USAGE
+        request.app.state.config.PERPLEXITY_SEARCH_API_URL = form_data.web.PERPLEXITY_SEARCH_API_URL
+        request.app.state.config.SOUGOU_API_SID = form_data.web.SOUGOU_API_SID
+        request.app.state.config.SOUGOU_API_SK = form_data.web.SOUGOU_API_SK
+
+        # Web loader settings
+        request.app.state.config.WEB_LOADER_ENGINE = form_data.web.WEB_LOADER_ENGINE
+        request.app.state.config.WEB_LOADER_TIMEOUT = form_data.web.WEB_LOADER_TIMEOUT
+
+        request.app.state.config.ENABLE_WEB_LOADER_SSL_VERIFICATION = form_data.web.ENABLE_WEB_LOADER_SSL_VERIFICATION
+        request.app.state.config.PLAYWRIGHT_WS_URL = form_data.web.PLAYWRIGHT_WS_URL
+        request.app.state.config.PLAYWRIGHT_TIMEOUT = form_data.web.PLAYWRIGHT_TIMEOUT
+        request.app.state.config.FIRECRAWL_API_KEY = form_data.web.FIRECRAWL_API_KEY
+        request.app.state.config.FIRECRAWL_API_BASE_URL = form_data.web.FIRECRAWL_API_BASE_URL
+        request.app.state.config.FIRECRAWL_TIMEOUT = form_data.web.FIRECRAWL_TIMEOUT
+        request.app.state.config.EXTERNAL_WEB_SEARCH_URL = form_data.web.EXTERNAL_WEB_SEARCH_URL
+        request.app.state.config.EXTERNAL_WEB_SEARCH_API_KEY = form_data.web.EXTERNAL_WEB_SEARCH_API_KEY
+        request.app.state.config.EXTERNAL_WEB_LOADER_URL = form_data.web.EXTERNAL_WEB_LOADER_URL
+        request.app.state.config.EXTERNAL_WEB_LOADER_API_KEY = form_data.web.EXTERNAL_WEB_LOADER_API_KEY
+        request.app.state.config.TAVILY_EXTRACT_DEPTH = form_data.web.TAVILY_EXTRACT_DEPTH
+        request.app.state.config.YOUTUBE_LOADER_LANGUAGE = form_data.web.YOUTUBE_LOADER_LANGUAGE
+        request.app.state.config.YOUTUBE_LOADER_PROXY_URL = form_data.web.YOUTUBE_LOADER_PROXY_URL
+        request.app.state.YOUTUBE_LOADER_TRANSLATION = form_data.web.YOUTUBE_LOADER_TRANSLATION
+        request.app.state.config.YANDEX_WEB_SEARCH_URL = form_data.web.YANDEX_WEB_SEARCH_URL
+        request.app.state.config.YANDEX_WEB_SEARCH_API_KEY = form_data.web.YANDEX_WEB_SEARCH_API_KEY
+        request.app.state.config.YANDEX_WEB_SEARCH_CONFIG = form_data.web.YANDEX_WEB_SEARCH_CONFIG
+        request.app.state.config.YOUCOM_API_KEY = form_data.web.YOUCOM_API_KEY
+        request.app.state.config.LINKUP_API_KEY = form_data.web.LINKUP_API_KEY
+        request.app.state.config.LINKUP_SEARCH_PARAMS = form_data.web.LINKUP_SEARCH_PARAMS
+
+    return {
+        'status': True,
+        # RAG settings
+        'RAG_TEMPLATE': request.app.state.config.RAG_TEMPLATE,
+        'TOP_K': request.app.state.config.TOP_K,
+        'BYPASS_EMBEDDING_AND_RETRIEVAL': request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL,
+        'RAG_FULL_CONTEXT': request.app.state.config.RAG_FULL_CONTEXT,
+        # Hybrid search settings
+        'ENABLE_RAG_HYBRID_SEARCH': request.app.state.config.ENABLE_RAG_HYBRID_SEARCH,
+        'TOP_K_RERANKER': request.app.state.config.TOP_K_RERANKER,
+        'RELEVANCE_THRESHOLD': request.app.state.config.RELEVANCE_THRESHOLD,
+        'HYBRID_BM25_WEIGHT': request.app.state.config.HYBRID_BM25_WEIGHT,
+        # Content extraction settings
+        'CONTENT_EXTRACTION_ENGINE': request.app.state.config.CONTENT_EXTRACTION_ENGINE,
+        'PDF_EXTRACT_IMAGES': request.app.state.config.PDF_EXTRACT_IMAGES,
+        'PDF_LOADER_MODE': request.app.state.config.PDF_LOADER_MODE,
+        'DATALAB_MARKER_API_KEY': request.app.state.config.DATALAB_MARKER_API_KEY,
+        'DATALAB_MARKER_API_BASE_URL': request.app.state.config.DATALAB_MARKER_API_BASE_URL,
+        'DATALAB_MARKER_ADDITIONAL_CONFIG': request.app.state.config.DATALAB_MARKER_ADDITIONAL_CONFIG,
+        'DATALAB_MARKER_SKIP_CACHE': request.app.state.config.DATALAB_MARKER_SKIP_CACHE,
+        'DATALAB_MARKER_FORCE_OCR': request.app.state.config.DATALAB_MARKER_FORCE_OCR,
+        'DATALAB_MARKER_PAGINATE': request.app.state.config.DATALAB_MARKER_PAGINATE,
+        'DATALAB_MARKER_STRIP_EXISTING_OCR': request.app.state.config.DATALAB_MARKER_STRIP_EXISTING_OCR,
+        'DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION': request.app.state.config.DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION,
+        'DATALAB_MARKER_USE_LLM': request.app.state.config.DATALAB_MARKER_USE_LLM,
+        'DATALAB_MARKER_OUTPUT_FORMAT': request.app.state.config.DATALAB_MARKER_OUTPUT_FORMAT,
+        'EXTERNAL_DOCUMENT_LOADER_URL': request.app.state.config.EXTERNAL_DOCUMENT_LOADER_URL,
+        'EXTERNAL_DOCUMENT_LOADER_API_KEY': request.app.state.config.EXTERNAL_DOCUMENT_LOADER_API_KEY,
+        'TIKA_SERVER_URL': request.app.state.config.TIKA_SERVER_URL,
+        'DOCLING_SERVER_URL': request.app.state.config.DOCLING_SERVER_URL,
+        'DOCLING_API_KEY': request.app.state.config.DOCLING_API_KEY,
+        'DOCLING_PARAMS': request.app.state.config.DOCLING_PARAMS,
+        'DOCUMENT_INTELLIGENCE_ENDPOINT': request.app.state.config.DOCUMENT_INTELLIGENCE_ENDPOINT,
+        'DOCUMENT_INTELLIGENCE_KEY': request.app.state.config.DOCUMENT_INTELLIGENCE_KEY,
+        'DOCUMENT_INTELLIGENCE_MODEL': request.app.state.config.DOCUMENT_INTELLIGENCE_MODEL,
+        'MISTRAL_OCR_API_BASE_URL': request.app.state.config.MISTRAL_OCR_API_BASE_URL,
+        'MISTRAL_OCR_API_KEY': request.app.state.config.MISTRAL_OCR_API_KEY,
+        'PADDLEOCR_VL_BASE_URL': request.app.state.config.PADDLEOCR_VL_BASE_URL,
+        'PADDLEOCR_VL_TOKEN': request.app.state.config.PADDLEOCR_VL_TOKEN,
+        # MinerU settings
+        'MINERU_API_MODE': request.app.state.config.MINERU_API_MODE,
+        'MINERU_API_URL': request.app.state.config.MINERU_API_URL,
+        'MINERU_API_KEY': request.app.state.config.MINERU_API_KEY,
+        'MINERU_API_TIMEOUT': request.app.state.config.MINERU_API_TIMEOUT,
+        'MINERU_PARAMS': request.app.state.config.MINERU_PARAMS,
+        # Reranking settings
+        'RAG_RERANKING_MODEL': request.app.state.config.RAG_RERANKING_MODEL,
+        'RAG_RERANKING_ENGINE': request.app.state.config.RAG_RERANKING_ENGINE,
+        'RAG_EXTERNAL_RERANKER_URL': request.app.state.config.RAG_EXTERNAL_RERANKER_URL,
+        'RAG_EXTERNAL_RERANKER_API_KEY': request.app.state.config.RAG_EXTERNAL_RERANKER_API_KEY,
+        'RAG_EXTERNAL_RERANKER_TIMEOUT': request.app.state.config.RAG_EXTERNAL_RERANKER_TIMEOUT,
+        # Chunking settings
+        'TEXT_SPLITTER': request.app.state.config.TEXT_SPLITTER,
+        'CHUNK_SIZE': request.app.state.config.CHUNK_SIZE,
+        'CHUNK_MIN_SIZE_TARGET': request.app.state.config.CHUNK_MIN_SIZE_TARGET,
+        'ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER': request.app.state.config.ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER,
+        'CHUNK_OVERLAP': request.app.state.config.CHUNK_OVERLAP,
+        # File upload settings
+        'FILE_MAX_SIZE': request.app.state.config.FILE_MAX_SIZE,
+        'FILE_MAX_COUNT': request.app.state.config.FILE_MAX_COUNT,
+        'FILE_IMAGE_COMPRESSION_WIDTH': request.app.state.config.FILE_IMAGE_COMPRESSION_WIDTH,
+        'FILE_IMAGE_COMPRESSION_HEIGHT': request.app.state.config.FILE_IMAGE_COMPRESSION_HEIGHT,
+        'ALLOWED_FILE_EXTENSIONS': request.app.state.config.ALLOWED_FILE_EXTENSIONS,
+        # Integration settings
+        'ENABLE_GOOGLE_DRIVE_INTEGRATION': request.app.state.config.ENABLE_GOOGLE_DRIVE_INTEGRATION,
+        'ENABLE_ONEDRIVE_INTEGRATION': request.app.state.config.ENABLE_ONEDRIVE_INTEGRATION,
+        # Web search settings
+        'web': {
+            'ENABLE_WEB_SEARCH': request.app.state.config.ENABLE_WEB_SEARCH,
+            'WEB_SEARCH_ENGINE': request.app.state.config.WEB_SEARCH_ENGINE,
+            'WEB_SEARCH_TRUST_ENV': request.app.state.config.WEB_SEARCH_TRUST_ENV,
+            'WEB_SEARCH_RESULT_COUNT': request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+            'WEB_SEARCH_CONCURRENT_REQUESTS': request.app.state.config.WEB_SEARCH_CONCURRENT_REQUESTS,
+            'WEB_FETCH_MAX_CONTENT_LENGTH': request.app.state.config.WEB_FETCH_MAX_CONTENT_LENGTH,
+            'WEB_LOADER_CONCURRENT_REQUESTS': request.app.state.config.WEB_LOADER_CONCURRENT_REQUESTS,
+            'WEB_SEARCH_DOMAIN_FILTER_LIST': request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            'BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL': request.app.state.config.BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL,
+            'BYPASS_WEB_SEARCH_WEB_LOADER': request.app.state.config.BYPASS_WEB_SEARCH_WEB_LOADER,
+            'OLLAMA_CLOUD_WEB_SEARCH_API_KEY': request.app.state.config.OLLAMA_CLOUD_WEB_SEARCH_API_KEY,
+            'SEARXNG_QUERY_URL': request.app.state.config.SEARXNG_QUERY_URL,
+            'SEARXNG_LANGUAGE': request.app.state.config.SEARXNG_LANGUAGE,
+            'YACY_QUERY_URL': request.app.state.config.YACY_QUERY_URL,
+            'YACY_USERNAME': request.app.state.config.YACY_USERNAME,
+            'YACY_PASSWORD': request.app.state.config.YACY_PASSWORD,
+            'GOOGLE_PSE_API_KEY': request.app.state.config.GOOGLE_PSE_API_KEY,
+            'GOOGLE_PSE_ENGINE_ID': request.app.state.config.GOOGLE_PSE_ENGINE_ID,
+            'BRAVE_SEARCH_API_KEY': request.app.state.config.BRAVE_SEARCH_API_KEY,
+            'BRAVE_SEARCH_CONTEXT_TOKENS': request.app.state.config.BRAVE_SEARCH_CONTEXT_TOKENS,
+            'KAGI_SEARCH_API_KEY': request.app.state.config.KAGI_SEARCH_API_KEY,
+            'MOJEEK_SEARCH_API_KEY': request.app.state.config.MOJEEK_SEARCH_API_KEY,
+            'BOCHA_SEARCH_API_KEY': request.app.state.config.BOCHA_SEARCH_API_KEY,
+            'SERPSTACK_API_KEY': request.app.state.config.SERPSTACK_API_KEY,
+            'SERPSTACK_HTTPS': request.app.state.config.SERPSTACK_HTTPS,
+            'SERPER_API_KEY': request.app.state.config.SERPER_API_KEY,
+            'SERPLY_API_KEY': request.app.state.config.SERPLY_API_KEY,
+            'TAVILY_API_KEY': request.app.state.config.TAVILY_API_KEY,
+            'SEARCHAPI_API_KEY': request.app.state.config.SEARCHAPI_API_KEY,
+            'SEARCHAPI_ENGINE': request.app.state.config.SEARCHAPI_ENGINE,
+            'SERPAPI_API_KEY': request.app.state.config.SERPAPI_API_KEY,
+            'SERPAPI_ENGINE': request.app.state.config.SERPAPI_ENGINE,
+            'JINA_API_KEY': request.app.state.config.JINA_API_KEY,
+            'JINA_API_BASE_URL': request.app.state.config.JINA_API_BASE_URL,
+            'BING_SEARCH_V7_ENDPOINT': request.app.state.config.BING_SEARCH_V7_ENDPOINT,
+            'BING_SEARCH_V7_SUBSCRIPTION_KEY': request.app.state.config.BING_SEARCH_V7_SUBSCRIPTION_KEY,
+            'EXA_API_KEY': request.app.state.config.EXA_API_KEY,
+            'PERPLEXITY_API_KEY': request.app.state.config.PERPLEXITY_API_KEY,
+            'PERPLEXITY_MODEL': request.app.state.config.PERPLEXITY_MODEL,
+            'PERPLEXITY_SEARCH_CONTEXT_USAGE': request.app.state.config.PERPLEXITY_SEARCH_CONTEXT_USAGE,
+            'PERPLEXITY_SEARCH_API_URL': request.app.state.config.PERPLEXITY_SEARCH_API_URL,
+            'SOUGOU_API_SID': request.app.state.config.SOUGOU_API_SID,
+            'SOUGOU_API_SK': request.app.state.config.SOUGOU_API_SK,
+            'WEB_LOADER_ENGINE': request.app.state.config.WEB_LOADER_ENGINE,
+            'WEB_LOADER_TIMEOUT': request.app.state.config.WEB_LOADER_TIMEOUT,
+            'ENABLE_WEB_LOADER_SSL_VERIFICATION': request.app.state.config.ENABLE_WEB_LOADER_SSL_VERIFICATION,
+            'PLAYWRIGHT_WS_URL': request.app.state.config.PLAYWRIGHT_WS_URL,
+            'PLAYWRIGHT_TIMEOUT': request.app.state.config.PLAYWRIGHT_TIMEOUT,
+            'FIRECRAWL_API_KEY': request.app.state.config.FIRECRAWL_API_KEY,
+            'FIRECRAWL_API_BASE_URL': request.app.state.config.FIRECRAWL_API_BASE_URL,
+            'FIRECRAWL_TIMEOUT': request.app.state.config.FIRECRAWL_TIMEOUT,
+            'TAVILY_EXTRACT_DEPTH': request.app.state.config.TAVILY_EXTRACT_DEPTH,
+            'EXTERNAL_WEB_SEARCH_URL': request.app.state.config.EXTERNAL_WEB_SEARCH_URL,
+            'EXTERNAL_WEB_SEARCH_API_KEY': request.app.state.config.EXTERNAL_WEB_SEARCH_API_KEY,
+            'EXTERNAL_WEB_LOADER_URL': request.app.state.config.EXTERNAL_WEB_LOADER_URL,
+            'EXTERNAL_WEB_LOADER_API_KEY': request.app.state.config.EXTERNAL_WEB_LOADER_API_KEY,
+            'YOUTUBE_LOADER_LANGUAGE': request.app.state.config.YOUTUBE_LOADER_LANGUAGE,
+            'YOUTUBE_LOADER_PROXY_URL': request.app.state.config.YOUTUBE_LOADER_PROXY_URL,
+            'YOUTUBE_LOADER_TRANSLATION': request.app.state.YOUTUBE_LOADER_TRANSLATION,
+            'YANDEX_WEB_SEARCH_URL': request.app.state.config.YANDEX_WEB_SEARCH_URL,
+            'YANDEX_WEB_SEARCH_API_KEY': request.app.state.config.YANDEX_WEB_SEARCH_API_KEY,
+            'YANDEX_WEB_SEARCH_CONFIG': request.app.state.config.YANDEX_WEB_SEARCH_CONFIG,
+            'YOUCOM_API_KEY': request.app.state.config.YOUCOM_API_KEY,
+            'LINKUP_API_KEY': request.app.state.config.LINKUP_API_KEY,
+            'LINKUP_SEARCH_PARAMS': request.app.state.config.LINKUP_SEARCH_PARAMS,
+        },
+    }
+
+
+####################################
+#
+# Document process and retrieval
+#
+####################################
+
+
+def can_merge_chunks(a: Document, b: Document) -> bool:
+    if a.metadata.get('source') != b.metadata.get('source'):
+        return False
+
+    a_file_id = a.metadata.get('file_id')
+    b_file_id = b.metadata.get('file_id')
+
+    if a_file_id is not None and b_file_id is not None:
+        return a_file_id == b_file_id
+
+    return True
+
+
+def merge_docs_to_target_size(
+    request: Request,
+    chunks: list[Document],
+) -> list[Document]:
+    """
+    Best-effort normalization of chunk sizes.
+
+    Attempts to grow small chunks up to a desired minimum size,
+    without exceeding the maximum size or crossing source/file
+    boundaries.
+
+    Uses forward merging first (absorb the next chunk), then
+    backward merging (append into the previous emitted chunk)
+    for undersized chunks that can't grow forward.
+    """
+    min_size = request.app.state.config.CHUNK_MIN_SIZE_TARGET
+    max_size = request.app.state.config.CHUNK_SIZE
+
+    if min_size <= 0:
+        return chunks
+
+    measure: Callable[[str], int] = len
+    if request.app.state.config.TEXT_SPLITTER == 'token':
+        encoding = tiktoken.get_encoding(str(request.app.state.config.TIKTOKEN_ENCODING_NAME))
+        measure = lambda text: len(encoding.encode(text))
+
+    def _merge_backward(result: list[Document], content: str, chunk: Document) -> bool:
+        """Try to append content into the last emitted chunk. Returns True on success."""
+        if not result:
+            return False
+        prev = result[-1]
+        if not can_merge_chunks(prev, chunk):
+            return False
+        merged = f'{prev.page_content}\n\n{content}'
+        if measure(merged) > max_size:
+            return False
+        result[-1] = Document(page_content=merged, metadata={**prev.metadata})
+        return True
+
+    def _emit(result: list[Document], content: str, chunk: Document) -> None:
+        """Emit a chunk, trying backward merge first if it's undersized."""
+        is_undersized = measure(content) < min_size
+        if is_undersized and _merge_backward(result, content, chunk):
+            return
+        result.append(Document(page_content=content, metadata={**chunk.metadata}))
+
+    result: list[Document] = []
+    current_chunk: Document | None = None
+    current_content: str = ''
+
+    for next_chunk in chunks:
+        if current_chunk is None:
+            current_chunk = next_chunk
+            current_content = next_chunk.page_content
+            continue
+
+        # Forward merge: absorb next chunk into current if undersized and fits
+        merged_content = f'{current_content}\n\n{next_chunk.page_content}'
+        can_merge_forward = (
+            can_merge_chunks(current_chunk, next_chunk)
+            and measure(current_content) < min_size
+            and measure(merged_content) <= max_size
+        )
+
+        if can_merge_forward:
+            current_content = merged_content
+        else:
+            _emit(result, current_content, current_chunk)
+            current_chunk = next_chunk
+            current_content = next_chunk.page_content
+
+    if current_chunk is not None:
+        _emit(result, current_content, current_chunk)
+
+    return result
+
+
+def save_docs_to_vector_db(
+    request: Request,
+    docs,
+    collection_name,
+    metadata: dict | None = None,
+    overwrite: bool = False,
+    split: bool = True,
+    add: bool = False,
+    user=None,
+) -> bool:
+    def _get_docs_info(docs: list[Document]) -> str:
+        docs_info = set()
+
+        # Trying to select relevant metadata identifying the document.
+        for doc in docs:
+            metadata = getattr(doc, 'metadata', {})
+            doc_name = metadata.get('name', '')
+            if not doc_name:
+                doc_name = metadata.get('title', '')
+            if not doc_name:
+                doc_name = metadata.get('source', '')
+            if doc_name:
+                docs_info.add(doc_name)
+
+        return ', '.join(docs_info)
+
+    log.debug(f'save_docs_to_vector_db: document {_get_docs_info(docs)} {collection_name}')
+
+    # Check if entries with the same hash (metadata.hash) already exist
+    if metadata and 'hash' in metadata:
+        result = VECTOR_DB_CLIENT.query(
+            collection_name=collection_name,
+            filter={'hash': metadata['hash']},
+        )
+
+        if result is not None and result.ids and len(result.ids) > 0:
+            existing_doc_ids = result.ids[0]
+            if existing_doc_ids:
+                # Check if the existing document belongs to the same file
+                # If same file_id, this is a re-add/reindex - allow it
+                # If different file_id, this is a duplicate - block it
+                existing_file_id = None
+                if result.metadatas and result.metadatas[0]:
+                    existing_file_id = result.metadatas[0][0].get('file_id')
+
+                if existing_file_id != metadata.get('file_id'):
+                    log.info(f'Document with hash {metadata["hash"]} already exists')
+                    raise ValueError(ERROR_MESSAGES.DUPLICATE_CONTENT)
+
+    if split:
+        if request.app.state.config.ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER:
+            log.info('Using markdown header text splitter')
+            # Define headers to split on - covering most common markdown header levels
+            markdown_splitter = MarkdownHeaderTextSplitter(
+                headers_to_split_on=[
+                    ('#', 'Header 1'),
+                    ('##', 'Header 2'),
+                    ('###', 'Header 3'),
+                    ('####', 'Header 4'),
+                    ('#####', 'Header 5'),
+                    ('######', 'Header 6'),
+                ],
+                strip_headers=False,  # Keep headers in content for context
+            )
+
+            split_docs = []
+            for doc in docs:
+                split_docs.extend(
+                    [
+                        Document(
+                            page_content=split_chunk.page_content,
+                            metadata={**doc.metadata},
+                        )
+                        for split_chunk in markdown_splitter.split_text(doc.page_content)
+                    ]
+                )
+
+            docs = split_docs
+            if request.app.state.config.CHUNK_MIN_SIZE_TARGET > 0:
+                docs = merge_docs_to_target_size(request, docs)
+
+        if request.app.state.config.TEXT_SPLITTER in ['', 'character']:
+            text_splitter = RecursiveCharacterTextSplitter(
+                chunk_size=request.app.state.config.CHUNK_SIZE,
+                chunk_overlap=request.app.state.config.CHUNK_OVERLAP,
+                add_start_index=True,
+            )
+            docs = text_splitter.split_documents(docs)
+        elif request.app.state.config.TEXT_SPLITTER == 'token':
+            log.info(f'Using token text splitter: {request.app.state.config.TIKTOKEN_ENCODING_NAME}')
+
+            tiktoken.get_encoding(str(request.app.state.config.TIKTOKEN_ENCODING_NAME))
+            text_splitter = TokenTextSplitter(
+                encoding_name=str(request.app.state.config.TIKTOKEN_ENCODING_NAME),
+                chunk_size=request.app.state.config.CHUNK_SIZE,
+                chunk_overlap=request.app.state.config.CHUNK_OVERLAP,
+                add_start_index=True,
+            )
+            docs = text_splitter.split_documents(docs)
+        else:
+            raise ValueError(ERROR_MESSAGES.DEFAULT('Invalid text splitter'))
+
+    if len(docs) == 0:
+        raise ValueError(ERROR_MESSAGES.EMPTY_CONTENT)
+
+    texts = [sanitize_text_for_db(doc.page_content) for doc in docs]
+    metadatas = [
+        {
+            **doc.metadata,
+            **(metadata if metadata else {}),
+            'embedding_config': {
+                'engine': request.app.state.config.RAG_EMBEDDING_ENGINE,
+                'model': request.app.state.config.RAG_EMBEDDING_MODEL,
+            },
+        }
+        for doc in docs
+    ]
+
+    try:
+        if VECTOR_DB_CLIENT.has_collection(collection_name=collection_name):
+            log.info(f'collection {collection_name} already exists')
+
+            if overwrite:
+                VECTOR_DB_CLIENT.delete_collection(collection_name=collection_name)
+                log.info(f'deleting existing collection {collection_name}')
+            elif add is False:
+                log.info(f'collection {collection_name} already exists, overwrite is False and add is False')
+                return True
+
+        log.info(f'generating embeddings for {collection_name}')
+        embedding_function = get_embedding_function(
+            request.app.state.config.RAG_EMBEDDING_ENGINE,
+            request.app.state.config.RAG_EMBEDDING_MODEL,
+            request.app.state.ef,
+            (
+                request.app.state.config.RAG_OPENAI_API_BASE_URL
+                if request.app.state.config.RAG_EMBEDDING_ENGINE == 'openai'
+                else (
+                    request.app.state.config.RAG_OLLAMA_BASE_URL
+                    if request.app.state.config.RAG_EMBEDDING_ENGINE == 'ollama'
+                    else request.app.state.config.RAG_AZURE_OPENAI_BASE_URL
+                )
+            ),
+            (
+                request.app.state.config.RAG_OPENAI_API_KEY
+                if request.app.state.config.RAG_EMBEDDING_ENGINE == 'openai'
+                else (
+                    request.app.state.config.RAG_OLLAMA_API_KEY
+                    if request.app.state.config.RAG_EMBEDDING_ENGINE == 'ollama'
+                    else request.app.state.config.RAG_AZURE_OPENAI_API_KEY
+                )
+            ),
+            request.app.state.config.RAG_EMBEDDING_BATCH_SIZE,
+            azure_api_version=(
+                request.app.state.config.RAG_AZURE_OPENAI_API_VERSION
+                if request.app.state.config.RAG_EMBEDDING_ENGINE == 'azure_openai'
+                else None
+            ),
+            enable_async=request.app.state.config.ENABLE_ASYNC_EMBEDDING,
+            concurrent_requests=request.app.state.config.RAG_EMBEDDING_CONCURRENT_REQUESTS,
+        )
+
+        # Run async embedding in sync context using the main event loop
+        # This allows the main loop to stay responsive to health checks during long operations
+        embedding_timeout = RAG_EMBEDDING_TIMEOUT
+
+        future = asyncio.run_coroutine_threadsafe(
+            embedding_function(
+                list(map(lambda x: x.replace('\n', ' '), texts)),
+                prefix=RAG_EMBEDDING_CONTENT_PREFIX,
+                user=user,
+            ),
+            request.app.state.main_loop,
+        )
+        embeddings = future.result(timeout=embedding_timeout)
+        log.info(f'embeddings generated {len(embeddings)} for {len(texts)} items')
+
+        items = [
+            {
+                'id': str(uuid.uuid4()),
+                'text': text,
+                'vector': embeddings[idx],
+                'metadata': metadatas[idx],
+            }
+            for idx, text in enumerate(texts)
+        ]
+
+        log.info(f'adding to collection {collection_name}')
+        VECTOR_DB_CLIENT.insert(
+            collection_name=collection_name,
+            items=items,
+        )
+
+        log.info(f'added {len(items)} items to collection {collection_name}')
+        return True
+    except Exception as e:
+        log.exception(e)
+        raise e
+
+
+class ProcessFileForm(BaseModel):
+    file_id: str
+    content: str | None = None
+    collection_name: str | None = None
+
+
+@router.post('/process/file')
+async def process_file(
+    request: Request,
+    form_data: ProcessFileForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """
+    Process a file and save its content to the vector database.
+    Process a file and save its content to the vector database.
+    Note: granular session management is used to prevent connection pool exhaustion.
+    The session is committed before external API calls, and updates use a fresh session.
+    """
+    if user.role == 'admin':
+        file = await Files.get_file_by_id(form_data.file_id, db=db)
+    else:
+        file = await Files.get_file_by_id_and_user_id(form_data.file_id, user.id, db=db)
+
+    if file:
+        try:
+            collection_name = form_data.collection_name
+
+            if collection_name is None:
+                collection_name = f'file-{file.id}'
+            else:
+                await _validate_collection_access([collection_name], user, access_type='write')
+
+            if form_data.content:
+                # Update the content in the file
+                # Usage: /files/{file_id}/data/content/update, /files/ (audio file upload pipeline)
+
+                try:
+                    # /files/{file_id}/data/content/update
+                    await ASYNC_VECTOR_DB_CLIENT.delete_collection(collection_name=f'file-{file.id}')
+                except Exception:
+                    # Audio file upload pipeline
+                    pass
+
+                docs = [
+                    Document(
+                        page_content=form_data.content.replace('<br/>', '\n'),
+                        metadata={
+                            **file.meta,
+                            'name': file.filename,
+                            'created_by': file.user_id,
+                            'file_id': file.id,
+                            'source': file.filename,
+                        },
+                    )
+                ]
+
+                text_content = form_data.content
+            elif form_data.collection_name:
+                # Check if the file has already been processed and save the content
+                # Usage: /knowledge/{id}/file/add, /knowledge/{id}/file/update
+
+                result = await ASYNC_VECTOR_DB_CLIENT.query(
+                    collection_name=f'file-{file.id}', filter={'file_id': file.id}
+                )
+
+                if result is not None and len(result.ids[0]) > 0:
+                    docs = [
+                        Document(
+                            page_content=result.documents[0][idx],
+                            metadata=result.metadatas[0][idx],
+                        )
+                        for idx, id in enumerate(result.ids[0])
+                    ]
+                else:
+                    docs = [
+                        Document(
+                            page_content=file.data.get('content', ''),
+                            metadata={
+                                **file.meta,
+                                'name': file.filename,
+                                'created_by': file.user_id,
+                                'file_id': file.id,
+                                'source': file.filename,
+                            },
+                        )
+                    ]
+
+                text_content = file.data.get('content', '')
+            else:
+                # Process the file and save the content
+                # Usage: /files/
+                file_path = file.path
+                if file_path:
+                    file_path = await asyncio.to_thread(Storage.get_file, file_path)
+                    loader = build_loader_from_config(request)
+                    loader.user = user
+                    docs = await loader.aload(file.filename, file.meta.get('content_type'), file_path)
+
+                    docs = [
+                        Document(
+                            page_content=doc.page_content,
+                            metadata={
+                                **filter_metadata(doc.metadata),
+                                'name': file.filename,
+                                'created_by': file.user_id,
+                                'file_id': file.id,
+                                'source': file.filename,
+                            },
+                        )
+                        for doc in docs
+                    ]
+                else:
+                    docs = [
+                        Document(
+                            page_content=file.data.get('content', ''),
+                            metadata={
+                                **file.meta,
+                                'name': file.filename,
+                                'created_by': file.user_id,
+                                'file_id': file.id,
+                                'source': file.filename,
+                            },
+                        )
+                    ]
+                text_content = ' '.join([doc.page_content for doc in docs])
+
+            log.debug(f'text_content: {text_content}')
+            await Files.update_file_data_by_id(
+                file.id,
+                {'content': text_content},
+                db=db,
+            )
+            hash = calculate_sha256_string(text_content)
+
+            if request.app.state.config.BYPASS_EMBEDDING_AND_RETRIEVAL:
+                await Files.update_file_data_by_id(file.id, {'status': 'completed'}, db=db)
+                await Files.update_file_hash_by_id(file.id, hash, db=db)
+                return {
+                    'status': True,
+                    'collection_name': None,
+                    'filename': file.filename,
+                    'content': text_content,
+                }
+            else:
+                try:
+                    # Commit any pending changes before the slow embedding step.
+                    # Note: file is already a Pydantic model (not ORM), so no expunge needed.
+                    await db.commit()
+
+                    # External embedding API takes time (5-60s+).
+                    # Subsequent updates use fresh async sessions.
+                    # NOTE: save_docs_to_vector_db is a sync function that
+                    # calls asyncio.run_coroutine_threadsafe(..., main_loop).result()
+                    # which blocks the calling thread.  We MUST run it in a
+                    # worker thread to avoid deadlocking the event loop.
+                    result = await run_in_threadpool(
+                        save_docs_to_vector_db,
+                        request,
+                        docs=docs,
+                        collection_name=collection_name,
+                        metadata={
+                            'file_id': file.id,
+                            'name': file.filename,
+                            'hash': hash,
+                        },
+                        add=(True if form_data.collection_name else False),
+                        user=user,
+                    )
+                    log.info(f'added {len(docs)} items to collection {collection_name}')
+
+                    if result:
+                        # Fresh session for the final update.
+                        async with get_async_db() as session:
+                            await Files.update_file_metadata_by_id(
+                                file.id,
+                                {
+                                    'collection_name': collection_name,
+                                },
+                                db=session,
+                            )
+
+                            await Files.update_file_data_by_id(
+                                file.id,
+                                {'status': 'completed'},
+                                db=session,
+                            )
+                            await Files.update_file_hash_by_id(file.id, hash, db=session)
+
+                            return {
+                                'status': True,
+                                'collection_name': collection_name,
+                                'filename': file.filename,
+                                'content': text_content,
+                            }
+                    else:
+                        raise Exception('Error saving document to vector database')
+                except Exception as e:
+                    raise e
+
+        except Exception as e:
+            log.exception(e)
+            # Fresh session for error status update.
+            async with get_async_db() as session:
+                await Files.update_file_data_by_id(
+                    file.id,
+                    {'status': 'failed'},
+                    db=session,
+                )
+                # Clear the hash so the file can be re-uploaded after fixing the issue
+                await Files.update_file_hash_by_id(file.id, None, db=session)
+
+            if 'No pandoc was found' in str(e):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=ERROR_MESSAGES.PANDOC_NOT_INSTALLED,
+                )
+            else:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=str(e),
+                )
+
+    else:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+
+class ProcessTextForm(BaseModel):
+    name: str
+    content: str
+    collection_name: str | None = None
+
+
+@router.post('/process/text')
+async def process_text(
+    request: Request,
+    form_data: ProcessTextForm,
+    user=Depends(get_verified_user),
+):
+    collection_name = form_data.collection_name
+    if collection_name is None:
+        collection_name = calculate_sha256_string(form_data.content)
+    else:
+        await _validate_collection_access([collection_name], user, access_type='write')
+
+    docs = [
+        Document(
+            page_content=form_data.content,
+            metadata={'name': form_data.name, 'created_by': user.id},
+        )
+    ]
+    text_content = form_data.content
+    log.debug(f'text_content: {text_content}')
+
+    result = await run_in_threadpool(save_docs_to_vector_db, request, docs, collection_name, user=user)
+    if result:
+        return {
+            'status': True,
+            'collection_name': collection_name,
+            'content': text_content,
+        }
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=ERROR_MESSAGES.DEFAULT(),
+        )
+
+
+@router.post('/process/youtube')
+@router.post('/process/web')
+async def process_web(
+    request: Request,
+    form_data: ProcessUrlForm,
+    process: bool = Query(True, description='Whether to process and save the content'),
+    overwrite: bool = Query(True, description='Whether to overwrite existing collection'),
+    user=Depends(get_verified_user),
+):
+    try:
+        content, docs = await run_in_threadpool(get_content_from_url, request, form_data.url)
+        log.debug(f'text_content: {content}')
+
+        if process:
+            collection_name = form_data.collection_name
+            if not collection_name:
+                collection_name = calculate_sha256_string(form_data.url)[:63]
+            else:
+                await _validate_collection_access([collection_name], user, access_type='write')
+
+            if not request.app.state.config.BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL:
+                await run_in_threadpool(
+                    save_docs_to_vector_db,
+                    request,
+                    docs,
+                    collection_name,
+                    overwrite=overwrite,
+                    add=(not overwrite),
+                    user=user,
+                )
+            else:
+                collection_name = None
+
+            return {
+                'status': True,
+                'collection_name': collection_name,
+                'filename': form_data.url,
+                'file': {
+                    'data': {
+                        'content': content,
+                    },
+                    'meta': {
+                        'name': form_data.url,
+                        'source': form_data.url,
+                    },
+                },
+            }
+        else:
+            return {
+                'status': True,
+                'content': content,
+            }
+    except Exception as e:
+        log.exception(e)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.DEFAULT(e),
+        )
+
+
+async def search_web(request: Request, engine: str, query: str, user=None) -> list[SearchResult]:
+    """Dispatch a web search query to the configured engine and return results.
+
+    Providers that have been migrated to async (aiohttp) are awaited natively.
+    Legacy sync providers are offloaded via ``asyncio.to_thread`` to avoid
+    blocking the event loop.
+    """
+
+    # TODO: add playwright to search the web
+    if engine == 'ollama_cloud':
+        return await asyncio.to_thread(
+            search_ollama_cloud,
+            'https://ollama.com',
+            request.app.state.config.OLLAMA_CLOUD_WEB_SEARCH_API_KEY,
+            query,
+            request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+            request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+        )
+    elif engine == 'perplexity_search':
+        if request.app.state.config.PERPLEXITY_API_KEY:
+            return await asyncio.to_thread(
+                search_perplexity_search,
+                request.app.state.config.PERPLEXITY_API_KEY,
+                query,
+                request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+                request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+                request.app.state.config.PERPLEXITY_SEARCH_API_URL,
+                user,
+            )
+        else:
+            raise Exception('No PERPLEXITY_API_KEY found in environment variables')
+    elif engine == 'searxng':
+        if request.app.state.config.SEARXNG_QUERY_URL:
+            searxng_kwargs = {'language': request.app.state.config.SEARXNG_LANGUAGE}
+            return await search_searxng(
+                request.app.state.config.SEARXNG_QUERY_URL,
+                query,
+                request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+                request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+                **searxng_kwargs,
+            )
+        else:
+            raise Exception('No SEARXNG_QUERY_URL found in environment variables')
+    elif engine == 'yacy':
+        if request.app.state.config.YACY_QUERY_URL:
+            return await asyncio.to_thread(
+                search_yacy,
+                request.app.state.config.YACY_QUERY_URL,
+                request.app.state.config.YACY_USERNAME,
+                request.app.state.config.YACY_PASSWORD,
+                query,
+                request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+                request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            )
+        else:
+            raise Exception('No YACY_QUERY_URL found in environment variables')
+    elif engine == 'google_pse':
+        if request.app.state.config.GOOGLE_PSE_API_KEY and request.app.state.config.GOOGLE_PSE_ENGINE_ID:
+            return await search_google_pse(
+                request.app.state.config.GOOGLE_PSE_API_KEY,
+                request.app.state.config.GOOGLE_PSE_ENGINE_ID,
+                query,
+                request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+                request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+                referer=request.app.state.config.WEBUI_URL,
+            )
+        else:
+            raise Exception('No GOOGLE_PSE_API_KEY or GOOGLE_PSE_ENGINE_ID found in environment variables')
+    elif engine == 'brave':
+        if request.app.state.config.BRAVE_SEARCH_API_KEY:
+            return await search_brave(
+                request.app.state.config.BRAVE_SEARCH_API_KEY,
+                query,
+                request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+                request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            )
+        else:
+            raise Exception('No BRAVE_SEARCH_API_KEY found in environment variables')
+    elif engine == 'brave_llm_context':
+        if request.app.state.config.BRAVE_SEARCH_API_KEY:
+            return await asyncio.to_thread(
+                search_brave_llm_context,
+                request.app.state.config.BRAVE_SEARCH_API_KEY,
+                query,
+                request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+                request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+                request.app.state.config.BRAVE_SEARCH_CONTEXT_TOKENS,
+            )
+        else:
+            raise Exception('No BRAVE_SEARCH_API_KEY found in environment variables')
+    elif engine == 'kagi':
+        if request.app.state.config.KAGI_SEARCH_API_KEY:
+            return await asyncio.to_thread(
+                search_kagi,
+                request.app.state.config.KAGI_SEARCH_API_KEY,
+                query,
+                request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+                request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            )
+        else:
+            raise Exception('No KAGI_SEARCH_API_KEY found in environment variables')
+    elif engine == 'mojeek':
+        if request.app.state.config.MOJEEK_SEARCH_API_KEY:
+            return await asyncio.to_thread(
+                search_mojeek,
+                request.app.state.config.MOJEEK_SEARCH_API_KEY,
+                query,
+                request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+                request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            )
+        else:
+            raise Exception('No MOJEEK_SEARCH_API_KEY found in environment variables')
+    elif engine == 'bocha':
+        if request.app.state.config.BOCHA_SEARCH_API_KEY:
+            return await asyncio.to_thread(
+                search_bocha,
+                request.app.state.config.BOCHA_SEARCH_API_KEY,
+                query,
+                request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+                request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            )
+        else:
+            raise Exception('No BOCHA_SEARCH_API_KEY found in environment variables')
+    elif engine == 'serpstack':
+        if request.app.state.config.SERPSTACK_API_KEY:
+            return await search_serpstack(
+                request.app.state.config.SERPSTACK_API_KEY,
+                query,
+                request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+                request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+                https_enabled=request.app.state.config.SERPSTACK_HTTPS,
+            )
+        else:
+            raise Exception('No SERPSTACK_API_KEY found in environment variables')
+    elif engine == 'serper':
+        if request.app.state.config.SERPER_API_KEY:
+            return await search_serper(
+                request.app.state.config.SERPER_API_KEY,
+                query,
+                request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+                request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            )
+        else:
+            raise Exception('No SERPER_API_KEY found in environment variables')
+    elif engine == 'serply':
+        if request.app.state.config.SERPLY_API_KEY:
+            return await asyncio.to_thread(
+                search_serply,
+                request.app.state.config.SERPLY_API_KEY,
+                query,
+                request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+                filter_list=request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            )
+        else:
+            raise Exception('No SERPLY_API_KEY found in environment variables')
+    elif engine == 'duckduckgo':
+        return await asyncio.to_thread(
+            search_duckduckgo,
+            query,
+            request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+            request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            concurrent_requests=request.app.state.config.WEB_SEARCH_CONCURRENT_REQUESTS,
+            backend=request.app.state.config.DDGS_BACKEND,
+        )
+    elif engine == 'tavily':
+        if request.app.state.config.TAVILY_API_KEY:
+            return await asyncio.to_thread(
+                search_tavily,
+                request.app.state.config.TAVILY_API_KEY,
+                query,
+                request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+                request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            )
+        else:
+            raise Exception('No TAVILY_API_KEY found in environment variables')
+    elif engine == 'exa':
+        if request.app.state.config.EXA_API_KEY:
+            return await asyncio.to_thread(
+                search_exa,
+                request.app.state.config.EXA_API_KEY,
+                query,
+                request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+                request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            )
+        else:
+            raise Exception('No EXA_API_KEY found in environment variables')
+    elif engine == 'searchapi':
+        if request.app.state.config.SEARCHAPI_API_KEY:
+            return await asyncio.to_thread(
+                search_searchapi,
+                request.app.state.config.SEARCHAPI_API_KEY,
+                request.app.state.config.SEARCHAPI_ENGINE,
+                query,
+                request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+                request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            )
+        else:
+            raise Exception('No SEARCHAPI_API_KEY found in environment variables')
+    elif engine == 'serpapi':
+        if request.app.state.config.SERPAPI_API_KEY:
+            return await asyncio.to_thread(
+                search_serpapi,
+                request.app.state.config.SERPAPI_API_KEY,
+                request.app.state.config.SERPAPI_ENGINE,
+                query,
+                request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+                request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            )
+        else:
+            raise Exception('No SERPAPI_API_KEY found in environment variables')
+    elif engine == 'jina':
+        return await asyncio.to_thread(
+            search_jina,
+            request.app.state.config.JINA_API_KEY,
+            query,
+            request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+            request.app.state.config.JINA_API_BASE_URL,
+        )
+    elif engine == 'bing':
+        return await asyncio.to_thread(
+            search_bing,
+            request.app.state.config.BING_SEARCH_V7_SUBSCRIPTION_KEY,
+            request.app.state.config.BING_SEARCH_V7_ENDPOINT,
+            str(DEFAULT_LOCALE),
+            query,
+            request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+            request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+        )
+    elif engine == 'azure':
+        if (
+            request.app.state.config.AZURE_AI_SEARCH_API_KEY
+            and request.app.state.config.AZURE_AI_SEARCH_ENDPOINT
+            and request.app.state.config.AZURE_AI_SEARCH_INDEX_NAME
+        ):
+            return await asyncio.to_thread(
+                search_azure,
+                request.app.state.config.AZURE_AI_SEARCH_API_KEY,
+                request.app.state.config.AZURE_AI_SEARCH_ENDPOINT,
+                request.app.state.config.AZURE_AI_SEARCH_INDEX_NAME,
+                query,
+                request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+                request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            )
+        else:
+            raise Exception(
+                'AZURE_AI_SEARCH_API_KEY, AZURE_AI_SEARCH_ENDPOINT, and AZURE_AI_SEARCH_INDEX_NAME are required for Azure AI Search'
+            )
+    elif engine == 'perplexity':
+        return await asyncio.to_thread(
+            search_perplexity,
+            request.app.state.config.PERPLEXITY_API_KEY,
+            query,
+            request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+            request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            model=request.app.state.config.PERPLEXITY_MODEL,
+            search_context_usage=request.app.state.config.PERPLEXITY_SEARCH_CONTEXT_USAGE,
+        )
+    elif engine == 'sougou':
+        if request.app.state.config.SOUGOU_API_SID and request.app.state.config.SOUGOU_API_SK:
+            return await asyncio.to_thread(
+                search_sougou,
+                request.app.state.config.SOUGOU_API_SID,
+                request.app.state.config.SOUGOU_API_SK,
+                query,
+                request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+                request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            )
+        else:
+            raise Exception('No SOUGOU_API_SID or SOUGOU_API_SK found in environment variables')
+    elif engine == 'firecrawl':
+        return await asyncio.to_thread(
+            search_firecrawl,
+            request.app.state.config.FIRECRAWL_API_BASE_URL,
+            request.app.state.config.FIRECRAWL_API_KEY,
+            query,
+            request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+            request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+        )
+    elif engine == 'external':
+        return await asyncio.to_thread(
+            search_external,
+            request,
+            request.app.state.config.EXTERNAL_WEB_SEARCH_URL,
+            request.app.state.config.EXTERNAL_WEB_SEARCH_API_KEY,
+            query,
+            request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+            request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            user=user,
+        )
+    elif engine == 'yandex':
+        return await asyncio.to_thread(
+            search_yandex,
+            request,
+            request.app.state.config.YANDEX_WEB_SEARCH_URL,
+            request.app.state.config.YANDEX_WEB_SEARCH_API_KEY,
+            request.app.state.config.YANDEX_WEB_SEARCH_CONFIG,
+            query,
+            request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+            request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            user=user,
+        )
+    elif engine == 'youcom':
+        return await asyncio.to_thread(
+            search_youcom,
+            request.app.state.config.YOUCOM_API_KEY,
+            query,
+            request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+            request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+        )
+    elif engine == 'linkup':
+        if request.app.state.config.LINKUP_API_KEY:
+            return await asyncio.to_thread(
+                search_linkup,
+                api_key=request.app.state.config.LINKUP_API_KEY,
+                query=query,
+                count=request.app.state.config.WEB_SEARCH_RESULT_COUNT,
+                filter_list=request.app.state.config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+                params=request.app.state.config.LINKUP_SEARCH_PARAMS,
+            )
+        else:
+            raise Exception('No LINKUP_API_KEY found in environment variables')
+    else:
+        raise Exception('No search engine API key found in environment variables')
+
+
+@router.post('/process/web/search')
+async def process_web_search(request: Request, form_data: SearchForm, user=Depends(get_verified_user)):
+    if not request.app.state.config.ENABLE_WEB_SEARCH:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
+    if user.role != 'admin' and not await has_permission(
+        user.id, 'features.web_search', request.app.state.config.USER_PERMISSIONS
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
+    urls = []
+    result_items = []
+
+    try:
+        logging.debug(f'trying to web search with {request.app.state.config.WEB_SEARCH_ENGINE, form_data.queries}')
+
+        # Use semaphore to limit concurrent requests based on WEB_SEARCH_CONCURRENT_REQUESTS
+        # 0 or None = unlimited (previous behavior), positive number = limited concurrency
+        # Set to 1 for sequential execution (rate-limited APIs like Brave free tier)
+        concurrent_limit = request.app.state.config.WEB_SEARCH_CONCURRENT_REQUESTS
+
+        if concurrent_limit:
+            # Limited concurrency with semaphore
+            semaphore = asyncio.Semaphore(concurrent_limit)
+
+            async def search_query_with_semaphore(query):
+                async with semaphore:
+                    return await search_web(
+                        request,
+                        request.app.state.config.WEB_SEARCH_ENGINE,
+                        query,
+                        user,
+                    )
+
+            search_tasks = [search_query_with_semaphore(query) for query in form_data.queries]
+        else:
+            # Unlimited parallel execution
+            search_tasks = [
+                search_web(
+                    request,
+                    request.app.state.config.WEB_SEARCH_ENGINE,
+                    query,
+                    user,
+                )
+                for query in form_data.queries
+            ]
+
+        search_results = await asyncio.gather(*search_tasks)
+
+        for result in search_results:
+            if result:
+                for item in result:
+                    if item and item.link:
+                        result_items.append(item)
+                        urls.append(item.link)
+
+        urls = list(dict.fromkeys(urls))
+        log.debug(f'urls: {urls}')
+
+    except Exception as e:
+        log.exception('Web search failed')
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=ERROR_MESSAGES.WEB_SEARCH_ERROR(e))
+
+    if len(urls) == 0:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.DEFAULT('No results found from web search'),
+        )
+
+    try:
+        if request.app.state.config.BYPASS_WEB_SEARCH_WEB_LOADER:
+            search_results = [item for result in search_results for item in result if result]
+
+            docs = [
+                Document(
+                    page_content=result.snippet,
+                    metadata={
+                        'source': result.link,
+                        'title': result.title,
+                        'snippet': result.snippet,
+                        'link': result.link,
+                    },
+                )
+                for result in search_results
+                if hasattr(result, 'snippet') and result.snippet is not None
+            ]
+        else:
+            loader = get_web_loader(
+                urls,
+                verify_ssl=request.app.state.config.ENABLE_WEB_LOADER_SSL_VERIFICATION,
+                requests_per_second=request.app.state.config.WEB_LOADER_CONCURRENT_REQUESTS,
+                trust_env=request.app.state.config.WEB_SEARCH_TRUST_ENV,
+            )
+            docs = await loader.aload()
+
+        urls = [
+            doc.metadata.get('source') for doc in docs if doc.metadata.get('source')
+        ]  # only keep the urls returned by the loader
+        result_items = [
+            dict(item) for item in result_items if item.link in urls
+        ]  # only keep the search results that have been loaded
+
+        if request.app.state.config.BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL:
+            return {
+                'status': True,
+                'collection_name': None,
+                'filenames': urls,
+                'items': result_items,
+                'docs': [
+                    {
+                        'content': doc.page_content,
+                        'metadata': doc.metadata,
+                    }
+                    for doc in docs
+                ],
+                'loaded_count': len(docs),
+            }
+        else:
+            # Create a single collection for all documents
+            collection_name = f'web-search-{calculate_sha256_string("-".join(form_data.queries))}'[:63]
+
+            try:
+                await run_in_threadpool(
+                    save_docs_to_vector_db,
+                    request,
+                    docs,
+                    collection_name,
+                    overwrite=True,
+                    user=user,
+                )
+            except Exception as e:
+                log.debug(f'error saving docs: {e}')
+
+            return {
+                'status': True,
+                'collection_names': [collection_name],
+                'items': result_items,
+                'filenames': urls,
+                'loaded_count': len(docs),
+            }
+    except Exception as e:
+        log.exception('Web search content loading failed')
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=ERROR_MESSAGES.DEFAULT(e))
+
+
+async def _validate_collection_access(collection_names: list[str], user, access_type: str = 'read') -> None:
+    """
+    Raise 403 if the user lacks access to any of the requested collections.
+    Delegates to the shared filter_accessible_collections utility so the
+    access rules stay in one place.
+    """
+    requested = set(collection_names)
+    allowed = await filter_accessible_collections(requested, user, access_type=access_type)
+    denied = requested - allowed
+    if denied:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
+
+class QueryDocForm(BaseModel):
+    collection_name: str
+    query: str
+    k: int | None = None
+    k_reranker: int | None = None
+    r: float | None = None
+    hybrid: bool | None = None
+
+
+@router.post('/query/doc')
+async def query_doc_handler(
+    request: Request,
+    form_data: QueryDocForm,
+    user=Depends(get_verified_user),
+):
+    await _validate_collection_access([form_data.collection_name], user)
+
+    try:
+        if request.app.state.config.ENABLE_RAG_HYBRID_SEARCH and (form_data.hybrid is None or form_data.hybrid):
+            collection_results = {}
+            collection_results[form_data.collection_name] = await ASYNC_VECTOR_DB_CLIENT.get(
+                collection_name=form_data.collection_name
+            )
+            return await query_doc_with_hybrid_search(
+                collection_name=form_data.collection_name,
+                collection_result=collection_results[form_data.collection_name],
+                query=form_data.query,
+                embedding_function=lambda query, prefix: request.app.state.EMBEDDING_FUNCTION(
+                    query, prefix=prefix, user=user
+                ),
+                k=form_data.k if form_data.k else request.app.state.config.TOP_K,
+                reranking_function=(
+                    (lambda query, documents: request.app.state.RERANKING_FUNCTION(query, documents, user=user))
+                    if request.app.state.RERANKING_FUNCTION
+                    else None
+                ),
+                k_reranker=form_data.k_reranker or request.app.state.config.TOP_K_RERANKER,
+                r=(form_data.r if form_data.r else request.app.state.config.RELEVANCE_THRESHOLD),
+                hybrid_bm25_weight=(
+                    form_data.hybrid_bm25_weight
+                    if form_data.hybrid_bm25_weight
+                    else request.app.state.config.HYBRID_BM25_WEIGHT
+                ),
+                user=user,
+            )
+        else:
+            query_embedding = await request.app.state.EMBEDDING_FUNCTION(
+                form_data.query, prefix=RAG_EMBEDDING_QUERY_PREFIX, user=user
+            )
+            # query_doc wraps a blocking VECTOR_DB_CLIENT.search call;
+            # offload so the request's event loop stays responsive.
+            return await asyncio.to_thread(
+                query_doc,
+                collection_name=form_data.collection_name,
+                query_embedding=query_embedding,
+                k=form_data.k if form_data.k else request.app.state.config.TOP_K,
+                user=user,
+            )
+    except Exception as e:
+        log.exception(e)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.DEFAULT(e),
+        )
+
+
+class QueryCollectionsForm(BaseModel):
+    collection_names: list[str]
+    query: str
+    k: int | None = None
+    k_reranker: int | None = None
+    r: float | None = None
+    hybrid: bool | None = None
+    hybrid_bm25_weight: float | None = None
+    enable_enriched_texts: bool | None = None
+
+
+@router.post('/query/collection')
+async def query_collection_handler(
+    request: Request,
+    form_data: QueryCollectionsForm,
+    user=Depends(get_verified_user),
+):
+    await _validate_collection_access(form_data.collection_names, user)
+
+    try:
+        if request.app.state.config.ENABLE_RAG_HYBRID_SEARCH and (form_data.hybrid is None or form_data.hybrid):
+            return await query_collection_with_hybrid_search(
+                collection_names=form_data.collection_names,
+                queries=[form_data.query],
+                embedding_function=lambda query, prefix: request.app.state.EMBEDDING_FUNCTION(
+                    query, prefix=prefix, user=user
+                ),
+                k=form_data.k if form_data.k else request.app.state.config.TOP_K,
+                reranking_function=(
+                    (lambda query, documents: request.app.state.RERANKING_FUNCTION(query, documents, user=user))
+                    if request.app.state.RERANKING_FUNCTION
+                    else None
+                ),
+                k_reranker=form_data.k_reranker or request.app.state.config.TOP_K_RERANKER,
+                r=(form_data.r if form_data.r else request.app.state.config.RELEVANCE_THRESHOLD),
+                hybrid_bm25_weight=(
+                    form_data.hybrid_bm25_weight
+                    if form_data.hybrid_bm25_weight
+                    else request.app.state.config.HYBRID_BM25_WEIGHT
+                ),
+                enable_enriched_texts=(
+                    form_data.enable_enriched_texts
+                    if form_data.enable_enriched_texts is not None
+                    else request.app.state.config.ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS
+                ),
+            )
+        else:
+            return await query_collection(
+                request,
+                collection_names=form_data.collection_names,
+                queries=[form_data.query],
+                embedding_function=lambda query, prefix: request.app.state.EMBEDDING_FUNCTION(
+                    query, prefix=prefix, user=user
+                ),
+                k=form_data.k if form_data.k else request.app.state.config.TOP_K,
+            )
+
+    except Exception as e:
+        log.exception(e)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.DEFAULT(e),
+        )
+
+
+####################################
+#
+# Vector DB operations
+#
+####################################
+
+
+class DeleteForm(BaseModel):
+    collection_name: str
+    file_id: str
+
+
+@router.post('/delete')
+async def delete_entries_from_collection(
+    form_data: DeleteForm,
+    user=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    try:
+        if await ASYNC_VECTOR_DB_CLIENT.has_collection(collection_name=form_data.collection_name):
+            file = await Files.get_file_by_id(form_data.file_id, db=db)
+            if not file:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=ERROR_MESSAGES.NOT_FOUND,
+                )
+            hash = file.hash
+
+            # Refuse to issue a `filter={'hash': None}` query — the
+            # match semantics of a null filter value are
+            # backend-dependent (some backends ignore the key, some
+            # match every row whose metadata lacks `hash`) and risk
+            # deleting unrelated entries. Files without a hash are
+            # typically unprocessed / failed / legacy records that
+            # can't be targeted by hash anyway.
+            if hash is None:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=ERROR_MESSAGES.DEFAULT('File has no hash; cannot delete vector entries by hash.'),
+                )
+
+            # Pre-existing bug: this used `metadata=` which is not a
+            # parameter on `VectorDBBase.delete` nor on any backend
+            # implementation, so the call always raised TypeError that
+            # was silently swallowed by the surrounding `except
+            # Exception` and the endpoint reported `{'status': False}`
+            # for every request. Use `filter` to actually do what the
+            # endpoint name promises.
+            await ASYNC_VECTOR_DB_CLIENT.delete(
+                collection_name=form_data.collection_name,
+                filter={'hash': hash},
+            )
+            return {'status': True}
+        else:
+            return {'status': False}
+    except HTTPException:
+        # Caller-meaningful errors (404/400 above) must not be
+        # swallowed and re-shaped as `{'status': False}`.
+        raise
+    except Exception as e:
+        log.exception(e)
+        return {'status': False}
+
+
+@router.post('/reset/db')
+async def reset_vector_db(user=Depends(get_admin_user), db: AsyncSession = Depends(get_async_session)):
+    await ASYNC_VECTOR_DB_CLIENT.reset()
+    await Knowledges.delete_all_knowledge(db=db)
+
+
+@router.post('/reset/uploads')
+async def reset_upload_dir(user=Depends(get_admin_user)) -> bool:
+    folder = f'{UPLOAD_DIR}'
+    try:
+        # Check if the directory exists
+        if os.path.exists(folder):
+            # Iterate over all the files and directories in the specified directory
+            for filename in os.listdir(folder):
+                file_path = os.path.join(folder, filename)
+                try:
+                    if os.path.isfile(file_path) or os.path.islink(file_path):
+                        os.unlink(file_path)  # Remove the file or link
+                    elif os.path.isdir(file_path):
+                        shutil.rmtree(file_path)  # Remove the directory
+                except Exception as e:
+                    log.exception(f'Failed to delete {file_path}. Reason: {e}')
+        else:
+            log.warning(f'The directory {folder} does not exist')
+    except Exception as e:
+        log.exception(f'Failed to process the directory {folder}. Reason: {e}')
+    return True
+
+
+if ENV == 'dev':
+
+    @router.get('/ef/{text}')
+    async def get_embeddings(request: Request, text: str | None = 'Hello World!'):
+        return {'result': await request.app.state.EMBEDDING_FUNCTION(text, prefix=RAG_EMBEDDING_QUERY_PREFIX)}
+
+
+class BatchProcessFilesForm(BaseModel):
+    files: list[FileModel]
+    collection_name: str
+
+
+class BatchProcessFilesResult(BaseModel):
+    file_id: str
+    status: str
+    error: str | None = None
+
+
+class BatchProcessFilesResponse(BaseModel):
+    results: list[BatchProcessFilesResult]
+    errors: list[BatchProcessFilesResult]
+
+
+@router.post('/process/files/batch')
+async def process_files_batch(
+    request: Request,
+    form_data: BatchProcessFilesForm,
+    user=Depends(get_verified_user),
+    db=None,
+) -> BatchProcessFilesResponse:
+    """
+    Process a batch of files and save them to the vector database.
+
+    NOTE: We intentionally do NOT use Depends(get_async_session) here.
+    The save_docs_to_vector_db() call makes external embedding API calls which
+    can take 5-60+ seconds for batch operations. Database operations after
+    embedding (Files.update_file_by_id) manage their own short-lived sessions.
+    """
+
+    collection_name = form_data.collection_name
+
+    if collection_name:
+        await _validate_collection_access([collection_name], user, access_type='write')
+
+    file_results: list[BatchProcessFilesResult] = []
+    file_errors: list[BatchProcessFilesResult] = []
+    file_updates: list[FileUpdateForm] = []
+
+    # Prepare all documents first
+    all_docs: list[Document] = []
+
+    for file in form_data.files:
+        try:
+            # Ownership check: verify the requesting user owns the file or is an admin
+            db_file = await Files.get_file_by_id(file.id, db=db)
+            if not db_file:
+                file_errors.append(
+                    BatchProcessFilesResult(
+                        file_id=file.id,
+                        status='failed',
+                        error='File not found',
+                    )
+                )
+                continue
+            if db_file.user_id != user.id and user.role != 'admin':
+                file_errors.append(
+                    BatchProcessFilesResult(
+                        file_id=file.id,
+                        status='failed',
+                        error='Permission denied: not file owner',
+                    )
+                )
+                continue
+
+            text_content = file.data.get('content', '')
+            docs: list[Document] = [
+                Document(
+                    page_content=text_content.replace('<br/>', '\n'),
+                    metadata={
+                        **file.meta,
+                        'name': file.filename,
+                        'created_by': file.user_id,
+                        'file_id': file.id,
+                        'source': file.filename,
+                    },
+                )
+            ]
+
+            all_docs.extend(docs)
+
+            file_updates.append(
+                FileUpdateForm(
+                    hash=calculate_sha256_string(text_content),
+                    data={'content': text_content},
+                )
+            )
+            file_results.append(BatchProcessFilesResult(file_id=file.id, status='prepared'))
+
+        except Exception as e:
+            log.error(f'process_files_batch: Error processing file {file.id}: {str(e)}')
+            file_errors.append(BatchProcessFilesResult(file_id=file.id, status='failed', error=str(e)))
+
+    # Save all documents in one batch
+    if all_docs:
+        try:
+            await run_in_threadpool(
+                save_docs_to_vector_db,
+                request,
+                all_docs,
+                collection_name,
+                add=True,
+                user=user,
+            )
+
+            # Update all files with collection name
+            for file_update, file_result in zip(file_updates, file_results):
+                await Files.update_file_by_id(id=file_result.file_id, form_data=file_update, db=db)
+                file_result.status = 'completed'
+
+        except Exception as e:
+            log.error(f'process_files_batch: Error saving documents to vector DB: {str(e)}')
+            for file_result in file_results:
+                file_result.status = 'failed'
+                file_errors.append(BatchProcessFilesResult(file_id=file_result.file_id, status='failed', error=str(e)))
+
+    return BatchProcessFilesResponse(results=file_results, errors=file_errors)

--- a/tests/patches/test_fix_attached_files_position.py
+++ b/tests/patches/test_fix_attached_files_position.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BUSL-1.1
 # Copyright (c) 2025 Open Computer Use Contributors
-"""Tests for fix_attached_files_position.py against v0.9.1 middleware.py."""
+"""Tests for fix_attached_files_position.py — anchor is stable across v0.9.1–v0.9.6."""
 import ast
 import os
 import shutil
@@ -13,7 +13,11 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PATCH_DIR = REPO_ROOT / "openwebui" / "patches"
 sys.path.insert(0, str(Path(__file__).parent))
-from conftest import load_middleware_v091, load_middleware_v092  # noqa: E402
+from conftest import (  # noqa: E402
+    load_middleware_v091,
+    load_middleware_v092,
+    load_middleware_v096,
+)
 
 
 def _run_patch(patch_name: str, target_file: Path) -> subprocess.CompletedProcess:
@@ -103,6 +107,52 @@ class TestFixAttachedFilesPositionV092(unittest.TestCase):
         self.assertEqual(after_first, self.target.read_text())
 
     def test_broken_fixture_fails_loud_v092(self):
+        content = self.target.read_text()
+        self.assertIn(self.PRIMARY_ANCHOR, content)
+        self.target.write_text(
+            content.replace(self.PRIMARY_ANCHOR, "            # ANCHOR_REMOVED_FOR_TEST")
+        )
+        r = _run_patch(self.PATCH_NAME, self.target)
+        self.assertEqual(r.returncode, 1, f"stdout={r.stdout} stderr={r.stderr}")
+        self.assertIn("ERROR:", r.stderr)
+        self.assertIn(self.PATCH_NAME, r.stderr)
+
+
+class TestFixAttachedFilesPositionV096(unittest.TestCase):
+    """3-state coverage against real v0.9.6 middleware.py fixture (build base)."""
+
+    PATCH_NAME = "fix_attached_files_position"
+    NEW_MARKER = "FIX_ATTACHED_FILES_POSITION"
+    PRIMARY_ANCHOR = (
+        "            message['content'] = [{'type': 'text', 'text': file_context}] + content"
+    )
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.target = Path(self.tmp) / "middleware.py"
+        self.target.write_text(load_middleware_v096(), encoding="utf-8")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_fresh_apply_v096(self):
+        r = _run_patch(self.PATCH_NAME, self.target)
+        self.assertEqual(r.returncode, 0, f"stderr={r.stderr}")
+        self.assertIn(f"PATCHED: {self.PATCH_NAME}", r.stdout)
+        content = self.target.read_text()
+        self.assertIn(self.NEW_MARKER, content)
+        ast.parse(content)
+
+    def test_idempotent_rerun_v096(self):
+        r1 = _run_patch(self.PATCH_NAME, self.target)
+        self.assertEqual(r1.returncode, 0)
+        after_first = self.target.read_text()
+        r2 = _run_patch(self.PATCH_NAME, self.target)
+        self.assertEqual(r2.returncode, 0)
+        self.assertIn("ALREADY PATCHED", r2.stdout)
+        self.assertEqual(after_first, self.target.read_text())
+
+    def test_broken_fixture_fails_loud_v096(self):
         content = self.target.read_text()
         self.assertIn(self.PRIMARY_ANCHOR, content)
         self.target.write_text(

--- a/tests/patches/test_fix_large_tool_args.py
+++ b/tests/patches/test_fix_large_tool_args.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BUSL-1.1
 # Copyright (c) 2025 Open Computer Use Contributors
-"""Tests for fix_large_tool_args.py against v0.9.1 middleware.py.
+"""Tests for fix_large_tool_args.py — anchor is stable across v0.9.1–v0.9.6.
 
 3-state coverage: fresh apply / idempotent re-run / broken fixture fails loud.
 Plus: count-assertion trigger test (3 occurrences -> hard fail).
@@ -17,7 +17,11 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PATCH_DIR = REPO_ROOT / "openwebui" / "patches"
 sys.path.insert(0, str(Path(__file__).parent))
-from conftest import load_middleware_v091, load_middleware_v092  # noqa: E402
+from conftest import (  # noqa: E402
+    load_middleware_v091,
+    load_middleware_v092,
+    load_middleware_v096,
+)
 
 
 def _run_patch(patch_name: str, target_file: Path) -> subprocess.CompletedProcess:
@@ -116,6 +120,49 @@ class TestFixLargeToolArgsV092(unittest.TestCase):
         self.assertEqual(after_first, self.target.read_text())
 
     def test_broken_fixture_fails_loud_v092(self):
+        content = self.target.read_text()
+        self.assertEqual(content.count(self.OLD_ARGS), 2)
+        self.target.write_text(content.replace(self.OLD_ARGS, 'arguments="REMOVED"', 1))
+        r = _run_patch(self.PATCH_NAME, self.target)
+        self.assertEqual(r.returncode, 1, f"stdout={r.stdout} stderr={r.stderr}")
+        self.assertIn("ERROR:", r.stderr)
+        self.assertIn("expected 2 occurrences", r.stderr)
+        self.assertIn("found 1", r.stderr)
+
+
+class TestFixLargeToolArgsV096(unittest.TestCase):
+    """3-state coverage against real v0.9.6 middleware.py fixture (build base)."""
+
+    PATCH_NAME = "fix_large_tool_args"
+    NEW_MARKER = "FIX_LARGE_TOOL_ARGS"
+    OLD_ARGS = 'arguments="{html.escape(json.dumps(arguments))}"'
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.target = Path(self.tmp) / "middleware.py"
+        self.target.write_text(load_middleware_v096(), encoding="utf-8")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_fresh_apply_v096(self):
+        r = _run_patch(self.PATCH_NAME, self.target)
+        self.assertEqual(r.returncode, 0, f"stderr={r.stderr}")
+        self.assertIn(f"PATCHED: {self.PATCH_NAME}", r.stdout)
+        content = self.target.read_text()
+        self.assertIn(self.NEW_MARKER, content)
+        ast.parse(content)
+
+    def test_idempotent_rerun_v096(self):
+        r1 = _run_patch(self.PATCH_NAME, self.target)
+        self.assertEqual(r1.returncode, 0)
+        after_first = self.target.read_text()
+        r2 = _run_patch(self.PATCH_NAME, self.target)
+        self.assertEqual(r2.returncode, 0)
+        self.assertIn("ALREADY PATCHED", r2.stdout)
+        self.assertEqual(after_first, self.target.read_text())
+
+    def test_broken_fixture_fails_loud_v096(self):
         content = self.target.read_text()
         self.assertEqual(content.count(self.OLD_ARGS), 2)
         self.target.write_text(content.replace(self.OLD_ARGS, 'arguments="REMOVED"', 1))

--- a/tests/patches/test_fix_large_tool_results.py
+++ b/tests/patches/test_fix_large_tool_results.py
@@ -34,33 +34,41 @@ class TestPatchApplication(unittest.TestCase):
     def _base_middleware(self) -> str:
         """Return minimal synthetic middleware content satisfying all 3 anchors.
 
-        Must include:
+        Mirrors the v0.9.5+ upstream shape the patch's SEARCH literals target:
         - `from open_webui.models.chats import Chats` (Mod 1 import marker)
         - SEARCH_TOOL_LOOP literal (TOOL_LOOP_ERRORS_UNIFIED save-for-restore marker
           + `\n                    try:\n                        new_form_data = {\n`)
-        - SEARCH_HISTORY literal (process_messages_with_output + blank + get_system_message)
+        - SEARCH_HISTORY literal (multi-line process_messages_with_output with
+          reasoning_format= kwarg, blank line, then get_system_message)
         """
         return (
             "import json\n"
             "from open_webui.models.chats import Chats\n"
             "\n"
-            "def process_messages_with_output(messages):\n"
+            "def process_messages_with_output(messages, reasoning_format=None):\n"
             "    return messages\n"
             "\n"
             "def get_system_message(messages):\n"
             "    return None\n"
             "\n"
+            "def get_reasoning_format(model):\n"
+            "    return None\n"
+            "\n"
             "async def middleware():\n"
             "    form_data = {'messages': []}\n"
             "    metadata = {'chat_id': 'test-123'}\n"
-            "    form_data['messages'] = process_messages_with_output(form_data.get('messages', []))\n"
+            "    model = {}\n"
+            "    form_data['messages'] = process_messages_with_output(\n"
+            "        form_data.get('messages', []),\n"
+            "        reasoning_format=get_reasoning_format(model),\n"
+            "    )\n"
             "\n"
             "    system_message = get_system_message(form_data.get('messages', []))\n"
             "\n"
             "    output = []\n"
-            "    tool_call_retries = 0\n"
-            "    while tool_call_retries < 5:\n"
-            "        tool_call_retries += 1\n"
+            "    tool_call_iterations = 0\n"
+            "    while tool_call_iterations < 5:\n"
+            "        tool_call_iterations += 1\n"
             "                    _saved_output = json.loads(json.dumps(output))  # TOOL_LOOP_ERRORS_UNIFIED: save for restore on error\n"
             "                    try:\n"
             "                        new_form_data = {\n"
@@ -366,7 +374,7 @@ class TestHistoryTruncation(unittest.TestCase):
 
 
 #
-# v0.9.1 integration tests — real upstream fixture via subprocess
+# v0.9.6 integration tests — real upstream fixture via subprocess
 #
 import ast
 import shutil
@@ -376,7 +384,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PATCH_DIR = REPO_ROOT / "openwebui" / "patches"
 sys.path.insert(0, str(Path(__file__).parent))
-from conftest import load_middleware_v091, load_middleware_v092  # noqa: E402
+from conftest import load_middleware_v096  # noqa: E402
 
 
 def _run_patch(patch_name: str, target_file: Path) -> subprocess.CompletedProcess:
@@ -387,27 +395,25 @@ def _run_patch(patch_name: str, target_file: Path) -> subprocess.CompletedProces
     )
 
 
-class TestFixLargeToolResultsV091(unittest.TestCase):
-    """3-state coverage + cascade tests against real v0.9.1 middleware."""
+class TestFixLargeToolResultsV096(unittest.TestCase):
+    """3-state coverage + cascade tests against real v0.9.6 middleware.py fixture."""
 
     PATCH_NAME = "fix_large_tool_results"
     NEW_MARKER = "FIX_LARGE_TOOL_RESULTS"
-    # Mod 3 anchor — removing this leaves Patch 3's marker intact so Mod 2 still
-    # succeeds after patch 3; Mod 3 is the one that fails loud.
-    PRIMARY_ANCHOR = (
-        "    form_data['messages'] = process_messages_with_output"
-        "(form_data.get('messages', []))"
-    )
+    # Mod 3 anchor (SEARCH_HISTORY) — first line of the multi-line
+    # process_messages_with_output call. Removing it leaves Patch 3's marker
+    # intact so Mod 2 still succeeds after patch 3; Mod 3 is the one that fails loud.
+    PRIMARY_ANCHOR = "    form_data['messages'] = process_messages_with_output("
 
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
         self.target = Path(self.tmp) / "middleware.py"
-        self.target.write_text(load_middleware_v091(), encoding="utf-8")
+        self.target.write_text(load_middleware_v096(), encoding="utf-8")
 
     def tearDown(self):
         shutil.rmtree(self.tmp, ignore_errors=True)
 
-    def test_fresh_apply(self):
+    def test_fresh_apply_v096(self):
         # Cascade dependency: fix_tool_loop_errors must run first
         r1 = _run_patch("fix_tool_loop_errors", self.target)
         self.assertEqual(r1.returncode, 0, f"patch3 stderr={r1.stderr}")
@@ -418,7 +424,7 @@ class TestFixLargeToolResultsV091(unittest.TestCase):
         self.assertIn(self.NEW_MARKER, content)
         ast.parse(content)
 
-    def test_idempotent_rerun(self):
+    def test_idempotent_rerun_v096(self):
         _run_patch("fix_tool_loop_errors", self.target)
         r1 = _run_patch(self.PATCH_NAME, self.target)
         self.assertEqual(r1.returncode, 0)
@@ -428,7 +434,7 @@ class TestFixLargeToolResultsV091(unittest.TestCase):
         self.assertIn("ALREADY PATCHED", r2.stdout)
         self.assertEqual(after_first, self.target.read_text())
 
-    def test_broken_fixture_fails_loud(self):
+    def test_broken_fixture_fails_loud_v096(self):
         # Apply patch 3 first (so Mod 2 anchor is present), then remove Mod 3 anchor
         _run_patch("fix_tool_loop_errors", self.target)
         content = self.target.read_text()
@@ -441,7 +447,7 @@ class TestFixLargeToolResultsV091(unittest.TestCase):
         self.assertIn("ERROR:", r.stderr)
         self.assertIn(self.PATCH_NAME, r.stderr)
 
-    def test_cascade_with_patch_3(self):
+    def test_cascade_with_patch_3_on_v096(self):
         r1 = _run_patch("fix_tool_loop_errors", self.target)
         self.assertEqual(r1.returncode, 0, r1.stderr)
         r2 = _run_patch("fix_large_tool_results", self.target)
@@ -449,82 +455,15 @@ class TestFixLargeToolResultsV091(unittest.TestCase):
         content = self.target.read_text()
         self.assertIn("FIX_TOOL_LOOP_ERRORS", content)
         self.assertIn("FIX_LARGE_TOOL_RESULTS", content)
-        # V091_SHIM injects 'metadata': metadata, before SEARCH_TOOL_LOOP runs,
-        # so the post-cascade content must carry the key (mirrors v0.9.2 assertion).
         self.assertIn("'metadata': metadata,", content)
         ast.parse(content)
 
     def test_patch_4_fails_loud_without_patch_3(self):
-        # Patch 4 direct on raw v0.9.1 — Mod 2 anchor (TOOL_LOOP_ERRORS_UNIFIED marker) missing
+        # Patch 4 direct on raw v0.9.6 — Mod 2 anchor (TOOL_LOOP_ERRORS_UNIFIED marker) missing
         r = _run_patch("fix_large_tool_results", self.target)
         self.assertEqual(r.returncode, 1, f"stdout={r.stdout} stderr={r.stderr}")
         # Error message points at running fix_tool_loop_errors first
         self.assertIn("fix_tool_loop_errors", r.stderr.lower())
-
-
-class TestFixLargeToolResultsV092(unittest.TestCase):
-    """3-state coverage + cascade tests against real v0.9.2 middleware.py fixture."""
-
-    PATCH_NAME = "fix_large_tool_results"
-    NEW_MARKER = "FIX_LARGE_TOOL_RESULTS"
-    PRIMARY_ANCHOR = (
-        "    form_data['messages'] = process_messages_with_output"
-        "(form_data.get('messages', []))"
-    )
-
-    def setUp(self):
-        self.tmp = tempfile.mkdtemp()
-        self.target = Path(self.tmp) / "middleware.py"
-        self.target.write_text(load_middleware_v092(), encoding="utf-8")
-
-    def tearDown(self):
-        shutil.rmtree(self.tmp, ignore_errors=True)
-
-    def test_fresh_apply_v092(self):
-        # Cascade dependency: fix_tool_loop_errors must run first
-        r1 = _run_patch("fix_tool_loop_errors", self.target)
-        self.assertEqual(r1.returncode, 0, f"patch3 stderr={r1.stderr}")
-        r = _run_patch(self.PATCH_NAME, self.target)
-        self.assertEqual(r.returncode, 0, f"stderr={r.stderr}")
-        self.assertIn(f"PATCHED: {self.PATCH_NAME}", r.stdout)
-        content = self.target.read_text()
-        self.assertIn(self.NEW_MARKER, content)
-        # v0.9.2 specific: post-patch3 content must carry the new metadata key
-        self.assertIn("'metadata': metadata,", content)
-        ast.parse(content)
-
-    def test_idempotent_rerun_v092(self):
-        _run_patch("fix_tool_loop_errors", self.target)
-        r1 = _run_patch(self.PATCH_NAME, self.target)
-        self.assertEqual(r1.returncode, 0)
-        after_first = self.target.read_text()
-        r2 = _run_patch(self.PATCH_NAME, self.target)
-        self.assertEqual(r2.returncode, 0)
-        self.assertIn("ALREADY PATCHED", r2.stdout)
-        self.assertEqual(after_first, self.target.read_text())
-
-    def test_broken_fixture_fails_loud_v092(self):
-        _run_patch("fix_tool_loop_errors", self.target)
-        content = self.target.read_text()
-        self.assertIn(self.PRIMARY_ANCHOR, content)
-        self.target.write_text(
-            content.replace(self.PRIMARY_ANCHOR, "    # ANCHOR_REMOVED_FOR_TEST")
-        )
-        r = _run_patch(self.PATCH_NAME, self.target)
-        self.assertEqual(r.returncode, 1, f"stdout={r.stdout} stderr={r.stderr}")
-        self.assertIn("ERROR:", r.stderr)
-        self.assertIn(self.PATCH_NAME, r.stderr)
-
-    def test_cascade_with_patch_3_on_v092(self):
-        r1 = _run_patch("fix_tool_loop_errors", self.target)
-        self.assertEqual(r1.returncode, 0, r1.stderr)
-        r2 = _run_patch("fix_large_tool_results", self.target)
-        self.assertEqual(r2.returncode, 0, r2.stderr)
-        content = self.target.read_text()
-        self.assertIn("FIX_TOOL_LOOP_ERRORS", content)
-        self.assertIn("FIX_LARGE_TOOL_RESULTS", content)
-        self.assertIn("'metadata': metadata,", content)
-        ast.parse(content)
 
 
 if __name__ == "__main__":

--- a/tests/patches/test_fix_skip_embedding_chat_files.py
+++ b/tests/patches/test_fix_skip_embedding_chat_files.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BUSL-1.1
 # Copyright (c) 2025 Open Computer Use Contributors
-"""Tests for fix_skip_embedding_chat_files.py against v0.9.1 and v0.9.2 retrieval.py fixtures."""
+"""Tests for fix_skip_embedding_chat_files.py against the v0.9.6 retrieval.py fixture."""
 import ast
 import os
 import shutil
@@ -13,7 +13,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PATCH_DIR = REPO_ROOT / "openwebui" / "patches"
 sys.path.insert(0, str(Path(__file__).parent))
-from conftest import load_retrieval_v091, load_retrieval_v092  # noqa: E402
+from conftest import load_retrieval_v096  # noqa: E402
 
 
 def _run_patch(patch_name: str, target_file: Path) -> subprocess.CompletedProcess:
@@ -24,7 +24,9 @@ def _run_patch(patch_name: str, target_file: Path) -> subprocess.CompletedProces
     )
 
 
-class TestFixSkipEmbeddingChatFiles(unittest.TestCase):
+class TestFixSkipEmbeddingChatFilesV096(unittest.TestCase):
+    """3-state coverage against real v0.9.6 retrieval.py fixture."""
+
     PATCH_NAME = "fix_skip_embedding_chat_files"
     NEW_MARKER = "FIX_SKIP_EMBEDDING_CHAT_FILES"
     PRIMARY_ANCHOR = "                collection_name = f'file-{file.id}'"
@@ -32,12 +34,12 @@ class TestFixSkipEmbeddingChatFiles(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
         self.target = Path(self.tmp) / "retrieval.py"
-        self.target.write_text(load_retrieval_v091(), encoding="utf-8")
+        self.target.write_text(load_retrieval_v096(), encoding="utf-8")
 
     def tearDown(self):
         shutil.rmtree(self.tmp, ignore_errors=True)
 
-    def test_fresh_apply(self):
+    def test_fresh_apply_v096(self):
         r = _run_patch(self.PATCH_NAME, self.target)
         self.assertEqual(r.returncode, 0, f"stderr={r.stderr}")
         self.assertIn(f"PATCHED: {self.PATCH_NAME}", r.stdout)
@@ -45,7 +47,7 @@ class TestFixSkipEmbeddingChatFiles(unittest.TestCase):
         self.assertIn(self.NEW_MARKER, content)
         ast.parse(content)
 
-    def test_idempotent_rerun(self):
+    def test_idempotent_rerun_v096(self):
         r1 = _run_patch(self.PATCH_NAME, self.target)
         self.assertEqual(r1.returncode, 0)
         after_first = self.target.read_text()
@@ -54,7 +56,7 @@ class TestFixSkipEmbeddingChatFiles(unittest.TestCase):
         self.assertIn("ALREADY PATCHED", r2.stdout)
         self.assertEqual(after_first, self.target.read_text())
 
-    def test_broken_fixture_fails_loud(self):
+    def test_broken_fixture_fails_loud_v096(self):
         content = self.target.read_text()
         self.assertIn(self.PRIMARY_ANCHOR, content)
         self.target.write_text(
@@ -65,51 +67,7 @@ class TestFixSkipEmbeddingChatFiles(unittest.TestCase):
         self.assertIn("ERROR:", r.stderr)
         self.assertIn(self.PATCH_NAME, r.stderr)
 
-
-class TestFixSkipEmbeddingChatFilesV092(unittest.TestCase):
-    """3-state coverage against real v0.9.2 retrieval.py fixture."""
-
-    PATCH_NAME = "fix_skip_embedding_chat_files"
-    NEW_MARKER = "FIX_SKIP_EMBEDDING_CHAT_FILES"
-    PRIMARY_ANCHOR = "                collection_name = f'file-{file.id}'"
-
-    def setUp(self):
-        self.tmp = tempfile.mkdtemp()
-        self.target = Path(self.tmp) / "retrieval.py"
-        self.target.write_text(load_retrieval_v092(), encoding="utf-8")
-
-    def tearDown(self):
-        shutil.rmtree(self.tmp, ignore_errors=True)
-
-    def test_fresh_apply_v092(self):
-        r = _run_patch(self.PATCH_NAME, self.target)
-        self.assertEqual(r.returncode, 0, f"stderr={r.stderr}")
-        self.assertIn(f"PATCHED: {self.PATCH_NAME}", r.stdout)
-        content = self.target.read_text()
-        self.assertIn(self.NEW_MARKER, content)
-        ast.parse(content)
-
-    def test_idempotent_rerun_v092(self):
-        r1 = _run_patch(self.PATCH_NAME, self.target)
-        self.assertEqual(r1.returncode, 0)
-        after_first = self.target.read_text()
-        r2 = _run_patch(self.PATCH_NAME, self.target)
-        self.assertEqual(r2.returncode, 0)
-        self.assertIn("ALREADY PATCHED", r2.stdout)
-        self.assertEqual(after_first, self.target.read_text())
-
-    def test_broken_fixture_fails_loud_v092(self):
-        content = self.target.read_text()
-        self.assertIn(self.PRIMARY_ANCHOR, content)
-        self.target.write_text(
-            content.replace(self.PRIMARY_ANCHOR, "                # ANCHOR_REMOVED_FOR_TEST")
-        )
-        r = _run_patch(self.PATCH_NAME, self.target)
-        self.assertEqual(r.returncode, 1, f"stdout={r.stdout} stderr={r.stderr}")
-        self.assertIn("ERROR:", r.stderr)
-        self.assertIn(self.PATCH_NAME, r.stderr)
-
-    def test_patched_call_uses_await_v092(self):
+    def test_patched_call_uses_await_v096(self):
         # Regression guard for issue #96: Files.update_file_data_by_id was
         # sync in v0.8.x, async since v0.9.x. process_file() is async, so the
         # patched call must be awaited — otherwise the coroutine is dropped,
@@ -125,7 +83,7 @@ class TestFixSkipEmbeddingChatFilesV092(unittest.TestCase):
             "this regresses issue #96.",
         )
 
-    def test_patched_kb_fallback_does_not_block_event_loop_v092(self):
+    def test_patched_kb_fallback_does_not_block_event_loop_v096(self):
         # Storage.get_file and Loader.load are sync; calling them directly in
         # the async process_file handler would block the OWUI event loop for
         # the entire read/parse (minutes for large PDFs). Upstream OWUI

--- a/tests/patches/test_fix_skip_rag_files_native_fc.py
+++ b/tests/patches/test_fix_skip_rag_files_native_fc.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BUSL-1.1
 # Copyright (c) 2025 Open Computer Use Contributors
-"""Tests for fix_skip_rag_files_native_fc.py against v0.9.1 middleware.py."""
+"""Tests for fix_skip_rag_files_native_fc.py — anchor is stable across v0.9.1–v0.9.6."""
 import ast
 import os
 import shutil
@@ -13,7 +13,11 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PATCH_DIR = REPO_ROOT / "openwebui" / "patches"
 sys.path.insert(0, str(Path(__file__).parent))
-from conftest import load_middleware_v091, load_middleware_v092  # noqa: E402
+from conftest import (  # noqa: E402
+    load_middleware_v091,
+    load_middleware_v092,
+    load_middleware_v096,
+)
 
 
 def _run_patch(patch_name: str, target_file: Path) -> subprocess.CompletedProcess:
@@ -105,6 +109,53 @@ class TestFixSkipRagFilesNativeFcV092(unittest.TestCase):
         self.assertEqual(after_first, self.target.read_text())
 
     def test_broken_fixture_fails_loud_v092(self):
+        content = self.target.read_text()
+        self.assertIn(self.PRIMARY_ANCHOR, content)
+        self.target.write_text(
+            content.replace(self.PRIMARY_ANCHOR, "            # ANCHOR_REMOVED_FOR_TEST")
+        )
+        r = _run_patch(self.PATCH_NAME, self.target)
+        self.assertEqual(r.returncode, 1, f"stdout={r.stdout} stderr={r.stderr}")
+        self.assertIn("ERROR:", r.stderr)
+        self.assertIn(self.PATCH_NAME, r.stderr)
+
+
+class TestFixSkipRagFilesNativeFcV096(unittest.TestCase):
+    """3-state coverage against real v0.9.6 middleware.py fixture (build base)."""
+
+    PATCH_NAME = "fix_skip_rag_files_native_fc"
+    NEW_MARKER = "FIX_SKIP_RAG_FILES_NATIVE_FC"
+    PRIMARY_ANCHOR = (
+        "            form_data, flags = await chat_completion_files_handler("
+        "request, form_data, extra_params, user)"
+    )
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.target = Path(self.tmp) / "middleware.py"
+        self.target.write_text(load_middleware_v096(), encoding="utf-8")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_fresh_apply_v096(self):
+        r = _run_patch(self.PATCH_NAME, self.target)
+        self.assertEqual(r.returncode, 0, f"stderr={r.stderr}")
+        self.assertIn(f"PATCHED: {self.PATCH_NAME}", r.stdout)
+        content = self.target.read_text()
+        self.assertIn(self.NEW_MARKER, content)
+        ast.parse(content)
+
+    def test_idempotent_rerun_v096(self):
+        r1 = _run_patch(self.PATCH_NAME, self.target)
+        self.assertEqual(r1.returncode, 0)
+        after_first = self.target.read_text()
+        r2 = _run_patch(self.PATCH_NAME, self.target)
+        self.assertEqual(r2.returncode, 0)
+        self.assertIn("ALREADY PATCHED", r2.stdout)
+        self.assertEqual(after_first, self.target.read_text())
+
+    def test_broken_fixture_fails_loud_v096(self):
         content = self.target.read_text()
         self.assertIn(self.PRIMARY_ANCHOR, content)
         self.target.write_text(

--- a/tests/patches/test_fix_tool_loop_errors.py
+++ b/tests/patches/test_fix_tool_loop_errors.py
@@ -1,8 +1,12 @@
 # SPDX-License-Identifier: BUSL-1.1
 # Copyright (c) 2025 Open Computer Use Contributors
-"""Tests for fix_tool_loop_errors.py against v0.9.1 middleware.py.
+"""Tests for fix_tool_loop_errors.py against the v0.9.6 middleware.py fixture.
 
 3-state coverage: fresh apply / idempotent re-run / broken fixture fails loud.
+The patch's SEARCH/REPLACE anchors target a single upstream shape (the version
+in openwebui/Dockerfile). v0.9.6 renamed the tool-loop counter
+(tool_call_retries -> tool_call_iterations) and reshaped the while-loop, so the
+fixture is pinned to that base.
 """
 import ast
 import os
@@ -16,7 +20,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PATCH_DIR = REPO_ROOT / "openwebui" / "patches"
 sys.path.insert(0, str(Path(__file__).parent))
-from conftest import load_middleware_v091, load_middleware_v092  # noqa: E402
+from conftest import load_middleware_v096  # noqa: E402
 
 
 def _run_patch(patch_name: str, target_file: Path) -> subprocess.CompletedProcess:
@@ -27,83 +31,34 @@ def _run_patch(patch_name: str, target_file: Path) -> subprocess.CompletedProces
     )
 
 
-class TestFixToolLoopErrors(unittest.TestCase):
+class TestFixToolLoopErrorsV096(unittest.TestCase):
+    """3-state coverage against real v0.9.6 middleware.py fixture."""
+
     PATCH_NAME = "fix_tool_loop_errors"
     NEW_MARKER = "FIX_TOOL_LOOP_ERRORS"
-    # Distinctive single line from SEARCH_TOOL_LOOP / SEARCH_ITER anchors
-    PRIMARY_ANCHOR = (
-        "                while len(tool_calls) > 0 and tool_call_retries < "
-        "CHAT_RESPONSE_MAX_TOOL_CALL_RETRIES:"
-    )
+    # Distinctive single line from the v0.9.6 SEARCH_ITER anchor.
+    PRIMARY_ANCHOR = "                    tool_call_iterations += 1"
 
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
         self.target = Path(self.tmp) / "middleware.py"
-        self.target.write_text(load_middleware_v091(), encoding="utf-8")
+        self.target.write_text(load_middleware_v096(), encoding="utf-8")
 
     def tearDown(self):
         shutil.rmtree(self.tmp, ignore_errors=True)
 
-    def test_fresh_apply(self):
+    def test_fresh_apply_v096(self):
         r = _run_patch(self.PATCH_NAME, self.target)
         self.assertEqual(r.returncode, 0, f"stderr={r.stderr}\nstdout={r.stdout}")
         self.assertIn(f"PATCHED: {self.PATCH_NAME}", r.stdout)
         content = self.target.read_text()
         self.assertIn(self.NEW_MARKER, content)
         self.assertIn("TOOL_LOOP_ERRORS_UNIFIED", content)
-        ast.parse(content)
-
-    def test_idempotent_rerun(self):
-        r1 = _run_patch(self.PATCH_NAME, self.target)
-        self.assertEqual(r1.returncode, 0)
-        after_first = self.target.read_text()
-        r2 = _run_patch(self.PATCH_NAME, self.target)
-        self.assertEqual(r2.returncode, 0)
-        self.assertIn("ALREADY PATCHED", r2.stdout)
-        self.assertEqual(after_first, self.target.read_text())
-
-    def test_broken_fixture_fails_loud(self):
-        content = self.target.read_text()
-        self.assertIn(self.PRIMARY_ANCHOR, content, "test fixture assumption wrong")
-        self.target.write_text(
-            content.replace(self.PRIMARY_ANCHOR, "                # ANCHOR_REMOVED_FOR_TEST")
-        )
-        r = _run_patch(self.PATCH_NAME, self.target)
-        self.assertEqual(r.returncode, 1, f"expected exit 1; stdout={r.stdout} stderr={r.stderr}")
-        self.assertIn("ERROR:", r.stderr)
-        self.assertIn(self.PATCH_NAME, r.stderr)
-
-
-class TestFixToolLoopErrorsV092(unittest.TestCase):
-    """3-state coverage against real v0.9.2 middleware.py fixture."""
-
-    PATCH_NAME = "fix_tool_loop_errors"
-    NEW_MARKER = "FIX_TOOL_LOOP_ERRORS"
-    PRIMARY_ANCHOR = (
-        "                while len(tool_calls) > 0 and tool_call_retries < "
-        "CHAT_RESPONSE_MAX_TOOL_CALL_RETRIES:"
-    )
-
-    def setUp(self):
-        self.tmp = tempfile.mkdtemp()
-        self.target = Path(self.tmp) / "middleware.py"
-        self.target.write_text(load_middleware_v092(), encoding="utf-8")
-
-    def tearDown(self):
-        shutil.rmtree(self.tmp, ignore_errors=True)
-
-    def test_fresh_apply_v092(self):
-        r = _run_patch(self.PATCH_NAME, self.target)
-        self.assertEqual(r.returncode, 0, f"stderr={r.stderr}\nstdout={r.stdout}")
-        self.assertIn(f"PATCHED: {self.PATCH_NAME}", r.stdout)
-        content = self.target.read_text()
-        self.assertIn(self.NEW_MARKER, content)
-        self.assertIn("TOOL_LOOP_ERRORS_UNIFIED", content)
-        # v0.9.2 specific: the new 'metadata': metadata, key is emitted
+        # v0.9.2+ specific: the 'metadata': metadata, key is emitted
         self.assertIn("'metadata': metadata,", content)
         ast.parse(content)
 
-    def test_idempotent_rerun_v092(self):
+    def test_idempotent_rerun_v096(self):
         r1 = _run_patch(self.PATCH_NAME, self.target)
         self.assertEqual(r1.returncode, 0)
         after_first = self.target.read_text()
@@ -112,11 +67,12 @@ class TestFixToolLoopErrorsV092(unittest.TestCase):
         self.assertIn("ALREADY PATCHED", r2.stdout)
         self.assertEqual(after_first, self.target.read_text())
 
-    def test_broken_fixture_fails_loud_v092(self):
+    def test_broken_fixture_fails_loud_v096(self):
         content = self.target.read_text()
         self.assertIn(self.PRIMARY_ANCHOR, content, "test fixture assumption wrong")
+        # Remove every occurrence so no anchor (Mod 1 or Mod 5) can match.
         self.target.write_text(
-            content.replace(self.PRIMARY_ANCHOR, "                # ANCHOR_REMOVED_FOR_TEST")
+            content.replace(self.PRIMARY_ANCHOR, "                    # ANCHOR_REMOVED_FOR_TEST")
         )
         r = _run_patch(self.PATCH_NAME, self.target)
         self.assertEqual(r.returncode, 1, f"expected exit 1; stdout={r.stdout} stderr={r.stderr}")


### PR DESCRIPTION
Bumps the Open WebUI base image `0.9.5` → `0.9.6` and re-audits all eight patches against the new upstream tree. Closes #243 (build failure on the 0.9.6 base).

## Root cause (#243)

Upstream 0.9.6 refactored the tool-call loop in `middleware.py`, breaking `fix_tool_loop_errors` anchor 1/5.

## Patch changes

Only `fix_tool_loop_errors` needed anchor updates (4 of 5 mods); the other five backend patches and both frontend chunk patches applied to 0.9.6 unchanged.

| Mod | 0.9.6 upstream change | Fix |
|-----|-----------------------|-----|
| 1 (tool_loop) | iteration-limit block inserted before `if DETECT_CODE_INTERPRETER:` | drop the trailing `if DETECT_CODE_INTERPRETER:` from the anchor |
| 2 (code_interp) | title guard `metadata['chat_id']` → `metadata.get('chat_id', '')` | update SEARCH/REPLACE |
| 3 (sse) | unchanged | none |
| 4 (done_bg) | reordered: `assistant_message` → `outlet_filter_handler` → `background_tasks_handler` | track new order |
| 5 (iter) | `tool_call_retries` → `tool_call_iterations`; multi-line `while ... ITERATIONS` | rename + reshape anchor and log lines |

## Tests

- Added byte-identical v0.9.6 fixtures (`middleware_v0.9.6.py`, `retrieval_v0.9.6.py`).
- Every patch suite now has v0.9.6 3-state coverage (fresh / idempotent / fail-loud). Stale v0.9.1/v0.9.2 classes that can no longer match the refactored anchors were replaced; version-stable patches keep their old coverage plus a new v0.9.6 class.
- `pytest tests/patches/` — **51 passed** (22 against the v0.9.6 base, all eight patches).

## Verified

- Cumulative dry-run against a fresh v0.9.6 tree — both files parse (`ast.parse`).
- Both frontend chunk patches locate their anchors (artifacts `B56SVFjv.js`, preview `CBKmxchQ.js`).
- `docker build --platform linux/amd64 -t open-webui-ocu:0.9.6.0-rc.1 -f openwebui/Dockerfile openwebui/` — succeeds, all eight hard-fail guards green, patched files parse inside the image.

After merge: tag `v0.9.6.0-rc.1` on the merge commit (RC first, matching the v0.9.5.0-rc.2 → v0.9.5.0 flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Upgraded to Open WebUI 0.9.6 base.

* **Bug Fixes**
  * Improved tool-loop error handling with better error messaging and recovery.
  * Enhanced chat metadata access safety.
  * Refined background task processing order.

* **Tests**
  * Extended regression coverage to v0.9.6 with version-specific fixtures and updated test assertions across all patches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->