### PR TITLE
chore: pre-push + CI lint flagging i@yambr.com in tracked content

### DIFF
--- a/.github/workflows/identity-lint.yml
+++ b/.github/workflows/identity-lint.yml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# Identity gate. Runs on every PR and every push to the long-lived branches.
+# The project commits and authors under developer@widemoat.ai; a personal
+# address must not appear in tracked file content. The exact banned address is
+# defined in scripts/docs-lint/identity-email-detector.sh. Commit *metadata* is
+# enforced locally by the pre-push hook (scripts/githooks/pre-push); this is
+# the CI backstop for file content.
+
+name: identity-lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - next/v1
+
+permissions:
+  contents: read
+
+jobs:
+  identity-email:
+    name: identity-email detector
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check tracked content for the banned personal address
+        run: bash scripts/docs-lint/identity-email-detector.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,19 @@ Thank you for your interest! PRs and issues welcome.
 2. Clone: `git clone https://github.com/your-username/open-computer-use.git`
 3. Branch: `git checkout -b feature/your-feature`
 
+## Git hooks
+
+Install the versioned pre-push hook once per clone. It blocks pushes that
+carry `.planning/` artefacts to the public remote, and pushes where a personal
+email address (defined in the identity-email detector) appears in tracked file
+content — rewrite it to `developer@widemoat.ai`:
+
+```bash
+ln -sf ../../scripts/githooks/pre-push .git/hooks/pre-push
+```
+
+The same content check runs in CI (`identity-lint` workflow) as a backstop.
+
 ## Development
 
 ```bash

--- a/scripts/docs-lint/identity-email-detector.sh
+++ b/scripts/docs-lint/identity-email-detector.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# Identity-email detector — the project commits and authors under the
+# Wide-Moat org identity, not a personal address.
+#
+#   banned:    i@yambr.com
+#   canonical: developer@widemoat.ai
+#
+# This gate scans tracked file content (docs, code, configs) for the banned
+# address and tells the author to rewrite it. Commit *metadata* (author /
+# committer email) is enforced separately by the pre-push hook; this script
+# only covers the file-content surface so the same rule holds in CI.
+#
+# Exits 1 if the banned address appears in any tracked file.
+
+set -uo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+BANNED="i@yambr.com"
+CANONICAL="developer@widemoat.ai"
+
+# Search tracked files only; never descend into references/ (vendored repos)
+# or .git. -I skips binary files. Fixed-string match so the dot is literal.
+# The two policy scripts (this detector and the pre-push hook) name the banned
+# address on purpose, to define the rule — exclude them so the gate does not
+# flag its own definition.
+hits="$(git grep -InF "$BANNED" -- \
+  ':(exclude)references/**' \
+  ':(exclude)*.sample' \
+  ':(exclude)scripts/docs-lint/identity-email-detector.sh' \
+  ':(exclude)scripts/githooks/pre-push' \
+  2>/dev/null || true)"
+
+if [ -n "$hits" ]; then
+  echo "-----------------------------------------------------------------"
+  echo "BLOCKED: the personal address '$BANNED' appears in tracked files."
+  echo "Rewrite it to the project identity: $CANONICAL"
+  echo ""
+  echo "$hits" | sed 's/^/  /'
+  echo "-----------------------------------------------------------------"
+  exit 1
+fi
+
+exit 0

--- a/scripts/docs-lint/test-linters.sh
+++ b/scripts/docs-lint/test-linters.sh
@@ -309,6 +309,36 @@ do
 done
 ok "tree-whitelist accepts files that match allowed patterns"
 
+# -------- identity-email-detector --------
+echo "Testing identity-email-detector.sh:"
+
+# The detector greps tracked content for the banned personal address and tells
+# the author to use developer@widemoat.ai. git grep needs tracked files, so
+# exercise the match logic on the same fixed-string pattern the script uses.
+# The banned address is assembled from parts so the literal never appears in
+# this tracked file (which would itself trip the detector it tests).
+banned="i@yambr$(printf '%s' .com)"
+canonical="developer@widemoat.ai"
+
+if printf 'contact %s for help\n' "$banned" | grep -qF "$banned"; then
+  ok "identity-email-detector flags the banned personal address"
+else
+  err "identity-email-detector pattern missed the banned address"
+fi
+
+if printf '%s\n' "$canonical" | grep -qF "$banned"; then
+  err "identity-email-detector false-positives on the canonical address"
+else
+  ok "identity-email-detector accepts the canonical project address"
+fi
+
+# Must not flag legitimate yambr.com product URLs (chat./api./docs.yambr.com).
+if printf 'see https://chat.yambr.com\n' | grep -qF "$banned"; then
+  err "identity-email-detector false-positives on a yambr.com product URL"
+else
+  ok "identity-email-detector ignores yambr.com product URLs"
+fi
+
 # -------- Summary --------
 echo
 echo "Linter self-test: $pass passed, $fail failed."

--- a/scripts/docs-lint/test-linters.sh
+++ b/scripts/docs-lint/test-linters.sh
@@ -312,31 +312,38 @@ ok "tree-whitelist accepts files that match allowed patterns"
 # -------- identity-email-detector --------
 echo "Testing identity-email-detector.sh:"
 
-# The detector greps tracked content for the banned personal address and tells
-# the author to use developer@widemoat.ai. git grep needs tracked files, so
-# exercise the match logic on the same fixed-string pattern the script uses.
-# The banned address is assembled from parts so the literal never appears in
-# this tracked file (which would itself trip the detector it tests).
+# Run the detector end-to-end against a throwaway git repo, so the test covers
+# the script's real behaviour (tracked-file scan, path excludes, git invocation,
+# exit code) rather than re-implementing its grep. The banned address is
+# assembled from parts so the literal never appears in this tracked file (which
+# would itself trip the detector it tests).
 banned="i@yambr$(printf '%s' .com)"
 canonical="developer@widemoat.ai"
+detector="$ROOT/scripts/docs-lint/identity-email-detector.sh"
 
-if printf 'contact %s for help\n' "$banned" | grep -qF "$banned"; then
+# Fixture repo with one tracked file carrying the banned address.
+fixture="$TMP/identity-fixture"
+git init -q "$fixture"
+git -C "$fixture" config user.email test@example.com
+git -C "$fixture" config user.name test
+printf 'contact %s for help\n' "$banned" > "$fixture/notes.md"
+git -C "$fixture" add notes.md
+git -C "$fixture" commit -q -m fixture
+
+if ( cd "$fixture" && bash "$detector" ) >/dev/null 2>&1; then
+  err "identity-email-detector did not flag the banned personal address"
+else
   ok "identity-email-detector flags the banned personal address"
-else
-  err "identity-email-detector pattern missed the banned address"
 fi
 
-if printf '%s\n' "$canonical" | grep -qF "$banned"; then
-  err "identity-email-detector false-positives on the canonical address"
+# Replace the tracked content with the canonical address and a product URL;
+# neither must trip the detector.
+printf 'contact %s — see https://chat.yambr.com\n' "$canonical" > "$fixture/notes.md"
+git -C "$fixture" commit -q -am clean
+if ( cd "$fixture" && bash "$detector" ) >/dev/null 2>&1; then
+  ok "identity-email-detector accepts the canonical address and yambr.com URLs"
 else
-  ok "identity-email-detector accepts the canonical project address"
-fi
-
-# Must not flag legitimate yambr.com product URLs (chat./api./docs.yambr.com).
-if printf 'see https://chat.yambr.com\n' | grep -qF "$banned"; then
-  err "identity-email-detector false-positives on a yambr.com product URL"
-else
-  ok "identity-email-detector ignores yambr.com product URLs"
+  err "identity-email-detector false-positives on the canonical address or a product URL"
 fi
 
 # -------- Summary --------

--- a/scripts/githooks/pre-push
+++ b/scripts/githooks/pre-push
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# Versioned pre-push policy. Git does not run this copy directly — hooks live
+# in .git/hooks/, which is not tracked. Install it once per clone:
+#
+#   ln -sf ../../scripts/githooks/pre-push .git/hooks/pre-push
+#
+# (or copy it). CONTRIBUTING.md documents the one-line install. This file is
+# the source of truth; the installed copy must match it.
+#
+# Two gates, both blocking:
+#   1. .planning/ guard — never push planning/roadmap/phase artefacts to the
+#      public GitHub remote.
+#   2. Documentation identity gate — the personal address i@yambr.com must not
+#      appear in tracked file content; rewrite it to developer@widemoat.ai.
+#      (This checks file CONTENT only, not commit author/committer metadata.)
+
+set -euo pipefail
+
+remote_name="$1"
+remote_url="$2"
+
+z40=$(printf '%040d' 0)
+exit_code=0
+
+# Recognise the public remote by URL host.
+case "$remote_url" in
+    *github.com*) is_public=true ;;
+    *)            is_public=false ;;
+esac
+
+# ---- Gate 1: .planning/ guard (public remote only) --------------------------
+if [ "$is_public" = "true" ]; then
+    while read -r local_ref local_sha remote_ref remote_sha; do
+        [ "$local_sha" = "$z40" ] && continue   # deletion
+
+        if [ "$remote_sha" = "$z40" ]; then
+            range="$local_sha"                  # new branch
+            bad_files=$(git ls-tree -r "$local_sha" --name-only | grep -E '^\.planning/' || true)
+        else
+            range="${remote_sha}..${local_sha}"
+            bad_files=$(git log "$range" --name-only --pretty=format: | grep -E '^\.planning/' | sort -u || true)
+        fi
+
+        if [ -n "$bad_files" ]; then
+            echo "-----------------------------------------------------------------"
+            echo "BLOCKED: this push to $remote_url would include .planning/ files."
+            echo "The public GitHub remote must not carry planning/roadmap/phase"
+            echo "artefacts."
+            echo ""
+            echo "Offending paths in range $range:"
+            echo "$bad_files" | sed 's/^/  /'
+            echo "-----------------------------------------------------------------"
+            exit_code=1
+        fi
+    done
+fi
+
+# ---- Gate 2: banned address in tracked file content -------------------------
+ROOT="$(git rev-parse --show-toplevel)"
+if [ -x "$ROOT/scripts/docs-lint/identity-email-detector.sh" ]; then
+    if ! "$ROOT/scripts/docs-lint/identity-email-detector.sh"; then
+        exit_code=1
+    fi
+fi
+
+exit $exit_code

--- a/scripts/githooks/pre-push
+++ b/scripts/githooks/pre-push
@@ -59,11 +59,17 @@ if [ "$is_public" = "true" ]; then
 fi
 
 # ---- Gate 2: banned address in tracked file content -------------------------
+# Run the detector through bash, not as an executable: a checkout that drops the
+# exec bit (no-exec filesystem, archive export) must not silently skip the gate.
 ROOT="$(git rev-parse --show-toplevel)"
-if [ -x "$ROOT/scripts/docs-lint/identity-email-detector.sh" ]; then
-    if ! "$ROOT/scripts/docs-lint/identity-email-detector.sh"; then
+detector="$ROOT/scripts/docs-lint/identity-email-detector.sh"
+if [ -f "$detector" ]; then
+    if ! bash "$detector"; then
         exit_code=1
     fi
+else
+    echo "BLOCKED: identity detector missing: $detector"
+    exit_code=1
 fi
 
 exit $exit_code


### PR DESCRIPTION
Flag the personal address `i@yambr.com` in tracked files and ask to rewrite it to `developer@widemoat.ai`. Content-only — does not touch commit metadata or git config.

## What

- `scripts/githooks/pre-push` — versioned hook merging the existing `.planning/` guard with a content check. Install via the symlink documented in `CONTRIBUTING.md`.
- `scripts/docs-lint/identity-email-detector.sh` — `git grep` over tracked files; excludes the two policy scripts that define the rule and `references/`. `yambr.com` product URLs (chat./api./docs.) are not flagged — only the exact mailbox.
- `.github/workflows/identity-lint.yml` — same check on every PR and on pushes to `main`/`next/v1`.
- `test-linters.sh` — self-test fixtures for the detector (flags banned, accepts canonical, ignores yambr.com product URLs).

## Verification

- Linter self-test: 17/17 pass.
- Detector runs clean against the full tree; the only literal occurrences are the two policy scripts that define the rule (self-excluded).
- The repo had zero `i@yambr.com` in content already — the lint is preventive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contributor guide for installing versioned Git pre-push hooks.
* **New Features**
  * Added CI “identity-lint” workflow that blocks pull requests/pushes containing a banned personal email in tracked content.
  * Added an optional local pre-push hook that prevents pushing `.planning/` artifacts and the banned personal email.
* **Tests**
  * Added an automated self-test for the identity-email detector to verify correct blocking and non-blocking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->