### PR TITLE
feat(contracts): freeze the mcp-key-set artifact and operator mcp-key verbs (ADR-0027)

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -15,6 +15,7 @@ The wire contracts OCU defines or conforms to, one file per boundary. Read [`doc
 | File | Surface | Format | Validated by |
 |---|---|---|---|
 | `mcp/2025-06-18/ocu-constraints.schema.json` | Agent tool-call ingress (caller → MCP gateway) | JSON Schema 2020-12 (MCP conform profile) | `json-schema` CI job |
+| `mcp/mcp-key-set.schema.json` | MCP hashed-key-set (control plane → MCP gateway boot-set, ADR-0027) | JSON Schema 2020-12 | `json-schema` CI job |
 | `exec/exec-channel.schema.json` | Exec / PTY+CDP (control API → sandbox, machine-to-machine) | JSON Schema 2020-12 | `json-schema` CI job |
 | `control/control-rpc.schema.json` | Control → guest control-RPC (control plane → sandbox, over a host-owned UDS) | JSON Schema 2020-12 | `json-schema` CI job |
 | `storage/mount-config.schema.json` | Mount-plane mount config (control plane → in-guest mount client) | JSON Schema 2020-12 | `json-schema` CI job |

--- a/contracts/mcp/2025-06-18/ocu-constraints.schema.json
+++ b/contracts/mcp/2025-06-18/ocu-constraints.schema.json
@@ -171,15 +171,16 @@
       "unconditional": [
         "Bearer token MUST NOT appear in the URI query.",
         "The caller credential MUST NOT be passed through to upstream or the sandbox; the trust edge injects custody credentials (NFR-SEC-23, NFR-SEC-27). The caller key is never forwarded onto F5 or into the sandbox.",
-        "Origin header MUST be validated (DNS-rebinding); local binds use 127.0.0.1 not 0.0.0.0 (NFR-SEC-43)."
+        "Origin header MUST be validated (DNS-rebinding); local binds use 127.0.0.1 not 0.0.0.0 (NFR-SEC-43).",
+        "A 401 carries a `WWW-Authenticate: Bearer` challenge in BOTH modes (the shipped gateway sets `Bearer realm=\"ocu-mcp-gateway\"`); the oauth2-rs mode additionally points it at the RFC 9728 resource-metadata URL."
       ],
       "static-key": [
         "The presented sk-ocu- bearer MUST resolve to a non-expired, non-revoked record in this gateway's boot-loaded hashed-key set; the gateway hashes the presented key and constant-time-compares. A key not in this deployment's set is refused with HTTP 401 (ADR-0027, NFR-SEC-87).",
-        "Tenant and permitted surface come from the resolved record, never from the request body or a claim in the key."
+        "Tenant and deployment scope come from the resolved record, never from the request body or a claim in the key."
       ],
       "oauth2-rs": [
         "Token MUST name this MCP server in its audience claim (RFC 8707); reject otherwise with HTTP 401.",
-        "On 401, WWW-Authenticate points to the RFC 9728 resource-metadata URL."
+        "On 401, the WWW-Authenticate Bearer challenge additionally points to the RFC 9728 resource-metadata URL."
       ]
     }
   },

