### PR TITLE
docs(architecture): component-02 — Control publishes JWKS as a static artifact

### DIFF
--- a/docs/architecture/components/02-control-operator-api.md
+++ b/docs/architecture/components/02-control-operator-api.md
@@ -87,6 +87,8 @@ Control authors the denylist; the Egress trust-edge reads it and refuses a revok
 
 Config surface: the operator/lifecycle ingress listener and the gateway service-identity listener are distinct network endpoints (the NFR-SEC-52 separation). Per-caller create-rate, per-tenant concurrent-session and calls/min ceilings (NFR-COST-06), and the reserved lifecycle/revoke capacity (NFR-SEC-55) are the principal knobs.
 
+Control renders the Storage-JWT JWKS as a static artifact at `-jwks-path` (atomic write, re-rendered on key rotation); the deploy layer serves it over HTTP at the egress edge's `remote_jwks` URI ([ADR-0019](../adr/0019-egress-exchanges-filestore-credential.md) §35). Control adds no third listener — the two-listener invariant (§39, NFR-SEC-52) is unchanged; the JWKS is a published public-key artifact, not a network endpoint on the signing-key holder.
+
 Observability: this container emits OCSF on the audit fan-in for session create/destroy, every enumerated privileged action (NFR-SEC-45), and quota rejections, into the hash-chained pipeline ([`audit/audit-fanin`](../../../contracts/audit/audit-fanin.asyncapi.yaml), NFR-SEC-03). The audit-write is on the critical path of a privileged action (fail-closed), not a side-channel.
 
 Scaling axis: this is a one-per-deployment deployable, distinct from the per-session `[1..N]` executor it drives over the host-dials-guest control channel; the two are separate repositories, `ocu-control` and `ocu-sandbox` ([ADR-0017](../adr/0017-control-plane-repo-boundary.md)). The single-instance minimal shelf is in scope for the kill-switch-under-saturation target (NFR-SEC-55), so the capacity model reserves admission priority for the revoke route rather than scaling out. RTO/RPO of this plane is NFR-REL-01.


### PR DESCRIPTION
## What

Adds one paragraph to component-02 §88 (Config surface): Control renders the Storage-JWT JWKS as a **static artifact** at `-jwks-path` (atomic write, re-rendered on rotation); the deploy layer serves it over HTTP at the egress edge's `remote_jwks` URI.

## Why (c) static-artifact, not a JWKS listener

- **No third listener on the signing-key holder.** The two-listener invariant (§39, NFR-SEC-52) stays intact. The JWKS is public keys — a published artifact, not a credential endpoint. This is the standard JWKS-publish pattern (OIDC/KMS publish JWKS as a static document behind a CDN/gateway, not a live endpoint on the signer).
- **Reconciles cleanly with the consumer side.** ADR-0019 §35 already pins that the edge fetches over `remote_jwks` — an HTTP URL, which the deploy layer serves; it need not be a Control-served endpoint.
- **Topology-independent.** A deploy-served URL is reachable whether the edge is co-located or on another host (#175 open), so no co-location assumption is baked in.

## Why no ADR

The edge-fetch mechanism is already decided (ADR-0019 §35), and the two-listener invariant is already fixed (§39). Nothing is contested — this is an internal design detail of one component (content-routing tree §4 → component spec, not an ADR).

## Changes

- `components/02-control-operator-api.md` §88 — one paragraph.

Line budget 106/600; banned-vocab clean; ADR-0019/§39 cross-refs resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated operational documentation to clarify how JWT keys are served and confirm that existing network infrastructure constraints remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->