### PR TITLE
feat(architecture): Files-API as the north contract of filestore (ADR-0023)

### DIFF
--- a/contracts/storage/file-artifact-api.schema.json
+++ b/contracts/storage/file-artifact-api.schema.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schemas.open-computer-use.dev/storage/file-artifact-api.schema.json",
-  "$comment": "SPDX-License-Identifier: FSL-1.1-Apache-2.0 | Copyright (c) 2025 Open Computer Use Contributors | File-artifact data plane, Web UI API (data-plane client -> Web UI service). HTTP+JSON REST plus the embeddable SPA, served on a dedicated file/UI ingress, NOT the MCP-tool-call listener. The Web UI service is its own deployable inside the Storage zone, alongside the object-store service (file-ops.schema.json) and the in-guest mount client (mount-plane). STATUS: TBD. Operation NAMES, the route shape, the three-axis authorization, the embed-token verify contract, the cookie/CSRF/CSP response envelope, and the body/archive/classification ceilings are sourced (PoC route shape) or NFR-derived (x-ocu-design / x-ocu-default); per-operation request/response BODIES are not pinned by any field-level source and are left unspecified. JSON Schema 2020-12 (json-schema.org). NFR-SEC-49, NFR-SEC-73, NFR-SEC-78, NFR-SEC-79, NFR-SEC-80, NFR-SEC-81, NFR-SEC-82, NFR-SEC-83, NFR-SEC-84.",
+  "$comment": "SPDX-License-Identifier: FSL-1.1-Apache-2.0 | Copyright (c) 2025 Open Computer Use Contributors | File-artifact data plane, Web UI API (data-plane client -> Web UI service). HTTP+JSON REST plus the embeddable SPA, served on a dedicated file/UI ingress, NOT the MCP-tool-call listener. The Web UI service is its own deployable inside the Storage zone, alongside the object-store service (file-ops.schema.json) and the in-guest mount client (mount-plane). STATUS: SUPERSEDED by ADR-0023 (Files-API north contract) — the public north op-shape is now the Files-API (/v1/files); the embed-token verify, cookie/CSRF/CSP envelope, and three-axis authorization survive as the auth/transport wrapper. See docs/architecture/adr/0023-files-api-north-contract.md. Operation NAMES, the route shape, the three-axis authorization, the embed-token verify contract, the cookie/CSRF/CSP response envelope, and the body/archive/classification ceilings are sourced (PoC route shape) or NFR-derived (x-ocu-design / x-ocu-default); per-operation request/response BODIES are not pinned by any field-level source and are left unspecified. JSON Schema 2020-12 (json-schema.org). NFR-SEC-49, NFR-SEC-73, NFR-SEC-78, NFR-SEC-79, NFR-SEC-80, NFR-SEC-81, NFR-SEC-82, NFR-SEC-83, NFR-SEC-84.",
   "title": "File-artifact data plane (Web UI API, TBD)",