--- a/contracts/mcp/2025-06-18/ocu-constraints.schema.json
+++ b/contracts/mcp/2025-06-18/ocu-constraints.schema.json
@@ -158,16 +158,30 @@
   },
 
   "x-ocu-authz": {
-    "$comment": "NFR-SEC-09 — audience-validated authz. Carried on the HTTP transport, not in the JSON-RPC body; documented here as a binding gateway rule.",
-    "model": "OAuth 2.1 Resource Server",
+    "$comment": "NFR-SEC-09 — the inbound caller MUST authenticate; no anonymous or shared path on either shelf. Carried on the HTTP transport, not in the JSON-RPC body; documented here as a binding gateway rule. ADR-0027 splits the model by shelf: the minimal shelf validates a per-caller static sk-ocu- API key in-process against a Control-minted boot-loaded hashed-key set (contracts/mcp/mcp-key-set.schema.json); the full shelf runs the OAuth 2.1 Resource Server relying-party flow against the customer IdP. The Origin-validation and no-passthrough rules are UNCONDITIONAL on both modes; the RFC 8707 audience and RFC 9728 resource-metadata rules are CONDITIONAL on the oauth2-rs mode (an opaque sk key carries no audience claim — its tenant/deployment scope is read from the resolved record). Both modes share the Authorization: Bearer credential header.",
+    "mode": {
+      "$comment": "The caller-authN mode, selected by deployment shelf (ADR-0027). A DEPLOYMENT-LEVEL selector, not a per-request wire field.",
+      "enum": ["static-key", "oauth2-rs"],
+      "default": "static-key",
+      "static-key": "Minimal shelf: a per-caller static sk-ocu- API key, Control-minted, salted-hash-at-rest, resolved in-process against the boot-loaded hashed-key set (contracts/mcp/mcp-key-set.schema.json). A key absent from this deployment's set is refused with 401; tenant and deployment scope are read from the resolved record, never from a claim in the opaque key.",
+      "oauth2-rs": "Full shelf: OAuth 2.1 Resource Server. The bearer is a customer-IdP-issued token whose audience claim names this MCP server (RFC 8707); OCU is always the relying party, never an in-house JWT issuer (NFR-FLEX-03)."
+    },
     "credential-header": "Authorization: Bearer <token>",
-    "rules": [
-      "Token MUST name this MCP server in its audience claim (RFC 8707); reject otherwise with HTTP 401.",
-      "Bearer token MUST NOT appear in the URI query.",
-      "The caller token MUST NOT be passed through to upstream or the sandbox; the trust edge injects custody credentials (NFR-SEC-23, NFR-SEC-27).",
-      "On 401, WWW-Authenticate points to the RFC 9728 resource-metadata URL.",
-      "Origin header MUST be validated (DNS-rebinding); local binds use 127.0.0.1 not 0.0.0.0 (NFR-SEC-43)."
-    ]
+    "rules": {
+      "unconditional": [
+        "Bearer token MUST NOT appear in the URI query.",
+        "The caller credential MUST NOT be passed through to upstream or the sandbox; the trust edge injects custody credentials (NFR-SEC-23, NFR-SEC-27). The caller key is never forwarded onto F5 or into the sandbox.",
+        "Origin header MUST be validated (DNS-rebinding); local binds use 127.0.0.1 not 0.0.0.0 (NFR-SEC-43)."
+      ],
+      "static-key": [
+        "The presented sk-ocu- bearer MUST resolve to a non-expired, non-revoked record in this gateway's boot-loaded hashed-key set; the gateway hashes the presented key and constant-time-compares. A key not in this deployment's set is refused with HTTP 401 (ADR-0027, NFR-SEC-87).",
+        "Tenant and permitted surface come from the resolved record, never from the request body or a claim in the key."
+      ],
+      "oauth2-rs": [
+        "Token MUST name this MCP server in its audience claim (RFC 8707); reject otherwise with HTTP 401.",
+        "On 401, WWW-Authenticate points to the RFC 9728 resource-metadata URL."
+      ]
+    }
   },
 
   "x-ocu-error-model": {

--- a/contracts/mcp/mcp-key-set.schema.json
+++ b/contracts/mcp/mcp-key-set.schema.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "SPDX-License-Identifier: FSL-1.1-Apache-2.0 | Copyright (c) 2025 Open Computer Use Contributors | STATUS frozen (Artifact-2, the Control->gateway hashed-key-set). The config-plane boot-set the MCP gateway loads at boot to validate a presented sk-ocu- caller key in-process (ADR-0027). Control mints the key (occ mcp-key create), stores the salted hash, and re-renders this set on every mint/revoke; the gateway hashes the presented bearer and constant-time-compares against these records. This is delivered over the same config plane that carries the gateway's signing material, NEVER a per-request Control lookup (component-01 no-state-that-outlives-a-request invariant is kept: the set is configuration, not request-derived state). FENCED SURFACE: hashes + salts only. No plaintext secret, no sk-ocu- key, no unsalted digest, no signing key ever appears here; additionalProperties:false at both levels forbids smuggling one in. The published subset is fail-closed to the ACTIVE, non-expired records: a revoked or expired key is OMITTED before render, so status is always \"active\" on the wire (a key absent from this set is refused with 401 at the gateway). The \"revoked\" enum value is present for at-rest generality with the single Record type, not because a revoked record is ever published here. This schema validates the SHAPE; the omit-before-render, boot-refresh-within-5-min (NFR-SEC-04), and constant-time comparison are peer invariants, not schema-checkable (NFR-SEC-87, ADR-0027). JSON Schema 2020-12 (json-schema.org).",
+  "$comment": "SPDX-License-Identifier: FSL-1.1-Apache-2.0 | Copyright (c) 2025 Open Computer Use Contributors | STATUS frozen (Artifact-2, the Control->gateway hashed-key-set). The config-plane boot-set the MCP gateway loads at boot to validate a presented sk-ocu- caller key in-process (ADR-0027). Control mints the key (occ mcp-key create), stores the salted hash, and re-renders this set on every mint/revoke; the gateway hashes the presented bearer and constant-time-compares against these records. This is delivered over the same config plane that carries the gateway's signing material, NEVER a per-request Control lookup (component-01 no-state-that-outlives-a-request invariant is kept: the set is configuration, not request-derived state). FENCED SURFACE: hashes + salts only. No plaintext secret, no sk-ocu- key, no unsalted digest, no signing key ever appears here; additionalProperties:false at both levels forbids smuggling one in. The published subset is fail-closed to the ACTIVE, non-expired records: a revoked or expired key is OMITTED before render, so status is always \"active\" on the wire (a key absent from this set is refused with 401 at the gateway). Status is pinned const \"active\" on this wire (the at-rest record type also carries revoked; it never reaches this artifact), and records has minItems 1 (Control refuses to render an empty active set), so both bad-render classes are schema-detectable. This schema validates the SHAPE; the omit-before-render, boot-refresh-within-5-min (NFR-SEC-04), and constant-time comparison are peer invariants, not schema-checkable (NFR-SEC-87, ADR-0027). JSON Schema 2020-12 (json-schema.org).",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schemas.open-computer-use.dev/mcp/mcp-key-set.schema.json",
   "title": "MCP hashed-key-set (Control -> gateway boot-set)",
@@ -48,9 +48,9 @@
     },
 
     "Status": {
-      "description": "Lifecycle state of the at-rest record. A CLOSED enum. On this published boot-set the value is always `active` (revoked/expired records are omitted before render); `revoked` is present for at-rest generality with the single Record type, not because a revoked record is published here.",
+      "description": "Lifecycle state as PUBLISHED on this wire: always `active`. Revoked/expired records are omitted before render (fail-closed), and the const makes a mis-render that leaks a revoked record schema-detectable by the vendored validator instead of silently usable. The at-rest record type also carries a `revoked` state; that state never reaches this artifact.",
       "type": "string",
-      "enum": ["active", "revoked"]
+      "const": "active"
     },
 
     "Timestamp": {
@@ -90,8 +90,9 @@
       "const": 1
     },
     "records": {
-      "description": "The active, non-expired records the gateway boot-loads. May be empty in the schema, but Control refuses to render an empty active set (fail-closed: an empty boot-set would make the gateway reject every presented key, masking a misconfiguration) — the empty-set refusal is a peer invariant, not schema-checkable.",
+      "description": "The active, non-expired records the gateway boot-loads. minItems 1 pins the empty-set refusal schema-side: Control refuses to render an empty active set (fail-closed — an empty boot-set would make the gateway reject every presented key, masking a misconfiguration), so an empty artifact is invalid, not merely unexpected.",
       "type": "array",
+      "minItems": 1,
       "items": { "$ref": "#/$defs/HashedKeyRecord" }
     }
   },

