### PR TITLE
ci(security): SHA-pin every third-party action to a 40-char commit SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Free disk space for 8GB+ image + local load
         run: |
@@ -32,16 +32,16 @@ jobs:
                       /opt/hostedtoolcache/CodeQL || true
           df -h /
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
         if: github.event_name != 'pull_request'
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v6
+      - uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
         id: meta
         with:
           images: ${{ env.SANDBOX_IMAGE }}
@@ -55,7 +55,7 @@ jobs:
             type=match,pattern=v(.*),group=1
             type=sha
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         id: build
         with:
           context: .
@@ -112,18 +112,18 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
         if: github.event_name != 'pull_request'
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v6
+      - uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
         id: meta
         with:
           images: ${{ env.SERVER_IMAGE }}
@@ -137,7 +137,7 @@ jobs:
             type=match,pattern=v(.*),group=1
             type=sha
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: ./computer-use-server
           push: ${{ github.event_name != 'pull_request' }}
@@ -154,18 +154,18 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
         if: github.event_name != 'pull_request'
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v6
+      - uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
         id: meta
         with:
           images: ghcr.io/${{ github.repository }}-cleanup
@@ -179,7 +179,7 @@ jobs:
             type=match,pattern=v(.*),group=1
             type=sha
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: ./cron
           push: ${{ github.event_name != 'pull_request' }}
@@ -196,18 +196,18 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
         if: github.event_name != 'pull_request'
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v6
+      - uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
         id: meta
         with:
           images: ghcr.io/${{ github.repository }}-webui
@@ -221,7 +221,7 @@ jobs:
             type=match,pattern=v(.*),group=1
             type=sha
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: ./openwebui
           push: ${{ github.event_name != 'pull_request' }}
@@ -235,7 +235,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Run structure and English-only tests
         run: |
@@ -248,9 +248,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.13'
 
@@ -272,12 +272,12 @@ jobs:
     # 2026-04-19 regression in one CI run.
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
       - name: Build computer-use-server image locally
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: ./computer-use-server
           load: true
@@ -331,7 +331,7 @@ jobs:
     # the publish step.
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Free disk space for the workspace image
         run: |
@@ -339,10 +339,10 @@ jobs:
                       /opt/hostedtoolcache/CodeQL || true
           df -h /
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
       - name: Build workspace image (linux/amd64, local tag)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: .
           platforms: linux/amd64
@@ -353,7 +353,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=sandbox-integration
 
       - name: Build server image (local tag)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: ./computer-use-server
           push: false
@@ -362,7 +362,7 @@ jobs:
           cache-from: type=gha,scope=server-smoke
           cache-to: type=gha,mode=max,scope=server-integration
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.13'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,13 +21,13 @@ jobs:
         language: [python, javascript]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3.36.2
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
-      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3.36.2
 
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3.36.2

--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -27,8 +27,8 @@ jobs:
   json-schema:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "20"
       - name: Validate JSON Schema 2020-12 documents
@@ -52,8 +52,8 @@ jobs:
   asyncapi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "20"
       - name: Validate AsyncAPI documents
