### PR TITLE
feat(architecture): ADR-0021 host-side L3 egress attach seam

### DIFF
--- a/docs/architecture/adr/0021-egress-l3-attach-seam.md
+++ b/docs/architecture/adr/0021-egress-l3-attach-seam.md
@@ -1,0 +1,62 @@
+<!-- SPDX-License-Identifier: FSL-1.1-Apache-2.0 -->
+<!-- Copyright (c) 2025 Open Computer Use Contributors -->
+
+---
+status: proposed
+last-reviewed: 2026-06-20
+owner: "@Wide-Moat/architects"
+applies-to: next/v1
+supersedes: []
+superseded-by: null
+amends: []
+compliance-impact: [SOC2-CC6.1, SOC2-CC6.6, NYDFS-500.15, DORA-Art.28]
+license-impact: none
+threat-mitigation-link: ../06-threat-model.md
+---
+
+Fixes how a sandbox session's outbound bytes physically reach the egress edge's L3 hop, and bounds that hop to a host-driven attach with no added privilege. Audience: anyone wiring or auditing the L3 path between a guest and the egress edge.
+
+# ADR-0021: Host-side L3 egress attach seam
+
+## Status
+
+`proposed`
+
+Companion to [ADR-0008](0008-session-egress-attribution.md): 0008 fixes *who* an outbound request is attributed to (the presented L7 token, never a network fact); this ADR fixes *how* the bytes physically transit to the hop that reads that token. The two are orthogonal — 0008 keys policy on the token; this keys nothing on the L3 fact, it only carries the bytes.
+
+## Context
+
+[ADR-0008](0008-session-egress-attribution.md) assumes the edge already holds the guest's plaintext request after TLS termination, but does not say how a guest's bytes physically reach the edge's L3 hop. The per-session bridge ships deny-all: `denyAllEgressNetworkOptions` creates each bridge `Internal: true` (no off-bridge route), and `DropEgress` is a host-side SDK `NetworkDisconnect` of the container from that bridge at teardown — the L3 teardown half (NFR-SEC-27). The attach half — the standing L3 path the edge listens on — had no decision. An `Internal: true` bridge's only on-bridge peer is a dead-end host gateway; bytes addressed to it land nowhere. Making the edge the real L3 exit needs a mechanism, and the mechanism must not regress the control plane's privilege: the control plane runs non-root (no `CAP_NET_ADMIN`), and `DropEgress` is SDK-only. The component-06 edge — the L7 demux, the credential exchange, the forwarding element — does not exist yet, so the decision is scoped to the L3 attach proven in component-05 against an off-bridge stand-in.
+
+## Decision
+
+A guest's bytes reach the edge over a **host-root-netns listener bound on the session's per-session bridge gateway IP** — the host-owned L3 address the bridge device already carries in the host root network namespace after `NetworkCreate`. The host-side attach seam (`EgressAttach`: `Attach` on Create, `Detach` on teardown) stands an ordinary `net.Listen` on that address: no `ip link`, no netns entry, no `CAP_NET_ADMIN`. A guest packet to its gateway IP leaves the container netns through the veth pair and is delivered in the host root netns — a real netns-boundary crossing, not a loopback to an on-bridge sibling.
+
+The per-session bridge stays `Internal: true`; the attach adds no cross-session L3 hole. The stand-in **terminates** the bytes (accept, decide, close) and is the chokepoint that owns the allow/deny decision; the deny-all default forwards nothing. The L7 session-JWT demux, the real upstream egress, and the forwarding element are the component-06 edge, deferred — the component-05 seam carries this boundary as a pinned doc-comment so the deferral cannot silently turn into an overclaimed edge.
+
+## Consequences
+
+- The mechanism is tier-identical, preserving [ADR-0008](0008-session-egress-attribution.md)'s cross-tier property: the gateway lives in the host root netns, outside the gVisor network stack, so the transit and the deny decision hold the same under `runc` and `runsc`. The proof runs against both tiers.
+- A host-root-netns listener holds L3 routes to every bridge, so locally-originated traffic bypasses the `FORWARD` chain — the cross-session-relay risk the gateway-bind introduces. The deny path must therefore prove a real **packet drop on a reachable path**, not absence of forwarding: the proof reaches a sibling session's guest from the host root netns under a positive control (the route is live, the test fails if it is not), then asserts the deny path forwarded zero. Co-tenant isolation (NFR-SEC-22) is shown by a packet that does not pass, not by an unconfigured route.
+- `denyAllEgressNetworkOptions` stays `Internal: true`; the `.Internal == true` posture check survives unchanged. Surviving that check is **not** read as "there is no off-bridge byte sink" — the gateway-bound listener is exactly such a sink, by a different path; the two posture facts are distinct.
+- `Detach` reaps the listener at teardown, advisory and ahead of `DropEgress`; teardown leaves zero orphaned listeners. A recycled gateway address re-binds cleanly.
+- Component-06 records this ADR in its `adr:` front-matter (`[…, 0016]` → `[…, 0016, 0021]`); the forwarding element, the L7 demux, and the credential exchange that turn this terminating stand-in into the real edge are its decision, not restated here.
+
+## Alternatives considered
+
+- **Per-session veth into an edge netns** — rejected: it requires `ip link add veth` and entry into the container netns, both of which the non-root control plane (no `CAP_NET_ADMIN`) cannot do; it would regress the SDK-only `DropEgress` to a privileged data path. The gateway-bind needs no privilege the SDK does not already hold.
+- **`NetworkConnect` the edge into the `Internal` bridge as a peer** — rejected: an `Internal: true` bridge has no off-bridge route and the edge-as-peer has no default gateway, so the bytes never leave the bridge — the same dead-end the on-bridge host gateway already is. It proves a loopback, not transit through a mechanism.
+- **Drop `Internal: true` and enforce deny-all only at the edge** — rejected for v1: it moves the deny-all guarantee off a kernel-enforced bridge posture onto edge configuration, widening the blast radius of an edge misconfiguration to cross-session reachability. The `Internal` bridge keeps the kernel as the first deny; the attach is additive to it, not a replacement.
+
+## Compliance impact
+
+- `SOC2-CC6.1` / `SOC2-CC6.6`: the outbound L3 path is a single host-controlled chokepoint per session with a deny-all default; cross-session reachability is denied at the kernel bridge and re-proven at the host hop.
+- `NYDFS-500.15` / `DORA-Art.28`: the session's outbound leg has one host-attested L3 exit, so each outbound flow is bound to its owning session's bridge before the edge attributes it by token.
+
+## License impact
+
+None. The seam is `net.Listen` on a Docker-SDK-created address; no new dependency.
+
+## Threat mitigation
+
+Closes the L3 half of per-session egress isolation behind P5-D2 / P6-D1 in [the threat model](../06-threat-model.md): a guest reaches only the host hop on its own bridge gateway, and the host hop's deny-all default relays nothing to a sibling even though the host root netns can route to one — the cross-session-relay path is proven dropped, not merely unconfigured. The L7 demux and the forwarding element that complete the edge are component-06, tracked with the one-per-host-vs-one-per-deployment instantiation question at [#175](https://github.com/Wide-Moat/open-computer-use/issues/175).

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -38,6 +38,7 @@ Architecture Decision Records. One file per decision. ADRs appear on demand foll
 | [0018](0018-in-guest-control-rpc-endpoint.md) | In-guest control-RPC endpoint (FID-03) | proposed | — | 2026-06-17 |
 | [0019](0019-egress-exchanges-filestore-credential.md) | Egress exchanges the filestore credential from the session JWT | proposed | 0013 (storage-leg custody half) | 2026-06-15 |
 | [0020](0020-sandbox-image-provisioning.md) | Sandbox image provisioning (image-fatness ladder + BYO) — stub | proposed | — | 2026-06-16 |