--- a/contracts/mcp/mcp-key-set.schema.json
+++ b/contracts/mcp/mcp-key-set.schema.json
@@ -1,0 +1,125 @@
+{
+  "$comment": "SPDX-License-Identifier: FSL-1.1-Apache-2.0 | Copyright (c) 2025 Open Computer Use Contributors | STATUS frozen (Artifact-2, the Control->gateway hashed-key-set). The config-plane boot-set the MCP gateway loads at boot to validate a presented sk-ocu- caller key in-process (ADR-0027). Control mints the key (occ mcp-key create), stores the salted hash, and re-renders this set on every mint/revoke; the gateway hashes the presented bearer and constant-time-compares against these records. This is delivered over the same config plane that carries the gateway's signing material, NEVER a per-request Control lookup (component-01 no-state-that-outlives-a-request invariant is kept: the set is configuration, not request-derived state). FENCED SURFACE: hashes + salts only. No plaintext secret, no sk-ocu- key, no unsalted digest, no signing key ever appears here; additionalProperties:false at both levels forbids smuggling one in. The published subset is fail-closed to the ACTIVE, non-expired records: a revoked or expired key is OMITTED before render, so status is always \"active\" on the wire (a key absent from this set is refused with 401 at the gateway). The \"revoked\" enum value is present for at-rest generality with the single Record type, not because a revoked record is ever published here. This schema validates the SHAPE; the omit-before-render, boot-refresh-within-5-min (NFR-SEC-04), and constant-time comparison are peer invariants, not schema-checkable (NFR-SEC-87, ADR-0027). JSON Schema 2020-12 (json-schema.org).",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.open-computer-use.dev/mcp/mcp-key-set.schema.json",
+  "title": "MCP hashed-key-set (Control -> gateway boot-set)",
+  "description": "The versioned hashed-key-set the Control plane renders for the MCP gateway to boot-load and validate presented sk-ocu- caller keys in-process (ADR-0027). Top-level `version` (const 1) + `records[]`; each record is one MCP API key as a salted SHA-256 hash plus its binding metadata, never the plaintext secret. Only active, non-expired records reach this set. The gateway resolves a presented bearer to a record here or refuses it (401); tenant and deployment scope are read from the resolved record, never from the opaque key.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "records"],
+
+  "$defs": {
+    "KeyId": {
+      "description": "Opaque public handle for the key: the value passed to `occ mcp-key revoke --id` and the correlation field on the audit record. A short random handle, structurally independent of the secret (never derived from it). Control mints it as the lowercase-hex encoding of 12 CSPRNG bytes (24 hex chars); the schema pins only that it is a non-empty opaque string, so a future id shape stays additive.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "examples": ["a1b2c3d4e5f6a7b8c9d0e1f2"]
+    },
+
+    "KeyHash": {
+      "description": "Salted key digest: `sha256(salt || secret)`, lowercase-hex. Exactly 64 hex chars (256-bit SHA-256). The unsalted digest is rejected at construction (pass-the-hash floor, NFR-SEC-87). Lowercase-hex, NOT base64 (a raw []byte defaults to base64; the projection hex-encodes it to satisfy this pattern).",
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "examples": ["0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"]
+    },
+
+    "Salt": {
+      "description": "Per-key salt, lowercase-hex, an even number of hex chars, at least 16 (>= 64-bit). Control draws a fresh 32-byte crypto/rand salt per key, so the rendered value is 64 hex chars; the pattern floor of 16 keeps the entropy floor without pinning the exact width. Stored alongside the hash so the gateway can re-hash a presented bearer for comparison.",
+      "type": "string",
+      "pattern": "^([0-9a-f]{2}){8,}$",
+      "examples": ["2122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40"]
+    },
+
+    "Tenant": {
+      "description": "The tenant the key is scoped to, read from THIS record at the gateway, never from a claim in the opaque key (an opaque key carries none). Operator-supplied at issuance (`occ mcp-key create --tenant <T>`).",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "examples": ["tenant-a"]
+    },
+
+    "Deployment": {
+      "description": "The deployment the key is scoped to. A key whose deployment does not match this set's deployment fails to resolve and is refused with 401 (ADR-0027 absent-from-set refuse-path). Operator-supplied at issuance.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "examples": ["deploy-1"]
+    },
+
+    "Status": {
+      "description": "Lifecycle state of the at-rest record. A CLOSED enum. On this published boot-set the value is always `active` (revoked/expired records are omitted before render); `revoked` is present for at-rest generality with the single Record type, not because a revoked record is published here.",
+      "type": "string",
+      "enum": ["active", "revoked"]
+    },
+
+    "Timestamp": {
+      "description": "An RFC 3339 date-time (UTC, e.g. 2026-03-01T12:00:00Z). Control formats the record's time from an injected monotonic Clock.",
+      "type": "string",
+      "format": "date-time",
+      "examples": ["2026-03-01T12:00:00Z"]
+    },
+
+    "HashedKeyRecord": {
+      "description": "One MCP API key as a salted hash plus its binding metadata. NEVER the plaintext secret. Required: key_id, key_hash, salt, tenant, deployment, status, created_at. Optional: expires_at (absent => non-expiring, so the one-click path is not blocked). additionalProperties:false forbids any extra field smuggling a secret in.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key_id", "key_hash", "salt", "tenant", "deployment", "status", "created_at"],
+      "properties": {
+        "key_id": { "$ref": "#/$defs/KeyId" },
+        "key_hash": { "$ref": "#/$defs/KeyHash" },
+        "salt": { "$ref": "#/$defs/Salt" },
+        "tenant": { "$ref": "#/$defs/Tenant" },
+        "deployment": { "$ref": "#/$defs/Deployment" },
+        "status": { "$ref": "#/$defs/Status" },
+        "expires_at": {
+          "$ref": "#/$defs/Timestamp",
+          "description": "Optional expiry. ABSENT means the key is non-expiring (ADR-0027). When present it is an RFC 3339 date-time; an expired record is omitted from this set before render, so a present expires_at here is always in the future relative to render time."
+        },
+        "created_at": {
+          "$ref": "#/$defs/Timestamp",
+          "description": "The instant the record was minted."
+        }
+      }
+    }
+  },
+
+  "properties": {
+    "version": {
+      "description": "Boot-set envelope format version. Pinned const 1; a format migration bumps it (NFR-IC-04, additive-only otherwise).",
+      "const": 1
+    },
+    "records": {
+      "description": "The active, non-expired records the gateway boot-loads. May be empty in the schema, but Control refuses to render an empty active set (fail-closed: an empty boot-set would make the gateway reject every presented key, masking a misconfiguration) — the empty-set refusal is a peer invariant, not schema-checkable.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/HashedKeyRecord" }
+    }
+  },
+
+  "examples": [
+    {
+      "version": 1,
+      "records": [
+        {
+          "key_id": "a1b2c3d4e5f6a7b8c9d0e1f2",
+          "key_hash": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "salt": "2122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40",
+          "tenant": "tenant-a",
+          "deployment": "deploy-1",
+          "status": "active",
+          "created_at": "2026-03-01T12:00:00Z"
+        },
+        {
+          "key_id": "0011223344556677889900aa",
+          "key_hash": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+          "salt": "2122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40",
+          "tenant": "tenant-a",
+          "deployment": "deploy-1",
+          "status": "active",
+          "expires_at": "2026-03-02T12:00:00Z",
+          "created_at": "2026-03-01T12:00:00Z"
+        }
+      ]
+    }
+  ]
+}

