### PR TITLE
build(ci): move all codeql-action refs to v4 together

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
-      - uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3.36.2
+      - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
-      - uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3.36.2
+      - uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
 
-      - uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3.36.2
+      - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -244,7 +244,7 @@ jobs:
           limit-severities-for-sarif: true
       - name: Upload SARIF (CRITICAL)
         if: always()
-        uses: github/codeql-action/upload-sarif@fee9466b8957867761f2d78f922ab084e3e2dd17  # v3
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
         with:
           sarif_file: trivy-fs.sarif
           category: trivy-fs
@@ -269,7 +269,7 @@ jobs:
           limit-severities-for-sarif: true
       - name: Upload SARIF (HIGH)
         if: always()
-        uses: github/codeql-action/upload-sarif@fee9466b8957867761f2d78f922ab084e3e2dd17  # v3
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
         with:
           sarif_file: trivy-fs-high.sarif
           category: trivy-fs-high


### PR DESCRIPTION
Supersedes #329, which bumped only `codeql-action/init` and failed at run time: `Loaded a configuration file for version '4.36.2', but running version '3.36.2'`. All four codeql-action refs (init/autobuild/analyze in codeql.yml, upload-sarif ×2 in security.yml) move to the same pinned v4 SHA (`8aad20d1…`, the one #329 resolved). CodeQL Action v3 is deprecated December 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security-related GitHub Actions to newer versions for CodeQL analysis and SARIF uploads.
  * Kept the existing workflow behavior, scan settings, and file paths unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->