@@ -73,7 +73,7 @@ jobs:
     env:
       LEXICON_DENYLIST: ${{ secrets.LEXICON_DENYLIST }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: naming denylist (contracts)
         run: |
           set -euo pipefail

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -42,9 +42,9 @@ jobs:
     name: linter self-test (fixtures)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
       - name: Run linter self-tests
@@ -54,9 +54,9 @@ jobs:
     name: front-matter validator
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
       - name: Validate
@@ -66,7 +66,7 @@ jobs:
     name: line-count budget
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Check
         run: bash scripts/docs-lint/wc-budget.sh
 
@@ -74,7 +74,7 @@ jobs:
     name: AI-slop detector
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Check
         env:
           LEXICON_DENYLIST: ${{ secrets.LEXICON_DENYLIST }}
@@ -84,9 +84,9 @@ jobs:
     name: architecture-tree whitelist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
       - name: Check
@@ -96,9 +96,9 @@ jobs:
     name: ASCII diagram detector
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
       - name: Check
@@ -108,9 +108,9 @@ jobs:
     name: markdownlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v18
+        uses: DavidAnson/markdownlint-cli2-action@eb5ca3ab411449c66620fe7f1b3c9e10547144b0  # v18.0.0
         with:
           # Scope to architecture docs only. Top-level CLAUDE.md, README.md,
           # and CONTRIBUTING.md are governed by "global rules" and were
@@ -123,9 +123,9 @@ jobs:
     name: vale prose linter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Run vale
-        uses: errata-ai/vale-action@v2.1.1
+        uses: errata-ai/vale-action@d89dee975228ae261d22c15adcd03578634d429c  # v2.1.1
         with:
           version: 3.9.1
           files: docs/architecture
@@ -135,9 +135,9 @@ jobs:
     name: lychee link checker
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Run lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2.8.0
         with:
           # We only care about *internal* / forward-reference link integrity.
           # `--offline` skips all HTTP checks — external URLs (rate-limit

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -33,9 +33,9 @@ jobs:
     name: helm lint + template
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
         with:
           version: v3.16.4   # Helm 3 LTS — chart-releaser-action does not yet ship a Helm 4 image
                             # and Helm 3 lints/templates the chart identically for our purposes.
@@ -110,7 +110,7 @@ jobs:
       contents: write
       pages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 0  # chart-releaser needs full history to detect tag bumps
 
@@ -119,11 +119,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
         with:
           version: v3.16.4
 
-      - uses: helm/chart-releaser-action@v1.7.0
+      - uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f  # v1.7.0
         with:
           charts_dir: helm
           mark_as_latest: true

--- a/.github/workflows/identity-lint.yml
+++ b/.github/workflows/identity-lint.yml
@@ -25,6 +25,6 @@ jobs:
     name: identity-email detector
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Check tracked content for the banned personal address
         run: bash scripts/docs-lint/identity-email-detector.sh

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -47,9 +47,9 @@ jobs:
     name: Package and push chart to OCI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
         with:
           version: v3.16.4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2
         with:
           generate_release_notes: true
           prerelease: ${{ steps.prerelease.outputs.is_prerelease == 'true' }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899  # v10.3.0
         with:
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
## Why

The scheduled `SAST — semgrep` gate has flagged `yaml.github-actions.security.github-actions-mutable-action-tag` on every `uses:` pinned to a movable tag — ~65 of the 69 blocking findings failing the nightly `security` run since 2026-06-18. `security.yml` already SHA-pins its own steps and documents the mandatory 40-char-SHA pinning policy (lines ~18-24); the other workflows predate that tightening and were never migrated.

Companion PR #319 clears the trufflehog job and the 4 `dependabot-missing-cooldown` findings. Together the two PRs return the nightly `security` run to green.

## Changes

**Pin-only** — every SHA is exactly what the tag resolves to today; no version upgrades. 67 substitutions across 9 workflow files, each with a trailing `# vX.Y.Z` comment.

| Action | Pinned SHA | Version |
|--------|-----------|---------|
| actions/checkout | `34e114876b0b11c390a56381ad16ebd13914f8d5` / `df4cb1c069e1874edd31b4311f1884172cec0e10` | v4.3.1 / v6.0.3 |
| actions/setup-node | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 |
| actions/setup-python | `a26af69be951a213d495a4c3e4e4022e16d87065` | v5.6.0 |
| actions/stale | `eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899` | v10.3.0 |
| azure/setup-helm | `1a275c3b69536ee54be43f2070a358922e12c8d4` | v4.3.1 |
| docker/build-push-action | `53b7df96c91f9c12dcc8a07bcb9ccacbed38856a` | v7.3.0 |
| docker/login-action | `c94ce9fb468520275223c153574b00df6fe4bcc9` | v3.7.0 |
| docker/metadata-action | `80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9` | v6.1.0 |
| docker/setup-buildx-action | `d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5` | v4.1.0 |
| github/codeql-action/* | `dd903d2e4f5405488e5ef1422510ee31c8b32357` | v3.36.2 |
| helm/chart-releaser-action | `cae68fefc6b5f367a0275617c9f83181ba54714f` | v1.7.0 |
| lycheeverse/lychee-action | `8646ba30535128ac92d33dfc9133794bfdd9b411` | v2.8.0 |
| softprops/action-gh-release | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` | v2.6.2 |
| errata-ai/vale-action | `d89dee975228ae261d22c15adcd03578634d429c` | v2.1.1 |
| DavidAnson/markdownlint-cli2-action | `eb5ca3ab411449c66620fe7f1b3c9e10547144b0` | v18.0.0 |

## Verification

- No movable `@vN` tag remains in `.github/workflows/`.
- All `.github/workflows/*.yml` parse under PyYAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)