### PR TITLE
docs(adr-0023): status proposed -> accepted (ratified on merge)

### DIFF
--- a/docs/architecture/adr/0023-files-api-north-contract.md
+++ b/docs/architecture/adr/0023-files-api-north-contract.md
@@ -2,7 +2,7 @@
 <!-- Copyright (c) 2025 Open Computer Use Contributors -->
 
 ---
-status: proposed
+status: accepted
 last-reviewed: 2026-06-22
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
@@ -20,7 +20,7 @@ The canonical public north contract of filestore is the de-facto Files-API shape
 
 ## Status
 
-`proposed`
+`accepted`
 
 ## Context
 


### PR DESCRIPTION
Flips ADR-0023 status `proposed` → `accepted` (front-matter + body).

Per PROCESS.md the ADR status flips to `accepted` on merge; the owner ratified ADR-0023 by ordering the merge of #298. This is a bookkeeping fix so the canon is self-consistent — the decision is already in canon and the implementer (component-04 durable handle-store) is released to build against it.

No content change beyond the two status fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)