-  "description": "The data-plane client HTTP API and embeddable SPA served by the Web UI service. Operation set and the auth/response envelope are fixed; per-operation message bodies are TBD until a field-level source pins them. Do not invent bodies, opaque object ids, list pagination, resumable upload, or share-by-link capability URLs — none are sourced for this surface. Fill each operation only when sourced.",
+  "description": "PoC north op-shape superseded by ADR-0023; the public north contract is now the Files-API (/v1/files) with an opaque, scope-bound, server-minted file_id and opaque-id cursor pagination. The auth/transport wrapper (embed-token verify, cookie/CSRF/CSP envelope, three-axis authorization) survives. Do not extend this PoC op-shape; new work lands on the Files-API surface per ADR-0023. Resumable upload and share-by-link capability URLs remain un-sourced for either surface.",
 
   "$defs": {
     "SchemaVersion": {
@@ -64,7 +64,7 @@
     },
 
     "FileEntry": {
-      "description": "List/metadata entry. Field names are sourced from the PoC list/outputs route shape; the union of the upload-list and output-list shapes. Object handle is the {filesystem_id, path} pair (the PoC addresses by chat-scope + relative path; it carries NO opaque object id, so none is modelled — inventing one is a P4-artifact-E3 traversal risk).",
+      "description": "List/metadata entry, superseded shape. The Files-API FileObject (ADR-0023) replaces FileEntry on the north surface: it carries an opaque, scope-bound, server-minted file_id whose traversal/enumeration risk is held by the scope-binding keystone (the resolver takes scope from the host-attested channel; a foreign or unknown file_id resolves to not_found, never forbidden), not by refusing an id. FileEntry stays the superseded PoC shape; field names are sourced from the PoC list/outputs route shape (the union of the upload-list and output-list shapes), addressed by {filesystem_id, path}. New work uses the FileObject per ADR-0023.",
       "type": "object",
       "additionalProperties": false,
       "required": ["name", "path", "size", "modified"],
@@ -308,7 +308,7 @@
         },
         "filesystem_id": { "$ref": "#/$defs/FilesystemId" },
         "object_handle": {
-          "description": "The {filesystem_id, path} handle (NOT an opaque object id — none exists in this surface).",
+          "description": "The resolved {filesystem_id, path} object reference logged on the audit event. The public north face addresses by the opaque, scope-bound file_id (ADR-0023); the event records the resolved object reference, not that public file_id.",
           "$ref": "#/$defs/RelativePath"
         },
         "byte_count": {
@@ -363,7 +363,7 @@
 
   "x-ocu-tbd-bodies": {
     "status": "tbd",
-    "reason": "No field-level source pins the per-operation request/response message bodies. The operation set, the route shape (chat-scope + relative path; ?download=1 -> attachment vs inline-by-MIME), the sourced list/metadata fields (FileEntry), the embed-token verify contract, the cookie/CSRF/CSP response envelope, and the body/archive/classification ceilings are known; full request/response bodies are not. Fill each entry below only when a field-level source exists; do not invent bodies, an opaque object id, list pagination, resumable/chunked upload, or share-by-link capability URLs — none are sourced for this surface.",
+    "reason": "Superseded by ADR-0023: the public north contract is now the Files-API (/v1/files) with an opaque, scope-bound, server-minted file_id and opaque-id cursor pagination; new work lands there, not on this PoC op-shape. The PoC route shape (chat-scope + relative path; ?download=1 -> attachment vs inline-by-MIME), the sourced list/metadata fields (FileEntry), the embed-token verify contract, the cookie/CSRF/CSP response envelope, and the body/archive/classification ceilings are the surviving auth/transport wrapper. Resumable/chunked upload and share-by-link capability URLs remain un-sourced for either surface.",
     "operations": {
       "upload": "POST to a {filesystem_id, path} target; multipart form field `file` (SOURCED). Response carries status + filename + size + md5 (SOURCED PoC shape). Bound by InboundBound (NFR-SEC-78); archive bodies validated pre-extraction (NFR-SEC-80); body classified on ingest (NFR-SEC-81). Full envelope TBD.",
       "listFiles": "GET list under a filesystem scope; returns FileEntry[] + total (SOURCED union of PoC uploads-list and outputs-list shapes). The unification of the two PoC route families into one operation is OCU-DESIGN. NO pagination cursor (PoC returns the full list; do not adopt one without a source). Full envelope TBD.",
@@ -371,7 +371,7 @@
       "download": "GET a {filesystem_id, path} object; ?download=1 -> Content-Disposition: attachment (octet-stream), else inline by real MIME (SOURCED). The Web UI service resolves downloadable at read (NFR-SEC-73); a non-downloadable object's byte path to the browser is refused. Full envelope TBD.",
       "downloadArchive": "GET the outputs of a filesystem scope as a zip; Content-Disposition: attachment (SOURCED PoC). Full envelope TBD.",
       "previewRender": "GET the embeddable SPA for a filesystem scope (SOURCED PoC SPA route). Render/parser isolation model is OCU-DESIGN with mechanism TBD (#218). Carries the SessionResponseEnvelope framing headers (NFR-SEC-83). Full envelope TBD.",
-      "delete": "NO PoC route. The operation exists by NFR (NFR-SEC-79 names delete in the Web UI activity set), but its request/response wire body is TBD — no field-level source pins it. Needs its own tracking issue before the body is filled. Do not invent it."
+      "delete": "ADR-0023 authorizes the DELETE /v1/files/{file_id} route on the Files-API north surface (the operation NFR-SEC-79 names in the Web UI activity set); it unlinks the handle so the file_id stops resolving and makes no byte-erasure guarantee. New work lands on that Files-API route, not on this superseded PoC op-shape."
     },
     "tbd-issues": {
       "embed-token-replay-binding": "https://github.com/Wide-Moat/open-computer-use/issues/217",

--- a/docs/architecture/adr/0023-files-api-north-contract.md
+++ b/docs/architecture/adr/0023-files-api-north-contract.md
@@ -14,7 +14,7 @@ license-impact: none
 threat-mitigation-link: ../06-threat-model.md
 ---
 
-The canonical public north contract of filestore is the de-facto Files-API shape (`/v1/files`), superseding the PoC custom op-shape while preserving the embed-token, cookie/CSRF/CSP, and three-axis-authz wrapper. Audience: anyone wiring an external file client into the Web UI, or editing the north-face contract or its handle model.
+The canonical public north contract of filestore is the de-facto Files-API shape (`/v1/files`), superseding the PoC custom op-shape while preserving the embed-token, cookie/CSRF/CSP, and three-axis-authz wrapper — for anyone wiring an external file client into the Web UI or editing the north-face contract or its handle model.
 
 # ADR-0023: Files-API as the north contract of filestore
 

--- a/docs/architecture/adr/0023-files-api-north-contract.md
+++ b/docs/architecture/adr/0023-files-api-north-contract.md
@@ -1,0 +1,79 @@
+<!-- SPDX-License-Identifier: FSL-1.1-Apache-2.0 -->
+<!-- Copyright (c) 2025 Open Computer Use Contributors -->
+
+---
+status: proposed
+last-reviewed: 2026-06-22
+owner: "@Wide-Moat/architects"
+applies-to: next/v1
+supersedes: ['contracts/storage/file-artifact-api.schema.json (PoC north op-shape: OperationName enum + {filesystem_id,path}-only handle model)']
+superseded-by: null
+amends: []
+compliance-impact: [SOC2-CC6.1, SOC2-CC7.2, ISO27001-A.8.15]
+license-impact: none
+threat-mitigation-link: ../06-threat-model.md
+---
+
+The canonical public north contract of filestore is the de-facto Files-API shape (`/v1/files`), superseding the PoC custom op-shape while preserving the embed-token, cookie/CSRF/CSP, and three-axis-authz wrapper. Audience: anyone wiring an external file client into the Web UI, or editing the north-face contract or its handle model.
+
+# ADR-0023: Files-API as the north contract of filestore
+
+## Status
+
+`proposed`
+
+## Context
+
+External clients hit the file API directly — `/v1/files` is the public data-plane surface, fronting the external data-plane client E5 ([`components/08-web-ui.md`](../components/08-web-ui.md)). The south `/v1/filestore/fs/<op>` surface is a different consumer: the in-guest rclone mount client speaks it as a POSIX/FUSE filesystem RPC ([`contracts/storage/file-ops.schema.json`](../../../contracts/storage/file-ops.schema.json)), authenticating with the egress-injected backend credential — a credential a browser cannot obtain. The two surfaces share one authorization spine (`filesystem_id` + `intent` + `downloadable`) but have different clients, auth, addressing, transport, and verbs.
+
+The PoC north op-shape ([`file-artifact-api.schema.json`](../../../contracts/storage/file-artifact-api.schema.json)) was a placeholder: seven custom ops over a `{filesystem_id, path}`-pair handle that carried no opaque object id. The shipped PoC file API (`/api/uploads`, `/api/outputs`, `/files/{chat_id}/...`, `/preview`) already serves humans the upload/list/download/preview quartet over browser auth — so the public surface is already file-management-shaped, and its model echoes the de-facto Files API supported by Anthropic and OpenAI. The recut keeps the cross-cutting auth/transport/audit wrapper intact ([invariants 1-4, 6, 8](../components/08-web-ui.md)) and honours the ephemeral-no-retention rule ([ADR-0010](0010-storage-backend-pluggable-adapter.md)).
+
+## Decision
+
+We will make the Files-API shape the canonical north contract of filestore — the public surface speaks Files-API natively rather than fronting a custom op-shape — because external clients hit the public surface directly and one open wire shape removes the adapter layer.
+
+- **Endpoints.** `POST /v1/files` (upload, `Create`), `GET /v1/files` (list, `Read`), `GET /v1/files/{file_id}` (metadata, `Read`), `GET /v1/files/{file_id}/content` (bytes, `Read`), `DELETE /v1/files/{file_id}` (`Delete`). These five replace the seven PoC ops. `getManifest` folds into a per-object `checksum_md5`; `downloadArchive` stays as a sibling OCU-extension route under the same cookie/CSP envelope, off `/v1/files`; `previewRender` stays an internal Web-UI SPA route.
+- **File object.** Anthropic-leaning dialect: `{id, type:"file", filename, mime_type, size_bytes, created_at (RFC-3339), downloadable, scope{id,type:"session"}, checksum_md5?}`. `id` is opaque and server-minted. No `expires_at`. List envelope is `{data, has_more, first_id, last_id}` with opaque-id cursors.
+- **Handle.** `file_id` resolves through a durable scope-bound mapping `file_id → {scope, object_ref, filename, mime, size, created_at, downloadable_policy_ref}`. The mapping holds metadata and a reference into the customer store, never customer bytes. It lives in the object-store service's own durable handle-store ([component-04](../components/04-object-store-service.md), a new on-disk fsync'd store beside the audit `FileSink`, `--handle-store` path flag; Postgres/engine-side impl deferred), not in the ephemeral within-session objectid store that backs the south mount RPC, and not in the control plane.
+- **Keystone invariant.** `file_id` is never a capability. The resolver always takes scope from the host-attested channel (embed-token + cookie), asserts `record.scope == attested_scope`, and on mismatch or no record returns `not_found`, never `forbidden` — so a `file_id` is durable but resolves only under its own attested scope. The `scope_mismatch` reason is reserved for the `authorization_metadata.filesystem_id` caller-hint axis; the `file_id`-resolve path emits only `not_found` (a cross-scope or unknown id is indistinguishable from non-existence — anti-enumeration).
+- **`downloadable`** is the read-time NFR-SEC-73 policy value surfaced through the Files-API field with a documented re-interpretation (read-time egress decision, not a create-time provenance bit); `intent=preview` stays non-downloadable regardless. `DELETE` unlinks the handle so the id stops resolving; the service owns no bytes, so it makes no byte-erasure guarantee. Symmetrically, a resolving `file_id` asserts the handle persists, not that the customer-store bytes still exist — `GET /v1/files/{file_id}/content` may resolve the handle and then fail re-fetch if the customer store dropped the bytes ([ADR-0010](0010-storage-backend-pluggable-adapter.md) makes no byte-durability promise).
+
+The south mount RPC (`file-ops.schema.json`) stays internal and untouched, including its weak-session-JWT-to-egress credential exchange ([ADR-0013](0013-storage-credential-custody.md), [ADR-0019](0019-egress-exchanges-filestore-credential.md)). The shared `AuthorizationMetadata` (`filesystem_id` + `intent` + `downloadable`) stays one referenced shape across both schemas — forking it into two near-copies is duplication and is rejected.
+
+## Consequences
+
+- Component [08](../components/08-web-ui.md): the seven-op `OperationName` enum and the `{filesystem_id, path}` `FileEntry` handle are superseded by the five Files-API endpoints and the opaque-`id` `FileObject`. Invariant 5 is recut from "the handle is the `{filesystem_id, path}` pair" to the scope-bound `file_id`-resolution rule; invariants 1-4, 6-8 hold unchanged. The embed-token verify, cookie/CSRF/CSP envelope, three-axis authz, ingest ceilings, and `DenyReason` survive frozen — `DenyReason` becomes the internal/audit reason, projected to the public Files-API error type with HTTP status authoritative.
+- Component [04](../components/04-object-store-service.md): gains the durable `file_id`→handle-record index (metadata + customer-store reference, never bytes) beside the audit `FileSink`. The OCSF `FileActivityEvent` `object_handle` field is recut for the north face: it logs the resolved `object_ref` / `{filesystem_id, path}`, not the public `file_id`; its "no opaque object id exists" note is dropped for the north surface. The ephemeral objectid store keeps its within-session lifecycle for the south mount RPC.
+- Component [02](../components/02-control-operator-api.md): unchanged. It keeps only the session↔`filesystem_id` binding it already owns; no file-handle table.
+- ADR-0010-clean: an `id ↔ handle` mapping is metadata-and-reference index-keeping, not customer-byte retention, WORM, versioning, or erasure duty — byte durability and erasure stay the customer store's duty. The service already owns durable fsync'd state (the audit hash-chain), so a durable handle index is the same persistence class, not a new capability.
+- Positive: external Anthropic/OpenAI-dialect file SDK clients point at the north face natively; persistence is honoured by the durable handle, not an ephemeral store. The opaque id the PoC schema warned against is made safe by the scope-binding rule.
+- Negative: the north face reintroduces an opaque object id and cursor pagination the PoC schema forbade; both are deliberate and gated on the now-durable, scope-bound handle home.
+
+## Alternatives considered
+
+- **Thin Files-API adapter over the custom north op-shape** — rejected: an adapter is a second layer over the same surface external clients hit directly.
+- **Files-API verb names on the south mount RPC** — rejected: a browser cannot present the egress-injected backend credential the mount requires, and the rclone client needs POSIX/FUSE verbs the five Files-API endpoints cannot express; a global-bearer surface on the guest leg re-creates the confused-deputy the no-cred-in-guest invariant kills.
+- **The durable handle registry in the control plane** — rejected: `file_id` is a storage concern; the object-store service already owns durable state and the scope-binding resolver, so the handle index belongs there, and a control-plane round-trip on every read is avoided.
+- **A separate `files-api-gateway` deployable** — deferred to v2; the minimal shelf serves the contract on the existing component-08 ingress.
+
+## Compliance impact
+
+- `SOC2-CC6.1` / `ISO27001-A.8.15`: the scope-binding rule re-derives authority from the host-attested channel per request; a `file_id` is never a capability and cross-scope resolution degrades to `not_found`, so the durable id adds no enumeration or confused-deputy path.
+- `SOC2-CC7.2`: every endpoint emits the unchanged gateway-authored, fail-closed OCSF `FileActivityEvent`; `Create`/`Read`/`Delete` map to the five endpoints, audit-write-failure still denies.
+
+## License impact
+
+None. The Files-API shape is the public, both-vendor de-facto standard adopted as the native north contract; the recut adds no bundled dependency.
+
+## Threat mitigation
+
+The opaque, durable `file_id` is the new surface this ADR introduces, and the scope-binding keystone is its mitigation: scope always comes from the host-attested channel, the id is asserted equal to its stored scope, and any mismatch resolves to `not_found` — so the traversal/enumeration risk the PoC schema guarded against by refusing an opaque id is held by binding instead. The auth/envelope/ingest/audit wrapper ([`06-threat-model.md`](../06-threat-model.md) §3) is unchanged.
+
+## Open questions
+
+1. OpenAI field-dialect alias view (`object`/`bytes`/epoch `created_at`/after-only cursor) as an edge serialization adapter over the same endpoints (tracking issue TBD).
+2. Engine-adapter delete semantics for customer-owned stores — handle-unlink vs requested byte-delete where the adapter exposes it (tracking issue TBD).
+3. Chat-message-embeddable session-scoped artifact URLs (the PoC `computer_link_filter` injects preview/archive links into chat) — how the Files-API surface emits a clickable URL alongside the raw `file_id` (tracking issue TBD).
+4. Preview rendering — the PoC `/preview/{chat_id}` SPA and inline-artifact URL promotion as an internal Web-UI route relating to a `file_id` (tracking issue TBD).
+5. Uploads-vs-outputs namespace split (human→sandbox vs sandbox→human, with the content-hash manifest for dedup sync) under the single `/v1/files` surface (tracking issue TBD).
+6. MCP-resource mirror — the same files surfaced as `file://uploads/{scope}/...` MCP resources reconciled with the Files-API `file_id` (tracking issue TBD).

--- a/docs/architecture/components/02-control-operator-api.md
+++ b/docs/architecture/components/02-control-operator-api.md
@@ -9,7 +9,7 @@ applies-to: next/v1
 compliance: []
 threat-model: 06-threat-model.md
 contract: null
-adr: [0004, 0013, 0017]
+adr: [0004, 0013, 0017, 0023]
 ---
 
 The only door to create or manage a session. Audience: engineers wiring the operator plane or auditing the kill-switch path.
@@ -38,7 +38,7 @@ There is no edge from the MCP gateway to the sandbox; every request to create or
 
 Two listeners back this container: an operator/lifecycle ingress and a gateway service-identity ingress, on distinct network endpoints. The kill-switch and force-kill routes exist only on the operator ingress. There is no storage-issuer listener: Control mints the weak Storage-JWT itself and holds its signing key as a config/secret mount, so no storage credential arrives on a network endpoint.
 
-Owned state: the session registry (live sessions, their `container_name` binding, tenant, quota counters) and the denylist (kill-switch state). This container is the sole custodian of both. No other component mutates either, and the guest holds no handle that reaches them.
+Owned state: the session registry (live sessions, their `container_name` binding, tenant, quota counters) and the denylist (kill-switch state). This container is the sole custodian of both. No other component mutates either, and the guest holds no handle that reaches them. The Files-API `file_id` handle-store is owned by the [object-store service](04-object-store-service.md), not the control plane — Control keeps only the session↔`filesystem_id` binding and no file-handle table ([ADR-0023](../adr/0023-files-api-north-contract.md)).
 
 Control mints and delivers the weak session JWT; relay and scope custody are in the table below ([ADR-0013](../adr/0013-storage-credential-custody.md)). Scrub-on-load is a requirement of the in-guest mount client ([`05-session-sandbox.md`](05-session-sandbox.md)), not Control behaviour. The upstream LLM credential never reaches Control; it reaches the Egress trust-edge over Envoy SDS ([ADR-0007](../adr/0007-egress-auth-mechanism.md)).
 

--- a/docs/architecture/components/04-object-store-service.md
+++ b/docs/architecture/components/04-object-store-service.md
@@ -9,7 +9,7 @@ applies-to: next/v1
 compliance: []
 threat-model: 06-threat-model.md
 contract: [contracts/storage/mount-config.schema.json, contracts/storage/file-ops.schema.json]
-adr: [0003, 0010, 0013, 0014, 0015, 0016]
+adr: [0003, 0010, 0013, 0014, 0015, 0016, 0023]
 ---
 
 The only door to storage. Audience: engineers and security reviewers implementing or auditing the storage path.
@@ -50,7 +50,8 @@ The file-operation verb names are fixed in [`file-ops`](../../../contracts/stora
 |---|---|
 | The `filesystem_id`→engine-prefix mapping | No storage-JWT signing key — the Control plane mints + holds it ([ADR-0013](../adr/0013-storage-credential-custody.md)) |
 | The storage-engine adapter selection (S3 or local volume) and its chunked-multipart transfer policy ([ADR-0010](../adr/0010-storage-backend-pluggable-adapter.md)) | No authorization authority — the engine validates the `filesystem_id` claim and rejects a foreign scope ([ADR-0013](../adr/0013-storage-credential-custody.md)) |
-| The engine credential where one exists — a network-engine key or a local-volume host-filesystem permission ([NFR-SEC-60](../manifesto/02-nfrs.md)) | No client-file API, embeddable SPA, or preview-render — those are the [Web UI](08-web-ui.md) |
+| The engine credential where one exists — a network-engine key or a local-volume host-filesystem permission ([NFR-SEC-60](../manifesto/02-nfrs.md)) | No client-file API, embeddable SPA, or preview-render — those are the [Web UI](08-web-ui.md); but the `file_id` handle-store and resolver the Web UI's Files-API surface calls are owned here ([ADR-0023](../adr/0023-files-api-north-contract.md)) |
+| The durable `file_id`→handle-record index for the Files-API north face — metadata plus a customer-store reference, never bytes; a fsync'd on-disk store beside the audit `FileSink` ([ADR-0010](../adr/0010-storage-backend-pluggable-adapter.md)-clean, [ADR-0023](../adr/0023-files-api-north-contract.md)) | Not the control plane's — Control keeps only the session↔`filesystem_id` binding and holds no file-handle table ([ADR-0023](../adr/0023-files-api-north-contract.md)) |
 
 The credential flow: the control plane delivers the weak session JWT into the mount config, the guest presents it to the edge as a static `Authorization: Bearer`, the edge exchanges it at the issuer for the real filestore credential and injects that credential, and the engine verifies the real credential ([ADR-0013](../adr/0013-storage-credential-custody.md), [ADR-0019](../adr/0019-egress-exchanges-filestore-credential.md)). The operation names and the three authorization axes are fixed in the bound schema; the per-operation field types are TBD there, not invented here ([`mount-config`](../../../contracts/storage/mount-config.schema.json), [`file-ops`](../../../contracts/storage/file-ops.schema.json)).
 

--- a/docs/architecture/components/08-web-ui.md
+++ b/docs/architecture/components/08-web-ui.md
@@ -9,7 +9,7 @@ applies-to: next/v1
 compliance: []
 threat-model: 06-threat-model.md
 contract: [contracts/storage/file-artifact-api.schema.json]
-adr: [0002, 0013, 0015, 0016, 0017]
+adr: [0002, 0013, 0015, 0016, 0017, 0023]
 ---
 
 The host-side file API and embeddable SPA an external data-plane client reaches to upload, preview, and download files; it calls the object-store service for every backend operation. Audience: engineers implementing or auditing the file data-plane surface.
@@ -31,7 +31,7 @@ The Web UI fronts one counterparty: the external data-plane client (E5). It does
 | internal | untrusted artifact body for validation and preview-render | Web UI → parser-sandbox | capability-free sub-boundary (below) |
 | outbound | OCSF File System Activity event per operation, fail-closed | Web UI → Audit pipeline (F10) | Published Language (OCSF) |
 
-The Web UI never reaches the storage engine; the object-store service is the one door to storage and speaks the backend leg ([ADR-0015](../adr/0015-storage-decomposition-by-trust-plane.md)). `F#` flow labels are defined in [`05-c4-container.md`](../05-c4-container.md) §4. The files surface is one entry in the descriptor-driven view list ([ADR-0002](../adr/0002-session-view-descriptor.md)); the deferred live-view surfaces ([#210](https://github.com/Wide-Moat/open-computer-use/issues/210)) sit outside this spec. The operation set, route shape, authorization axes, embed-token verify contract, response envelope, and size ceilings are frozen in [`file-artifact-api`](../../../contracts/storage/file-artifact-api.schema.json); per-operation message bodies are TBD there and not invented here.
+The Web UI never reaches the storage engine; the object-store service is the one door to storage and speaks the backend leg ([ADR-0015](../adr/0015-storage-decomposition-by-trust-plane.md)). `F#` flow labels are defined in [`05-c4-container.md`](../05-c4-container.md) §4. The files surface is one entry in the descriptor-driven view list ([ADR-0002](../adr/0002-session-view-descriptor.md)); the deferred live-view surfaces ([#210](https://github.com/Wide-Moat/open-computer-use/issues/210)) sit outside this spec. The public north op-shape is the Files-API (`/v1/files`) with an opaque, scope-bound `file_id` ([ADR-0023](../adr/0023-files-api-north-contract.md)); the embed-token verify, cookie/CSRF/CSP response envelope, three-axis authorization axes, and size ceilings survive as the auth/transport wrapper, frozen in [`file-artifact-api`](../../../contracts/storage/file-artifact-api.schema.json), and per-operation message bodies are TBD there and not invented here.
 
 ### Parser-sandbox sub-boundary
 
@@ -68,7 +68,7 @@ Each rule holds for any caller and is falsifiable by the named check. The reachi
 2. Every state-mutating call requires a server-validated CSRF token, and every UI/artifact response carries `CSP: frame-ancestors` from the per-deployment allowlist (NFR-SEC-83, NFR-SEC-84). Header values are fixed in [`08-contracts.md`](../08-contracts.md) §3.
 3. The Web UI holds no backend key and sends no OCU secret to the browser; the object-store service is the one door to storage and the Web UI reaches it over the host leg, never the storage engine directly ([ADR-0015](../adr/0015-storage-decomposition-by-trust-plane.md)) (unit-test + property-test, NFR-SEC-82, NFR-SEC-25).
 4. Authorization (scope `filesystem_id` + intent `read`/`write`/`preview` + downloadable) is re-derived per request, deny-by-default, keyed on the authenticated caller; a `preview`-authorized caller cannot invoke `download` or `write`, and `intent=preview` stays read-only and non-downloadable regardless of stored tag (property-test, NFR-SEC-49, NFR-SEC-73).
-5. No file operation resolves a handle outside the request's `filesystem_id` scope; the handle is the `{filesystem_id, path}` pair, and traversal, symlink, absolute-path, and URL-shaped handles are rejected before any object-store-service call (property-test, NFR-SEC-49, NFR-SEC-80).
+5. The handle is an opaque, server-minted, scope-bound `file_id` ([ADR-0023](../adr/0023-files-api-north-contract.md)); the resolver always takes scope from the host-attested channel (embed-token + cookie) and refuses any `file_id` outside the attested `filesystem_id` scope, returning `not_found` (never `forbidden`) so a cross-scope or unknown id is indistinguishable from non-existence (anti-enumeration); traversal, symlink, absolute-path, and URL-shaped inputs are still rejected before any object-store-service call (property-test, NFR-SEC-49, NFR-SEC-80).
 6. An inbound body above the configured ceiling is rejected pre-buffer, never partially staged; an archive body is validated (uncompressed total, entry count, traversal, symlink) and content-classified before extraction (schema-validation + property-test, NFR-SEC-78, NFR-SEC-80, NFR-SEC-81).
 7. Preview-render and archive validation run in the parser-sandbox; a body the parser rejects mints no session state and reaches no credential ([#218](https://github.com/Wide-Moat/open-computer-use/issues/218)) (isolation assertion, NFR-SEC-25, NFR-SEC-49).
 8. Every file operation emits an OCSF File System Activity event into the hash-chained pipeline before the operation is acknowledged, under host-attested identity; an audit-write failure denies the operation (unit-test, NFR-SEC-79).


### PR DESCRIPTION
## What

Makes the **Files-API shape (`/v1/files`) the canonical public north contract** of filestore, superseding the PoC custom op-shape. External clients hit the public file API directly; the de-facto standard both Anthropic and OpenAI expose is adopted as the native north contract. The south `/v1/filestore/fs/<op>` rclone-mount RPC is a **different consumer** (machine FUSE client over an egress-injected credential a browser cannot hold) and stays **internal, untouched**.

## Why

A side-by-side review (south `fs/<op>` vs the shipped PoC file API vs the Files-API) confirmed the two surfaces are genuinely different consumers over one shared authorization spine:
- `fs/<op>` = machine mount protocol (POSIX/FUSE verbs, edge-injected backend credential, in-guest rclone client). A browser cannot present its credential.
- The shipped PoC file API (`/api/uploads`, `/api/outputs`, `/files/{chat_id}`, `/preview`) already serves humans the upload/list/download/preview quartet over browser auth — empirically the frontend needs the Files-API shape.

## Changes (coordinated, no self-contradiction)

- **ADR-0023** (new): five `/v1/files` endpoints replace the seven PoC ops; opaque, scope-bound, server-minted `file_id`; durable handle-store in the **object-store service (component-04)**, beside the audit `FileSink`, **not** the control plane; keystone invariant `file_id`-is-never-a-capability (scope from the host-attested channel, foreign id → `not_found`); `downloadable` as the read-time policy value.
- **file-artifact-api.schema.json**: `STATUS` → superseded-by ADR-0023; the PoC prohibitions on an opaque id and cursor pagination are lifted (now sourced to ADR-0023); the auth/transport wrapper (embed-token verify, cookie/CSRF/CSP, three-axis authz, ingest ceilings, `DenyReason`) survives frozen (partial supersession).
- **component-08**: invariant 5 recut to the scope-bound `file_id` resolution rule.
- **component-04**: durable `file_id`→handle-record index added to Owned state (metadata + a customer-store reference, never bytes; ADR-0010-clean).
- **component-02**: clarified it owns no file-handle table.

## Invariants preserved

- The south mount RPC (`file-ops.schema.json`) is **unchanged** (0 diff).
- The shared three-axis `AuthorizationMetadata` stays one shape (not forked).
- ADR-0010-clean: a handle mapping is metadata-and-reference index-keeping, not customer-byte retention — the object-store service already owns durable fsync'd state (the audit hash-chain).
- The 3 honesty fixes are in the ADR: OCSF `object_handle` logs the resolved `object_ref` not the public `file_id`; a resolving `file_id` asserts the handle persists, not that the bytes still exist; `scope_mismatch` reserved for the caller-hint axis, `file_id`-resolve emits only `not_found`.

## Deferred (Open questions, tracking issues)

The 4 PoC frontend extras — chat-embeddable artifact links, the preview SPA, the uploads/outputs namespace split, the MCP-resource mirror — are recorded as Open questions, not built in this change.

## Verification

- ADR ≤200 lines (79), Nygard format, front-matter complete, no banned vocabulary.
- Adversarial cross-consistency check (8 axes): PASS — no schema-vs-ADR contradiction, custody consistent (component-04, not control-plane), south untouched, authz not forked, all 3 fixes present, back-links in all affected components.
- Schema JSON well-formed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Formalized the Files-API as the official public contract, superseding the previous proof-of-concept interface.
  * Documented the `/v1/files` lifecycle endpoints (including archive download) and the opaque, server-minted `file_id` model with scope-bound resolution.
  * Updated the security invariants to reduce enumeration risk and clarified transport/auth wrapper behavior and `DELETE` semantics.
* **Schema / Contract Updates**
  * Refreshed the public contract documentation to align with ADR-0023, including audit event `object_handle` meaning and updated delete operation descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->