--- a/contracts/openapi/operator-rest.openapi.yaml
+++ b/contracts/openapi/operator-rest.openapi.yaml
@@ -680,8 +680,11 @@ components:
       description: >-
         Mint an sk-ocu- MCP API key. `tenant`/`deployment` are the operator-chosen scope the
         key binds; the acting operator is host-attested, never a field here (NFR-SEC-43,
-        NFR-SEC-45). `expires_at` is optional (absent => non-expiring, ADR-0027).
-      required: [tenant]
+        NFR-SEC-45). Both are REQUIRED: the published key-set record carries both
+        (ADR-0027 Storage) and neither has a meaningful default — an empty value would
+        render a schema-invalid artifact. `expires_at` is optional (absent =>
+        non-expiring, ADR-0027).
+      required: [tenant, deployment]
       properties:
         tenant:
           type: string

--- a/contracts/openapi/operator-rest.openapi.yaml
+++ b/contracts/openapi/operator-rest.openapi.yaml
@@ -235,6 +235,77 @@ paths:
         '503':
           $ref: '#/components/responses/Denied'
 
+  /v1alpha/mcp-keys:
+    post:
+      operationId: createMCPKey
+      summary: Mint an sk-ocu- MCP API key (operator scope).
+      description: >-
+        Mint a per-caller static sk-ocu- MCP API key (ADR-0027). This route exists ONLY on
+        this operator ingress; the gateway audience cannot reach it (NFR-SEC-52) — the
+        gateway VALIDATES keys against the boot-loaded hashed-key set, it never mints them.
+        `tenant` and `deployment` are the operator-supplied SCOPE the new key serves — a
+        legitimate operator choice of WHICH tenant/deployment the key binds, distinct from
+        the NFR-SEC-43 rule that a body id never names the acting caller. The acting
+        operator is host-attested from the transport peer credential; the audit actor is
+        that operator, never the `tenant` field. The action is audit-gated: the OCSF event
+        (carrying key_id, NEVER the raw key) is written fail-closed BEFORE the key is
+        persisted (NFR-SEC-45). The raw key is revealed exactly ONCE in this 201 response
+        (shown-once) and is never persisted in plaintext or served again; Control stores
+        only its salted hash. `expires_at` is optional — absent means non-expiring.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MCPKeyCreateRequest'
+      responses:
+        '201':
+          description: >-
+            Key minted and its salted-hash record persisted; the audit event was recorded
+            first. The body carries the shown-once raw key exactly once — this is the sole
+            surface on which the plaintext sk-ocu- key ever appears (custody: NFR-SEC-87).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MCPKeyCreateResponse'
+        '401':
+          $ref: '#/components/responses/Denied'
+        '403':
+          $ref: '#/components/responses/Denied'
+        '503':
+          $ref: '#/components/responses/Denied'
+
+  /v1alpha/mcp-keys/revoke:
+    post:
+      operationId: revokeMCPKey
+      summary: Revoke an sk-ocu- MCP API key by key_id (operator scope).
+      description: >-
+        Flip an MCP API key's status to revoked by its public `key_id` (ADR-0027). Revoke
+        exists ONLY on this operator ingress (NFR-SEC-52). The audit actor is the
+        host-attested operator; `reason` is operator-supplied audit text. The action is
+        audit-gated fail-closed (NFR-SEC-45). Revoke is IDEMPOTENT: revoking an
+        already-revoked or absent key_id is a satisfied no-op (200), so the surface is not a
+        cross-tenant existence oracle — an unknown id is 200, never 404. After revoke,
+        Control re-renders the hashed-key set and the gateway refreshes within NFR-SEC-04
+        (<= 5 min), after which the key is refused with 401.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MCPKeyRevokeRequest'
+      responses:
+        '200':
+          description: >-
+            Revoke applied (or a satisfied no-op for an already-revoked/absent id). Audit
+            event recorded. No body.
+        '401':
+          $ref: '#/components/responses/Denied'
+        '403':
+          $ref: '#/components/responses/Denied'
+        '503':
+          $ref: '#/components/responses/Denied'
+
 components:
   securitySchemes:
     operatorPeerCred:
