### PR TITLE
docs(adr): ratify 0022/0024/0025/0026/0027 proposed → accepted

### DIFF
--- a/docs/architecture/adr/0022-admin-read-surface.md
+++ b/docs/architecture/adr/0022-admin-read-surface.md
@@ -2,8 +2,8 @@
 <!-- Copyright (c) 2025 Open Computer Use Contributors -->
 
 ---
-status: proposed
-last-reviewed: 2026-06-27
+status: accepted
+last-reviewed: 2026-06-28
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
 supersedes: []
@@ -20,7 +20,7 @@ The read-only operator console reaches the Control plane through a server-side B
 
 ## Status
 
-`proposed`
+`accepted`
 
 ## Context
 

--- a/docs/architecture/adr/0024-host-side-session-driver.md
+++ b/docs/architecture/adr/0024-host-side-session-driver.md
@@ -2,8 +2,8 @@
 <!-- Copyright (c) 2025 Open Computer Use Contributors -->
 
 ---
-status: proposed
-last-reviewed: 2026-06-23
+status: accepted
+last-reviewed: 2026-06-28
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
 supersedes: []
@@ -66,4 +66,4 @@ This carries ADR-0017's "thin control driver for [component-02]" (0017:48) to th
 
 ## Status
 
-Proposed (2026-06-23). Amends ADR-0017. Separate from ADR-0018 (control-RPC), ADR-0019 (storage JWT), and ADR-0021 (egress attach).
+Accepted (ratified on merge of #303). Amends ADR-0017. Separate from ADR-0018 (control-RPC), ADR-0019 (storage JWT), and ADR-0021 (egress attach).

--- a/docs/architecture/adr/0025-f9-internal-transport.md
+++ b/docs/architecture/adr/0025-f9-internal-transport.md
@@ -2,8 +2,8 @@
 <!-- Copyright (c) 2025 Open Computer Use Contributors -->
 
 ---
-status: proposed
-last-reviewed: 2026-06-26
+status: accepted
+last-reviewed: 2026-06-28
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
 supersedes: []
@@ -20,7 +20,7 @@ The F9 hop — how the component-08 BFF reaches component-04 to resolve a durabl
 
 ## Status
 
-`proposed`
+`accepted`
 
 ## Context
 

--- a/docs/architecture/adr/0026-parser-sandbox-substrate.md
+++ b/docs/architecture/adr/0026-parser-sandbox-substrate.md
@@ -2,8 +2,8 @@
 <!-- Copyright (c) 2025 Open Computer Use Contributors -->
 
 ---
-status: proposed
-last-reviewed: 2026-06-27
+status: accepted
+last-reviewed: 2026-06-28
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
 supersedes: []
@@ -20,7 +20,7 @@ The isolation substrate for reading an untrusted artifact body is chosen per ren
 
 ## Status
 
-`proposed` — amends [ADR-0015](0015-storage-decomposition-by-trust-plane.md), resolves its Open Question 1 and [component-08](../components/08-web-ui.md) Open Question 1.
+`accepted` — amends [ADR-0015](0015-storage-decomposition-by-trust-plane.md), resolves its Open Question 1 and [component-08](../components/08-web-ui.md) Open Question 1.
 
 ## Context
 

--- a/docs/architecture/adr/0027-mcp-caller-static-api-key-auth.md
+++ b/docs/architecture/adr/0027-mcp-caller-static-api-key-auth.md
@@ -2,8 +2,8 @@
 <!-- Copyright (c) 2025 Open Computer Use Contributors -->
 
 ---
-status: proposed
-last-reviewed: 2026-06-27
+status: accepted
+last-reviewed: 2026-06-28
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
 supersedes: []
@@ -20,7 +20,7 @@ Names the minimal-shelf MCP-caller credential: a per-caller static `sk-` API key
 
 ## Status
 
-`proposed`
+`accepted`
 
 ## Context
 


### PR DESCRIPTION
## What

Flip `status: proposed → accepted` (front-matter + Status body) on the five ADRs whose introducing PRs already merged to `next/v1`:

| ADR | introducing PR |
|---|---|
| 0022 admin read-surface | #310 |
| 0024 host-side session driver | #303 |
| 0025 F9 internal transport | #305 |
| 0026 parser-sandbox substrate | #307 |
| 0027 MCP-caller static API-key auth | #311 |

## Why

The merge of an introducing PR does not flip the ADR status — it stayed `proposed`, an orphan status. A builder reading a landed decision's status had to treat it as not-yet-accepted (gv76tkct flagged this firsthand on ADR-0025). This mirrors the ADR-0004 / ADR-0023 bookkeeping fixes (#312 / #299): the status flips to `accepted` on the owner ordering those merges. **Merging this PR is the ratification.**

`last-reviewed` bumped to 2026-06-28. No decision content changed — status-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several architecture decision records to reflect final approval status.
  * Advanced review dates and refreshed in-document status text across the affected entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->