### PR TITLE
fix(contracts): restore snake_case field names in the exec-channel union

### DIFF
--- a/contracts/exec/exec-channel.schema.json
+++ b/contracts/exec/exec-channel.schema.json
@@ -58,7 +58,7 @@
           "items": { "type": "string", "maxLength": 4096 },
           "maxItems": 1024
         },
-        "env_vars": {
+        "env": {
           "type": "object",
           "additionalProperties": { "type": "string", "maxLength": 32768 },
           "maxProperties": 1024
@@ -74,7 +74,7 @@
         "gid": { "type": "integer", "minimum": 0, "maximum": 4294967295 },
         "allow_process_id_reuse": { "type": "boolean", "default": false },
         "reattachable": { "type": "boolean", "default": false },
-        "boundPid": {
+        "bound_pid": {
           "type": ["integer", "null"],
           "minimum": 0,
           "maximum": 4294967295
@@ -105,13 +105,13 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "supports_trace": { "type": "boolean" },
+        "supports_traces": { "type": "boolean" },
         "supports_compression": {
           "type": "boolean",
           "x-ocu-tbd": "Server advertises frame compression support. The algorithm and frame layout are unsourced; carried as a negotiation flag, not a frozen algorithm choice (x-ocu-open-questions: compression-algorithm)."
         }
       },
-      "required": ["supports_trace", "supports_compression"]
+      "required": ["supports_traces", "supports_compression"]
     },
 
     "ServerMessage": {
@@ -168,7 +168,7 @@
         "InvalidSignal": { "$ref": "#/$defs/BoundedReason" },
 
         "TraceEvent": {
-          "$comment": "Server-side trace event; emitted only when supports_trace was negotiated. No source pins a field list, so the body is an open object (TBD: field set, see x-ocu-open-questions).",
+          "$comment": "Server-side trace event; emitted only when supports_traces was negotiated. No source pins a field list, so the body is an open object (TBD: field set, see x-ocu-open-questions).",
           "type": "object"
         },
 
@@ -218,7 +218,7 @@
         "KeepAlive": { "type": "null" },
         "Closed": { "type": "null" },
         "TraceEvent": {
-          "$comment": "Client-side trace event; valid only when supports_trace was negotiated. Body unspecified by any source, so left as an open object (TBD: field set, see x-ocu-open-questions).",
+          "$comment": "Client-side trace event; valid only when supports_traces was negotiated. Body unspecified by any source, so left as an open object (TBD: field set, see x-ocu-open-questions).",
           "type": "object"
         }
       }
@@ -227,11 +227,11 @@
 
   "x-ocu-open-questions": [
     "ProcessCreatedV2 / AttachedToProcessV2 payload body: the V2 success tags exist but no source pins their frame body. A server-tracked status set (memory_usage_bytes, memory_cgroup_path, process_group_pid, internal_state with states CgroupCreated/Ready) is the expected payload, but its carrier frame is unconfirmed. Pin the V2 payload (and whether it carries the status set) before hardening either tag's body beyond an open object.",
-    "TraceEvent field set: the tag is negotiated via supports_trace but no source pins its fields; define a trace contract before constraining the body.",
+    "TraceEvent field set: the tag is negotiated via supports_traces but no source pins its fields; define a trace contract before constraining the body.",
     "compression-algorithm: accept_compression / supports_compression negotiate frame compression, but no source pins the algorithm or the compressed-frame layout; pick and pin the algorithm before constraining the wire format."
   ],
 
-  "$comment-anyOf": "A frame is the phase-1 handshake (ProcessConnection, identified by its required process_id) or a post-handshake control frame. Frame direction — server-sent vs client-sent — is a transport property (which peer wrote it), not an envelope distinction, so the same tag may appear in both directions (e.g. TraceEvent flows both ways under a negotiated supports_trace). anyOf, not oneOf: a TraceEvent frame is a valid control frame in either direction, and the envelope does not assert mutual exclusivity the wire does not have.",
+  "$comment-anyOf": "A frame is the phase-1 handshake (ProcessConnection, identified by its required process_id) or a post-handshake control frame. Frame direction — server-sent vs client-sent — is a transport property (which peer wrote it), not an envelope distinction, so the same tag may appear in both directions (e.g. TraceEvent flows both ways under a negotiated supports_traces). anyOf, not oneOf: a TraceEvent frame is a valid control frame in either direction, and the envelope does not assert mutual exclusivity the wire does not have.",
   "anyOf": [
     { "$ref": "#/$defs/ProcessConnection" },
     { "$ref": "#/$defs/ServerMessage" },


### PR DESCRIPTION
Restores three handshake field names to the schema's universal snake_case convention: `env_vars` → `env`, `boundPid` → `bound_pid`, `supports_trace` → `supports_traces`.

`boundPid` was the only camelCase property in the schema. Both language bindings already declare these fields as `env` / `bound_pid` / `supports_traces` and carried per-field rename attributes to compensate; the existing prose in `docs/future-architecture` also references `supports_traces`. Frozen-contract changes ride in dedicated PRs.

The companion ocu-sandbox PR updates the embedded schema copies, fixtures, and both bindings; the byte-identity gate there verifies against this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated Exec WebSocket control protocol schema with normalized property names: `env_vars` → `env` and `boundPid` → `bound_pid`.
* Renamed trace-negotiation flag from `supports_trace` to `supports_traces` across connection capabilities and trace-event references for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->