+| [0021](0021-egress-l3-attach-seam.md) | Host-side L3 egress attach seam (gateway-bound stand-in) | proposed | — | 2026-06-20 |
 
 ## Lifecycle
 

--- a/docs/architecture/components/05-session-sandbox.md
+++ b/docs/architecture/components/05-session-sandbox.md
@@ -9,7 +9,7 @@ applies-to: next/v1
 compliance: []
 threat-model: 06-threat-model.md
 contract: [contracts/exec/exec-channel.schema.json, contracts/control/control-rpc.schema.json]
-adr: [0003, 0005, 0007, 0013, 0014, 0015, 0016, 0017, 0018]
+adr: [0003, 0005, 0007, 0013, 0014, 0015, 0016, 0017, 0018, 0021]
 ---
 
 Internal design of the per-session execution container, for engineers implementing and auditing the guest agent and its host-side edges.
@@ -60,6 +60,7 @@ Each is falsifiable by the named check; cross-cutting zone, egress-mode, retenti
 13. Every TTL/expiry decision the guest is subject to reads a monotonic clock immune to wall-clock setback, and on resume the wall clock is corrected before any time-bound check runs (red-team clock-rollback harness, NFR-SEC-48 + NFR-SEC-63 — trusted-time theme [#185](https://github.com/Wide-Moat/open-computer-use/issues/185), [`06-threat-model.md`](../06-threat-model.md) §5).
 14. A recycled mount substrate carries no readable session-1 content into session-2: the page cache is dropped and the local mount/scratch region is zeroized (or its per-session DEK destroyed) before the region is re-granted, so erase completes-before re-grant (property test: write a session-1 marker, recycle, assert session-2 cannot read it, NFR-SEC-54 + NFR-SEC-64 + NFR-SEC-66). The resume-time CSPRNG/identity reseed that prevents a shared RNG stream is invariant 12, not restated here.
 15. The control-RPC endpoint ([`control/control-rpc`](../../../contracts/control/control-rpc.schema.json), [ADR-0018](../adr/0018-in-guest-control-rpc-endpoint.md)) is a second host-dialled listener on a host-owned UDS in a 0700 host-owned directory, not a redefinition of invariant 2's exec listener: a non-host peer cannot connect to the socket and so is dropped before any frame is parsed (accept-time negative-test, NFR-SEC-76 — the host-only-at-accept enforcement of NFR-SEC-43, scoped here to the control-RPC listener; the directory-permission gate is the v1 realization, an `SO_PEERCRED` compare is future hardening), it adds no outbound network route (invariant 4 holds), and invariant 3's predicate extends to it (a guest with in-sandbox root cannot dial it through the guest's own network stack nor present another session's identity). No control verb carries standalone authority: every body field is a hint, the host-attested caller identity the sole authority (matching component-02's hint-never-authority invariant); `shutdown` is therefore a cooperative fast-path that cannot reorder or mark-complete the host-driven finalizer (Operational concerns, NFR-SEC-65).
+16. The session's outbound L3 path reaches the Egress trust-edge over a host-driven attach on its per-session bridge gateway IP, added with no privilege the control plane lacks and reaped at teardown ahead of the route drop; the per-session bridge stays `Internal`, so the attach opens no cross-session L3 hole and the deny-all default relays nothing to a sibling even from the host root netns ([ADR-0021](../adr/0021-egress-l3-attach-seam.md)). The cross-session-relay deny is proven a packet drop on a route that is live under a positive control, not an absent route, and holds identically under `runc` and `runsc` (egress attach e2e: transit to the host hop + zero-relay-to-sibling under positive control, both tiers, NFR-SEC-22 + NFR-SEC-27).
 
 ## Failure modes
 

--- a/docs/architecture/components/06-egress-trust-edge.md
+++ b/docs/architecture/components/06-egress-trust-edge.md
@@ -9,7 +9,7 @@ applies-to: next/v1
 compliance: []
 threat-model: 06-threat-model.md
 contract: null
-adr: [0005, 0006, 0007, 0008, 0013, 0016]
+adr: [0005, 0006, 0007, 0008, 0013, 0016, 0021]
 ---
 
 The sandbox's single outbound hop: it terminates TLS for inspection, and on the storage leg validates the guest's weak session JWT and exchanges it at the issuer for the real filestore credential it injects — holding no signing key, minting nothing. Audience: engineers and security reviewers wiring or auditing egress policy.
@@ -54,6 +54,7 @@ Each rule holds independent of the caller and is falsifiable by the named check.
 7. Where edge-injection hardening is enabled, the injected authorization never reaches a guest-visible response surface; it is stripped before any response crosses back to the guest leg (integration test, [NFR-SEC-23](../manifesto/02-nfrs.md)).
 8. When the denylist names a session, the edge drops its outbound connections independent of any credential's validity window ([ADR-0008](../adr/0008-session-egress-attribution.md), integration test, [NFR-SEC-04](../manifesto/02-nfrs.md), [NFR-SEC-29](../manifesto/02-nfrs.md)).
 9. Denylist-propagation timing reads a monotonic clock, so a wall-clock setback cannot stall the revoke signal past its window (clock-rollback red-team harness, [NFR-SEC-48](../manifesto/02-nfrs.md), [NFR-SEC-63](../manifesto/02-nfrs.md)).
+10. The L3 ingress face is a host-root-netns hop bound on each session's per-session bridge gateway, the single host-attested exit a guest's bytes cross into before any L7 read; it owns the allow/deny decision and its deny-all default relays nothing to a sibling even though the host root netns can route to one ([ADR-0021](../adr/0021-egress-l3-attach-seam.md), cross-session zero-relay under a positive control, [NFR-SEC-22](../manifesto/02-nfrs.md), [NFR-SEC-27](../manifesto/02-nfrs.md)). The L7 demux that splits sessions on this shared face, the forwarding element to the genuine origin, and the credential exchange (Invariant 3) are the edge proper; the L3 attach proven in [component 05](05-session-sandbox.md) terminates without them until the edge is built.
 
 ## Failure modes
 


### PR DESCRIPTION
## What

ADR-0021 fixes **how** a sandbox session's outbound bytes physically reach the Egress trust-edge's L3 hop — the attach half that [ADR-0008](../blob/next/v1/docs/architecture/adr/0008-session-egress-attribution.md) (attribution) assumed but never decided.

**Decision:** bytes reach the edge over a **host-root-netns listener bound on the per-session bridge gateway IP** — an ordinary `net.Listen` on the address `NetworkCreate` already carries. No `ip link`, no netns entry, no `CAP_NET_ADMIN`, so it does not regress the SDK-only `DropEgress`. The per-session bridge stays `Internal: true`; the attach opens no cross-session L3 hole. The v1 stand-in **terminates** the bytes and owns the deny decision; the L7 demux, the real upstream egress, and the forwarding element are the component-06 edge, **deferred**.

## Why this is sound, not speculative

Proven non-vacuous in component-05 (`ocu-sandbox` PR #35, merged `465ed60`) under **both** `runc` and `runsc`:

- **Transit** — a guest nonce to its gateway IP crosses the container-netns → host-root-netns boundary and lands at the stand-in (a real byte landing, not just a socket existing).
- **Negative gate (keystone)** — the deny path is proven a **packet drop on a route that is live under a positive control**: the test reaches a sibling guest from the host root netns (fails if the route is dead), *then* asserts the deny path forwarded zero. Cross-session isolation (NFR-SEC-22) shown by a packet that does not pass, not an absent route.

## Scope boundary (no overclaim)

The ADR and the component-05 doc-comment both fix verbatim: *L3 attach proven; stand-in terminates, not yet a forwarding/NAT element; L7 demux + real upstream egress + forwarding element = component-06, deferred.*

## Changes

- `adr/0021-egress-l3-attach-seam.md` (new, 62 lines, Nygard, companion to 0008)
- `components/05-session-sandbox.md` — invariant 15 (host-driven attach, deny-all, advisory-reaped); `adr:` +0021
- `components/06-egress-trust-edge.md` — invariant 10 (L3 ingress face, forwarding deferred); `adr:` +0021
- `adr/README.md` — 0021 row

Doc-slop reviewer: 0 blockers (1 warning fixed). Cross-refs resolve; banned-vocab clean; line budget 62/200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)