@@ -590,6 +661,104 @@ components:
           description: >-
             The ceiling the atomic charge checks the post-delta counter against; the cell is
             left unchanged if the delta would carry it past this limit.
+        reason:
+          type: string
+          maxLength: 256
+          description: Operator-supplied justification recorded on the audit event.
+          x-ocu-default: >-
+            maxLength 256 mirrors the NFR-SEC-51 BoundedReason.message default; retunable,
+            not source-pinned.
+
+    # MCPKeyCreateRequest mirrors the in-process MCPKeyCreate(tenant, deployment, expiresAt)
+    # (internal/ingress/operator/mcpkey.go). tenant/deployment are the operator-supplied
+    # SCOPE the new key serves — a legitimate operator input, distinct from the NFR-SEC-43
+    # rule that a body id never names the acting caller. No caller/actor id here — the actor
+    # is the host-attested operator (ADR-0027).
+    MCPKeyCreateRequest:
+      type: object
+      additionalProperties: false
+      description: >-
+        Mint an sk-ocu- MCP API key. `tenant`/`deployment` are the operator-chosen scope the
+        key binds; the acting operator is host-attested, never a field here (NFR-SEC-43,
+        NFR-SEC-45). `expires_at` is optional (absent => non-expiring, ADR-0027).
+      required: [tenant]
+      properties:
+        tenant:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: >-
+            The tenant the new key is scoped to. The operator chooses it; it is the key's
+            binding scope, never the acting caller's identity (NFR-SEC-43).
+        deployment:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: >-
+            The deployment the new key is scoped to. A key whose deployment does not match
+            the gateway's boot-set fails to resolve and is refused with 401 (ADR-0027).
+        expires_at:
+          type: string
+          format: date-time
+          description: >-
+            Optional RFC 3339 expiry. ABSENT means the key is non-expiring (ADR-0027), so
+            the one-click path is not blocked.
+
+    # MCPKeyCreateResponse mirrors the in-process create render (routes.go
+    # mcpKeyCreateResponse): the SHOWN-ONCE raw key plus its public key_id and bound tenant.
+    # This is the SOLE surface on which the plaintext sk-ocu- key appears — Control persists
+    # only its salted hash and never serves the plaintext again (NFR-SEC-87). This departs
+    # from the SessionHandle no-credential posture BY DESIGN: an sk key is a caller
+    # credential the operator must capture at issuance, unlike the server-minted Storage-JWT
+    # which is pushed on a separate custody plane and is absent from every operator body.
+    MCPKeyCreateResponse:
+      type: object
+      additionalProperties: false
+      description: >-
+        The shown-once create result. `raw_key` is the plaintext sk-ocu- key returned
+        exactly once; the operator captures it now and it is never served again. `key_id` is
+        the public handle for a subsequent revoke; `tenant` echoes the bound scope.
+      required: [raw_key, key_id, tenant]
+      properties:
+        raw_key:
+          type: string
+          pattern: '^sk-ocu-[0-9A-Za-z]{43}$'
+          description: >-
+            The plaintext MCP API key, shown ONCE. Format: `sk-ocu-` + 43 base62 chars
+            (256-bit CSPRNG body). The `sk-ocu-` prefix is a secret-scanner signature. It is
+            never persisted in plaintext and never appears on any other surface (ADR-0027,
+            NFR-SEC-87).
+        key_id:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: >-
+            The key's public handle — the id passed to `POST /v1alpha/mcp-keys/revoke` and
+            the audit correlation field. A short random handle, never derived from the
+            secret.
+        tenant:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Echo of the tenant scope the minted key binds.
+
+    # MCPKeyRevokeRequest mirrors the in-process MCPKeyRevoke(keyID, reason) (mcpkey.go).
+    # key_id is the public handle; reason is operator audit text. Revoke is idempotent — an
+    # unknown id is a satisfied no-op (200), not a 404 (no cross-tenant existence oracle).
+    MCPKeyRevokeRequest:
+      type: object
+      additionalProperties: false
+      description: >-
+        Revoke an sk-ocu- MCP API key by its public `key_id`. The actor is the host-attested
+        operator, never a field here (NFR-SEC-43, NFR-SEC-45). Idempotent: an already-revoked
+        or absent id is a satisfied no-op.
+      required: [key_id]
+      properties:
+        key_id:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: The public handle of the key to revoke (the value from the create response).
         reason:
           type: string
           maxLength: 256

