### PR TITLE
chore: drop a stale local-notes ignore glob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,4 +142,3 @@ docs/future-architecture/research/20-*.md
 docs/future-architecture/research/21-*.md
 docs/future-architecture/research/22-*.md
 docs/future-architecture/research/23-*.md
-docs/future-architecture/research/proof-anthropic-*.md


### PR DESCRIPTION
The pattern matches files that are kept out of the repository by the local excludes file; the committed ignore entry is redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git configuration to track documentation and research files in version control that were previously excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->