### PR TITLE
docs(adr-0004): status proposed → accepted (ratify on owner merge)

### DIFF
--- a/docs/architecture/adr/0004-operator-authentication-substrate.md
+++ b/docs/architecture/adr/0004-operator-authentication-substrate.md
@@ -2,8 +2,8 @@
 <!-- Copyright (c) 2025 Open Computer Use Contributors -->
 
 ---
-status: proposed
-last-reviewed: 2026-06-01
+status: accepted
+last-reviewed: 2026-06-27
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
 supersedes: []
@@ -19,7 +19,7 @@ Fixes how a human operator and an automated SOAR caller authenticate to the Cont
 
 ## Status
 
-`proposed`
+`accepted`
 
 ## Context
 


### PR DESCRIPTION
## What

Flip ADR-0004 (operator authentication substrate) front-matter `status: proposed → accepted`, in both the front-matter and the Status section.

## Why

ADR-0004 has shipped in the canon since the initial public release (466ee20) and is load-bearing: `components/02-control-operator-api.md` carries `adr: [0004, ...]` and treats the substrate as fixed (operator credential on ingress §53, substrate fixed §106). Its front-matter stayed `proposed` — an orphan status, not a live gate.

This mirrors the ADR-0023 bookkeeping fix (#299): per `PROCESS.md` the status flips to `accepted` on the owner ordering the merge. **The flip itself is owner-ratified by merging this PR** — I am not asserting acceptance, the merge is the ratification.

## Unblocks

The admin read-identity gate (ocu-admin Phase-5) rests on an accepted operator-auth substrate; this removes the orphan-`proposed` from that path. Phase-5's only remaining real gate is then `ocu-control` read.go live.

## Scope

One file, status-only. No semantic change to the decision. Bookkeeping so the canon is self-consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the architecture decision record to show it has been accepted.
  * Refreshed the review date to the latest date.
  * The visible status in the document now reflects the accepted state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->