--- a/docs/architecture/08-contracts.md
+++ b/docs/architecture/08-contracts.md
@@ -3,7 +3,7 @@
 
 ---
 status: draft
-last-reviewed: 2026-06-20
+last-reviewed: 2026-07-01
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
 ---
@@ -87,6 +87,7 @@ This overview is the map; the schema files under `contracts/` own the field-leve
 Drafted (not merged):
 
 - `contracts/mcp/2025-06-18/ocu-constraints.schema.json` — the MCP conform profile.
+- `contracts/mcp/mcp-key-set.schema.json` — the hashed-key-set boot-set the control plane renders for the MCP gateway (ADR-0027).
 - `contracts/exec/exec-channel.schema.json` — the exec/PTY WebSocket envelope.
 - `contracts/control/control-rpc.schema.json` — the in-guest control-RPC envelope (host-owned UDS; v1 verb set `shutdown` only, the deferred and forbidden verbs carried as `x-ocu-tbd-verbs` absent members). STATUS `partial`.
 - `contracts/storage/mount-config.schema.json` and `contracts/storage/file-ops.schema.json` — the mount-plane mount config and file-op RPC (the file-op message bodies are tbd).


### PR DESCRIPTION
Freezes the Phase-8 `occ mcp-key` wire surfaces so ocu-control can vendor and ajv-gate its emitted artifact byte-for-byte.

