### PR TITLE
fix(ci): align gha cache scopes so Integration reuses build caches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,8 +64,12 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Named scope so the integration job's `cache-from: scope=sandbox`
+          # actually hits this layer cache. Default (unscoped) gha cache uses a
+          # per-job key, so integration never found it and rebuilt the 8GB
+          # sandbox image from scratch every run.
+          cache-from: type=gha,scope=sandbox
+          cache-to: type=gha,mode=max,scope=sandbox
 
       - name: Pick image tag for smoke tests
         id: img
@@ -143,8 +147,10 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Shared scope with the smoke + integration server builds so they
+          # reuse these layers instead of rebuilding (see scope=server-smoke).
+          cache-from: type=gha,scope=server-smoke
+          cache-to: type=gha,mode=max,scope=server-smoke
 
   build-cleanup:
     name: Build Cleanup Image
@@ -349,8 +355,11 @@ jobs:
           push: false
           load: true
           tags: open-computer-use:test
+          # Read-only: build-sandbox (this job's dependency) owns writing the
+          # `sandbox` scope. With matching context/platform the layers are
+          # identical, so this is a full cache hit and no rebuild. No cache-to —
+          # re-exporting the 8GB layer cache here would just waste upload time.
           cache-from: type=gha,scope=sandbox
-          cache-to: type=gha,mode=max,scope=sandbox-integration
 
       - name: Build server image (local tag)
         uses: docker/build-push-action@v7
@@ -359,8 +368,8 @@ jobs:
           push: false
           load: true
           tags: open-computer-use-server:test
+          # Read-only: build-server / smoke own the `server-smoke` scope.
           cache-from: type=gha,scope=server-smoke
-          cache-to: type=gha,mode=max,scope=server-integration
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Problem

The `Integration — real MCP + Docker` job rebuilds the ~8GB sandbox image from scratch on every run (no cache), making it by far the slowest job.

## Root cause

gha cache **scope mismatch**:

| Image | `cache-to` (writer) | Integration `cache-from` | Hit? |
|-------|---------------------|--------------------------|------|
| sandbox | `build-sandbox` → default (unscoped) | `scope=sandbox` | ❌ miss |
| server | `build-server` → default; smoke → `scope=server-smoke` | `scope=server-smoke` | ⚠️ only via smoke |

`type=gha` keys cache by scope; the default scope is per-job, so Integration's `scope=sandbox` read never matched build-sandbox's default-scope write → 100% miss → full rebuild (Playwright, Chromium, npm, Python).

## Fix

- `build-sandbox`: write + read `scope=sandbox`.
- `build-server`: write + read `scope=server-smoke` (shared with smoke + Integration).
- `Integration`: drop `cache-to` on both inline builds — they are pure consumers of caches owned by the build jobs that run first via `needs:`; re-exporting the 8GB layer cache only wasted upload time.

`build-sandbox` runs before Integration (`needs:`), so the hit lands on the **same** run, not just the next one.

CI-only; no image-content change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized GitHub Actions Docker build caching configuration for improved CI/CD pipeline efficiency across sandbox and server image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->