### PR TITLE
feat(contracts): freeze the admission tier-token vocabulary and pairing matrix

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -3,7 +3,7 @@
 
 ---
 status: draft
-last-reviewed: 2026-05-31
+last-reviewed: 2026-06-20
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
 ---
@@ -21,6 +21,7 @@ The wire contracts OCU defines or conforms to, one file per boundary. Read [`doc
 | `storage/file-ops.schema.json` | Object-store client RPC (in-guest mount client → object-store service) | JSON Schema 2020-12 | `json-schema` CI job |
 | `storage/file-artifact-api.schema.json` | Web UI file/artifact data plane (data-plane client → Web UI) | JSON Schema 2020-12 | `json-schema` CI job |
 | `audit/audit-fanin.asyncapi.yaml` | Audit event fan-in (five source channels → audit → SIEM) | AsyncAPI 3.0 / OCSF | `asyncapi` CI job |
+| `admission/runtime-tokens.schema.json` | Admission tier vocabulary (shared profile/tier-token + pairing matrix, resolved independently in control plane and sandbox) | JSON Schema 2020-12 | `json-schema` CI job |
 
 The storage surface is three files: the guest mount config (`mount-config`), the mount-plane RPC (`file-ops`), and the Web UI HTTP API (`file-artifact-api`). The two callers stay distinct — `file-ops` is the in-guest mount client's RPC to the object-store service (the narrow object-store client speaks the storage protocol guest-out, holds no signing key, and forwards the weak session JWT it was provisioned; the egress edge validates that JWT and exchanges it at the issuer for the real filestore credential, which the object-store service translates each verb into a storage-engine request against, and the engine enforces the scope), `file-artifact-api` is the data-plane client's HTTP surface to the Web UI. Not-yet-built surfaces (operator REST, session-setup gRPC, transparency-log envelope, mock servers) are tracked in `08-contracts.md` §5.
 

--- a/contracts/admission/runtime-tokens.schema.json
+++ b/contracts/admission/runtime-tokens.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.open-computer-use.dev/admission/runtime-tokens.schema.json",
+  "$comment": "SPDX-License-Identifier: FSL-1.1-Apache-2.0. Copyright (c) 2025 Open Computer Use Contributors. STATUS frozen (the tier wire-token vocabulary and the 9-cell pairing matrix are fixed; the microVM tier is pairing-valid but not capability-built in v1 GA, the per-session trust profile is deferred). The shared admission vocabulary contract for the sandbox runtime tier: the workload-trust profile enum, the runtime-tier WIRE tokens, and the workload-trust-profile x runtime-tier pairing matrix with its three outcome classes. This is NOT a wire message that crosses a session boundary at runtime: the tier is resolved independently from deployment configuration in BOTH the Control / operator API (component-02, deploy-time admission) and the Session sandbox (component-05, Invariant 8 re-validation as the last-line gate), and component-05 Invariant 8 requires the two to agree (NFR-SEC-38, ADR-0003). This schema is the single frozen reference both planes are checked against: a control plane MUST emit exactly these tier wire tokens and MUST produce admit/reject outcomes matching this matrix; the sandbox runtime seam MUST accept exactly these tokens and reject any other (fail-closed). The distinction this contract freezes: gVisor's runtime WIRE token is the string `runsc` (the value dockerd dispatches on) — the human label `gvisor` is a control-internal audit label on a different layer and is deliberately NOT part of this vocabulary; any synonym or case variant of a wire token is non-conformant. Pairing policy and the rejected cells live in NFR-SEC-38; the tier-selection axis (by deployment-wide workload-trust profile, never by data classification) lives in ADR-0003. Per-tier escape resistance is governed by NFR-SEC-02, the tier-downgrade alarm by NFR-SEC-39 (config.trust_profile.downgraded). Scope: docker/runc/runsc tiers; the microVM tier is named here as pairing-valid-but-deferred (open-computer-use #161), and the per-session trust profile is deferred (#162). This schema validates the SHAPE of a conforming token/matrix declaration; the runtime authority (admission runs before any mutable host state, no fallback, no tier substitution) is a peer invariant, not schema-checkable (NFR-SEC-38, component-05 Invariant 8).",
+
+  "title": "AdmissionRuntimeTokens",
+  "description": "The frozen workload-trust-profile and runtime-tier vocabulary plus the 9-cell pairing matrix. A conforming control plane and the sandbox each declare this same structure; the values below are the canon reference (NFR-SEC-38, ADR-0003).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profiles", "tier_wire_tokens", "matrix"],
+
+  "$defs": {
+    "WorkloadTrustProfile": {
+      "$comment": "Closed enum (NFR-SEC-38). The deployment-declared trust posture of the workloads a deployment admits; deployment configuration, never a per-request field. The per-session trust profile is deferred (#162).",
+      "type": "string",
+      "enum": ["trusted_operator", "internal_workforce", "untrusted"]
+    },
+    "RuntimeTierWireToken": {
+      "$comment": "Closed enum of the runtime-tier WIRE tokens (ADR-0003 code-tokens) — the exact strings the runtime seam dispatches on and a control plane must emit. `runsc` is the gVisor tier (the human label `gvisor` is a control-internal audit label on a different layer and is NOT a wire token). `firecracker` is the microVM tier (pairing-valid, capability-deferred in v1 GA, #161). No synonym, no case variant.",
+      "type": "string",
+      "enum": ["runc", "runsc", "firecracker"]
+    },
+    "PairingOutcome": {
+      "$comment": "The three outcome classes a (profile, tier) cell resolves to (NFR-SEC-38). `ga_live`: pairing-valid AND capability-built in v1 GA (admit, then run). `microvm_not_shipped`: pairing-valid by policy but the microVM tier is not capability-built in v1 GA (admit the pairing, then fail closed at the runtime seam) — the two-layer, defense-in-depth refusal. `pairing_rejected`: forbidden by pairing policy, a hard error at admission before the runtime is consulted. A control plane MAY collapse `microvm_not_shipped` into an admission-time reject (same end-state, both fail closed); only the end-state and `mismatch is a hard error` are mandated, the refusal layer is implementation latitude.",
+      "type": "string",
+      "enum": ["ga_live", "microvm_not_shipped", "pairing_rejected"]
+    },
+    "MatrixCell": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profile", "tier", "outcome"],
+      "properties": {
+        "profile": { "$ref": "#/$defs/WorkloadTrustProfile" },
+        "tier": { "$ref": "#/$defs/RuntimeTierWireToken" },
+        "outcome": { "$ref": "#/$defs/PairingOutcome" }
+      }
+    }
+  },
+
+  "properties": {
+    "profiles": {
+      "$comment": "The closed profile enum, restated as the authoritative set so a conforming declaration is checked against it by value.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/WorkloadTrustProfile" },
+      "minItems": 3,
+      "maxItems": 3,
+      "uniqueItems": true
+    },
+    "tier_wire_tokens": {
+      "$comment": "The closed wire-token enum, the frozen LAYER-B vocabulary a control plane is checked against by value.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/RuntimeTierWireToken" },
+      "minItems": 3,
+      "maxItems": 3,
+      "uniqueItems": true
+    },
+    "matrix": {
+      "$comment": "The full 9-cell NFR-SEC-38 pairing matrix as data: every (profile, tier) pair with its outcome class. Exactly 9 cells, one per (profile x tier) combination. The canon partition is 3 ga_live + 3 microvm_not_shipped + 3 pairing_rejected; 6 cells are valid by pairing rules (3 GA-deployable + 3 microVM-not-shipped) and 3 are pairing-rejected.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/MatrixCell" },
+      "minItems": 9,
+      "maxItems": 9,
+      "uniqueItems": true
+    }
+  },
+
+  "examples": [
+    {
+      "$comment": "The canon reference values (NFR-SEC-38, ADR-0003). A conforming declaration on either plane equals this set: trusted_operator runs runc (the one-click solo default) or the stronger runsc; internal_workforce runs runsc; both may pair with microVM (deferred); untrusted pairs only with microVM (deferred). runc for a weaker-than-trusted_operator profile, and runsc for untrusted, are pairing-rejected.",
+      "profiles": ["trusted_operator", "internal_workforce", "untrusted"],
+      "tier_wire_tokens": ["runc", "runsc", "firecracker"],
+      "matrix": [
+        { "profile": "trusted_operator", "tier": "runc", "outcome": "ga_live" },
+        { "profile": "trusted_operator", "tier": "runsc", "outcome": "ga_live" },
+        { "profile": "trusted_operator", "tier": "firecracker", "outcome": "microvm_not_shipped" },
+        { "profile": "internal_workforce", "tier": "runc", "outcome": "pairing_rejected" },
+        { "profile": "internal_workforce", "tier": "runsc", "outcome": "ga_live" },
+        { "profile": "internal_workforce", "tier": "firecracker", "outcome": "microvm_not_shipped" },
+        { "profile": "untrusted", "tier": "runc", "outcome": "pairing_rejected" },
+        { "profile": "untrusted", "tier": "runsc", "outcome": "pairing_rejected" },
+        { "profile": "untrusted", "tier": "firecracker", "outcome": "microvm_not_shipped" }
+      ]
+    }
+  ]
+}

--- a/contracts/admission/runtime-tokens.schema.json
+++ b/contracts/admission/runtime-tokens.schema.json
@@ -60,7 +60,109 @@
       "items": { "$ref": "#/$defs/MatrixCell" },
       "minItems": 9,
       "maxItems": 9,
-      "uniqueItems": true
+      "uniqueItems": true,
+      "allOf": [
+        {
+          "contains": {
+            "type": "object",
+            "required": ["profile", "tier", "outcome"],
+            "properties": {
+              "profile": { "const": "trusted_operator" },
+              "tier": { "const": "runc" },
+              "outcome": { "const": "ga_live" }
+            }
+          }
+        },
+        {
+          "contains": {
+            "type": "object",
+            "required": ["profile", "tier", "outcome"],
+            "properties": {
+              "profile": { "const": "trusted_operator" },
+              "tier": { "const": "runsc" },
+              "outcome": { "const": "ga_live" }
+            }
+          }
+        },
+        {
+          "contains": {
+            "type": "object",
+            "required": ["profile", "tier", "outcome"],
+            "properties": {
+              "profile": { "const": "trusted_operator" },
+              "tier": { "const": "firecracker" },
+              "outcome": { "const": "microvm_not_shipped" }
+            }
+          }
+        },
+        {
+          "contains": {
+            "type": "object",
+            "required": ["profile", "tier", "outcome"],
+            "properties": {
+              "profile": { "const": "internal_workforce" },
+              "tier": { "const": "runc" },
+              "outcome": { "const": "pairing_rejected" }
+            }
+          }
+        },
+        {
+          "contains": {
+            "type": "object",
+            "required": ["profile", "tier", "outcome"],
+            "properties": {
+              "profile": { "const": "internal_workforce" },
+              "tier": { "const": "runsc" },
+              "outcome": { "const": "ga_live" }
+            }
+          }
+        },
+        {
+          "contains": {
+            "type": "object",
+            "required": ["profile", "tier", "outcome"],
+            "properties": {
+              "profile": { "const": "internal_workforce" },
+              "tier": { "const": "firecracker" },
+              "outcome": { "const": "microvm_not_shipped" }
+            }
+          }
+        },
+        {
+          "contains": {
+            "type": "object",
+            "required": ["profile", "tier", "outcome"],
+            "properties": {
+              "profile": { "const": "untrusted" },
+              "tier": { "const": "runc" },
+              "outcome": { "const": "pairing_rejected" }
+            }
+          }
+        },
+        {
+          "contains": {
+            "type": "object",
+            "required": ["profile", "tier", "outcome"],
+            "properties": {
+              "profile": { "const": "untrusted" },
+              "tier": { "const": "runsc" },
+              "outcome": { "const": "pairing_rejected" }
+            }
+          }
+        },
+        {
+          "contains": {
+            "type": "object",
+            "required": ["profile", "tier", "outcome"],
+            "properties": {
+              "profile": { "const": "untrusted" },
+              "tier": { "const": "firecracker" },
+              "outcome": { "const": "microvm_not_shipped" }
+            }
+          }
+        }
+      ],
+      "$comment-allOf": "WHY the allOf-of-9-contains, not minItems/maxItems/uniqueItems alone: uniqueItems on objects is WHOLE-object uniqueness (shape-only), so it neither pins each (profile, tier) pair to its frozen outcome nor forbids a duplicate pair carrying a different outcome while another canonical pair goes missing. Each contains below requires the EXACT canonical (profile, tier, outcome) triple to be PRESENT; nine such requirements against exactly nine unique slots (maxItems 9 + uniqueItems) leave no room for a wrong-outcome, duplicate-pair, or missing-pair forgery. Only the frozen canon matrix validates. The array has no guaranteed element order, so this is order-independent (contains), not positional (prefixItems)."
     }
   },
 

--- a/docs/architecture/08-contracts.md
+++ b/docs/architecture/08-contracts.md
@@ -3,7 +3,7 @@
 
 ---
 status: draft
-last-reviewed: 2026-06-14
+last-reviewed: 2026-06-20
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
 ---
@@ -82,7 +82,7 @@ The control-plane RPC rule (breaking = major version + deprecation header) is ca
 
 ## 5. Schema artifacts
 
-This overview is the map; the schema files under `contracts/` own the field-level types. Seven schema files are drafted (the storage surface carries three — mount config, the mount-plane file-op RPC, the Web UI file/artifact API); the rest are not yet built. [`contracts/README.md`](../../contracts/README.md) is the navigator: how to read a schema file and what the `x-ocu-*` annotations mean.
+This overview is the map; the schema files under `contracts/` own the field-level types. Eight schema files are drafted (the storage surface carries three — mount config, the mount-plane file-op RPC, the Web UI file/artifact API); the rest are not yet built. [`contracts/README.md`](../../contracts/README.md) is the navigator: how to read a schema file and what the `x-ocu-*` annotations mean.
 
 Drafted (not merged):
 
@@ -92,6 +92,7 @@ Drafted (not merged):
 - `contracts/storage/mount-config.schema.json` and `contracts/storage/file-ops.schema.json` — the mount-plane mount config and file-op RPC (the file-op message bodies are tbd).
 - `contracts/storage/file-artifact-api.schema.json` — the Web UI file/artifact data plane (upload/list/download/getManifest/preview-render + the embed-token/CSP/CSRF envelope). Per-operation bodies are tbd, like the mount-plane RPC; the embed-token binding claim ([#217](https://github.com/Wide-Moat/open-computer-use/issues/217)) and preview-render parser isolation ([#218](https://github.com/Wide-Moat/open-computer-use/issues/218)) are tracked open items.
 - `contracts/audit/audit-fanin.asyncapi.yaml` — the OCSF fan-in (the compute-metering and saturation payloads are tbd, [#150](https://github.com/Wide-Moat/open-computer-use/issues/150)).
+- `contracts/admission/runtime-tokens.schema.json` — the admission tier vocabulary: the frozen workload-trust-profile and runtime-tier wire tokens and the 9-cell pairing matrix (NFR-SEC-38, [ADR-0003](adr/0003-sandbox-runtime-tier-ladder.md)). Not a runtime wire message — the tier is resolved independently in the Control / operator API (deploy-time admission) and the Session sandbox (Invariant 8 re-validation), and this schema is the single frozen reference both are checked against. STATUS `frozen`; the microVM tier is pairing-valid but capability-deferred ([#161](https://github.com/Wide-Moat/open-computer-use/issues/161)).
 
 Not built:
 


### PR DESCRIPTION
Adds `contracts/admission/runtime-tokens.schema.json` — the shared admission vocabulary contract for the sandbox runtime tier, the canon side of the HOST-03 cross-repo conformance work.

## What it freezes
- The closed **workload-trust-profile** enum (`trusted_operator` / `internal_workforce` / `untrusted`).
- The runtime-tier **WIRE tokens** (`runc` / `runsc` / `firecracker`) — the exact strings the runtime dispatches on.
- The **9-cell pairing matrix** with its three outcome classes: `ga_live` (3), `microvm_not_shipped` (3), `pairing_rejected` (3), per NFR-SEC-38 and ADR-0003.

## Why a schema, not a data file
`contracts-lint`'s `json-schema` job compiles `*.schema.json` via ajv (`--spec=draft2020`), so a JSON Schema is lint-covered with no new CI; a plain data JSON would be a lint orphan. The schema both **documents** (the `$comment` carries the prose contract + NFR/ADR anchors) and **validates** (const/enum on tokens + the fixed 9-cell structure express "exactly these tokens, exactly these cells" as a checkable contract). No separate CONTRACT.md — one source.

## The layer distinction it pins
gVisor's runtime **wire token is `runsc`** (the value the runtime dispatches on). The human label `gvisor` is a control-internal audit label on a different layer and is **deliberately not** in this vocabulary — a synonym or case variant is non-conformant. This is the cross-repo naming contract: a control plane MUST emit `runsc`, and the sandbox runtime seam MUST reject anything else, fail-closed.

## Not a runtime wire message
The tier does not cross a session boundary in v1 — it is resolved independently from deployment config in both the Control / operator API (deploy-time admission) and the Session sandbox (component-05 Invariant 8 re-validation as the last-line gate), which Invariant 8 requires to agree. This schema is the single frozen reference both planes are checked against. The microVM tier is named pairing-valid but capability-deferred (#161).

Registered in the `contracts/README.md` navigator and the `08-contracts.md` schema-artifacts index.

## Validation run locally
- `ajv-cli@5 compile --spec=draft2020 --strict=false` → valid.
- markdownlint (canon `.markdownlint.yaml`) → no new violations on changed docs.
- lexicon clean; English-only; SPDX in `$comment` per sibling schemas.

The sandbox side (the conformance test fixture asserting this same matrix + tokens) lands separately in ocu-sandbox PR #42. Both repos then vendor this golden by pinned canon-rev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation with metadata reflecting the addition of a new schema contract for admission runtime tokens.
  * Added comprehensive schema contract definition for admission runtime tokens, including validation rules and canonical pairing matrix examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->