## What
- **ADD** `contracts/mcp/mcp-key-set.schema.json` — the hashed-key-set boot-set the control plane renders for the MCP gateway (ADR-0027): `{version: const 1, records[]}`, `additionalProperties:false` at both levels; record = `key_id, key_hash, salt, tenant, deployment, status, expires_at?, created_at`; lowercase-hex `key_hash` (`^[0-9a-f]{64}$`) and `salt` (even hex, >=16 floor — matches the frozen-shape pin; production renders 64); only active, non-expired records are published (`revoked` stays in the enum for at-rest generality; the omit-before-render rule is documented in the top-level `$comment`).
- **operator-rest.openapi.yaml**: `POST /v1alpha/mcp-keys` (201, shown-once `raw_key` `^sk-ocu-[0-9A-Za-z]{43}$`; the sole surface where the plaintext key ever appears) and `POST /v1alpha/mcp-keys/revoke` (200, idempotent — unknown id is a satisfied no-op, never 404, so the surface is not a cross-tenant existence oracle). Both operator-ingress-only (NFR-SEC-52), audit-gated fail-closed (NFR-SEC-45).
- **ocu-constraints `x-ocu-authz`**: `mode` enum `static-key` (default) | `oauth2-rs`; Origin-validation and no-passthrough rules stay UNCONDITIONAL on both modes; RFC 8707 audience / RFC 9728 resource-metadata rules move under `oauth2-rs` (an opaque sk key carries no audience claim — scope reads from the resolved record).
- README layout row + 08-contracts §5 bullet; `last-reviewed` bumped.

## Verification
- `ajv-cli@5 compile --spec=draft2020` clean on both schemas (same invocation as the `json-schema` CI job).
- `@redocly/cli@1.34.2 lint` clean against `contracts/openapi/redocly.yaml` (same as CI).
- A control-emitted key-set sample validates against the new schema (kept out of the repo; the byte-identity gate lands control-side as vendor + ajv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added operator-facing MCP key management endpoints for creating and revoking static keys.
  * Introduced support for a hashed key-set schema used during gateway startup.
* **Bug Fixes**
  * Clarified authentication handling with mode-specific validation and safer fallback behavior.
  * Improved key revocation behavior so repeated or unknown revocations succeed consistently.
* **Documentation**
  * Updated contract and architecture docs to include the new MCP key-set artifact and refreshed review metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->