### PR TITLE
ci(release): add a manual release path that creates the tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,13 @@ on:
     tags: ['v*']
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to tag the images with, no leading v (e.g. 0.10.2.0). Empty builds without a version tag.'
+        required: false
+        default: ''
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -53,6 +60,12 @@ jobs:
             # both 3-segment SemVer and 4-segment tags, with or without a
             # pre-release suffix.
             type=match,pattern=v(.*),group=1
+            # Manual release path: a tag pushed by release.yml's GITHUB_TOKEN
+            # does not start a new workflow run (GitHub's recursion guard), so
+            # release.yml dispatches this workflow and passes the version here.
+            # type=match reads the ref, which is not a tag on dispatch, so the
+            # version has to arrive as an explicit raw tag instead.
+            type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
             type=sha
 
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
@@ -135,6 +148,12 @@ jobs:
             # both 3-segment SemVer and 4-segment tags, with or without a
             # pre-release suffix.
             type=match,pattern=v(.*),group=1
+            # Manual release path: a tag pushed by release.yml's GITHUB_TOKEN
+            # does not start a new workflow run (GitHub's recursion guard), so
+            # release.yml dispatches this workflow and passes the version here.
+            # type=match reads the ref, which is not a tag on dispatch, so the
+            # version has to arrive as an explicit raw tag instead.
+            type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
             type=sha
 
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
@@ -177,6 +196,12 @@ jobs:
             # both 3-segment SemVer and 4-segment tags, with or without a
             # pre-release suffix.
             type=match,pattern=v(.*),group=1
+            # Manual release path: a tag pushed by release.yml's GITHUB_TOKEN
+            # does not start a new workflow run (GitHub's recursion guard), so
+            # release.yml dispatches this workflow and passes the version here.
+            # type=match reads the ref, which is not a tag on dispatch, so the
+            # version has to arrive as an explicit raw tag instead.
+            type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
             type=sha
 
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
@@ -219,6 +244,12 @@ jobs:
             # both 3-segment SemVer and 4-segment tags, with or without a
             # pre-release suffix.
             type=match,pattern=v(.*),group=1
+            # Manual release path: a tag pushed by release.yml's GITHUB_TOKEN
+            # does not start a new workflow run (GitHub's recursion guard), so
+            # release.yml dispatches this workflow and passes the version here.
+            # type=match reads the ref, which is not a tag on dispatch, so the
+            # version has to arrive as an explicit raw tag instead.
+            type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
             type=sha
 
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,20 @@ name: Release
 on:
   push:
     tags: ['v*']
+  # Manual entry point for environments that cannot push a tag — Claude Code
+  # on the web restricts git pushes to the working branch, so `git push --tags`
+  # from a cloud session is refused. Dispatch this workflow instead and it
+  # creates the tag itself.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to tag and release, with the leading v (e.g. v0.10.2.0). CHANGELOG.md must already carry its heading.'
+        required: true
+        type: string
 
 permissions:
   contents: write
+  actions: write   # dispatch the tag-driven workflows the recursion guard skips
 
 jobs:
   release:
@@ -16,6 +27,54 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 0
+
+      # Every `${{ }}` value below is bound to an env var and referenced as
+      # "$VAR" inside run: blocks — semgrep's run-shell-injection rule (CWE-78)
+      # blocks direct interpolation.
+      - name: Resolve version
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "$EVENT_NAME" = 'workflow_dispatch' ]; then
+            version="$INPUT_VERSION"
+            # Only the manual path is validated. A tag push has already
+            # committed to whatever name it carries, and older releases used a
+            # 3-segment scheme this pattern would reject.
+            if ! printf '%s' "$version" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'; then
+              echo "::error::version '$version' is not vX.Y.Z.W or vX.Y.Z.W-suffix"
+              exit 1
+            fi
+          else
+            version="$REF_NAME"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          # build.yml tags images with `type=match,pattern=v(.*),group=1`, i.e.
+          # the version without the leading v.
+          echo "image_tag=${version#v}" >> "$GITHUB_OUTPUT"
+          echo "chart_version=$(printf '%s' "${version#v}" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+)(\.[0-9]+)?(-.*)?$/\1\3/')" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/$VERSION" >/dev/null 2>&1; then
+            echo "::error::tag $VERSION already exists on the remote"
+            exit 1
+          fi
+          # The release notes link the CHANGELOG entry, so refuse to tag a
+          # version that has none rather than publish a release with no record.
+          if ! grep -qF "## $VERSION " CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## $VERSION' heading — add the release entry first"
+            exit 1
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git tag -a "$VERSION" -m "$VERSION"
+          git push origin "refs/tags/$VERSION"
 
       - name: Generate changelog
         id: changelog
@@ -32,6 +91,8 @@ jobs:
 
       - name: Detect pre-release tag
         id: prerelease
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           # Strip leading v; if what's left contains a SemVer pre-release suffix
           # (`-rc.1`, `-alpha.2`, `-beta.0`, `-dev.X`), mark the GitHub Release
@@ -41,7 +102,7 @@ jobs:
           # 4-segment app-version scheme (`0.8.12.3-rc.1`). Any pre-release
           # suffix flips the release to "pre-release" in GitHub so the
           # "Latest" badge keeps tracking stable.
-          v="${GITHUB_REF_NAME#v}"
+          v="${VERSION#v}"
           if echo "$v" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?-[A-Za-z0-9.]+$'; then
             echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
           else
@@ -50,16 +111,19 @@ jobs:
 
       - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2
         with:
+          # Explicit: on a dispatch the ref is a branch, so the action cannot
+          # infer the tag from it.
+          tag_name: ${{ steps.version.outputs.version }}
           generate_release_notes: true
           prerelease: ${{ steps.prerelease.outputs.is_prerelease == 'true' }}
           body: |
             ## Docker Images
 
             ```bash
-            docker pull ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-            docker pull ghcr.io/${{ github.repository }}-server:${{ github.ref_name }}
-            docker pull ghcr.io/${{ github.repository }}-cleanup:${{ github.ref_name }}
-            docker pull ghcr.io/${{ github.repository }}-webui:${{ github.ref_name }}
+            docker pull ghcr.io/${{ github.repository }}:${{ steps.version.outputs.image_tag }}
+            docker pull ghcr.io/${{ github.repository }}-server:${{ steps.version.outputs.image_tag }}
+            docker pull ghcr.io/${{ github.repository }}-cleanup:${{ steps.version.outputs.image_tag }}
+            docker pull ghcr.io/${{ github.repository }}-webui:${{ steps.version.outputs.image_tag }}
             ```
 
             ## Helm chart (Kubernetes)
@@ -68,7 +132,7 @@ jobs:
             # Image tags follow the 4-segment app version (e.g. 0.8.12.3);
             # Helm chart versions are 3-segment SemVer, so strip the 4th
             # segment (and any pre-release suffix) for --version.
-            VERSION="${{ github.ref_name }}"; VERSION="${VERSION#v}"
+            VERSION="${{ steps.version.outputs.image_tag }}"
             CHART_VERSION="$(echo "$VERSION" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+)(\.[0-9]+)?(-.*)?$/\1\3/')"
             helm install ocu oci://ghcr.io/${{ github.repository_owner }}/charts/computer-use-server \
               --version "$CHART_VERSION" \
@@ -78,14 +142,14 @@ jobs:
               --set cleanup.image.tag="$VERSION"
             ```
 
-            See [`helm/computer-use-server/README.md`](https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/helm/computer-use-server/README.md) for prerequisites (Kata Containers) and full values reference.
+            See [`helm/computer-use-server/README.md`](https://github.com/${{ github.repository }}/blob/${{ steps.version.outputs.version }}/helm/computer-use-server/README.md) for prerequisites (Kata Containers) and full values reference.
 
             ## Quick Start (Docker Compose)
 
             ```bash
             git clone https://github.com/${{ github.repository }}.git
             cd open-computer-use
-            git checkout ${{ github.ref_name }}
+            git checkout ${{ steps.version.outputs.version }}
             cp .env.example .env
             # Edit .env with your API key
             docker compose up
@@ -93,3 +157,21 @@ jobs:
 
             ## Changes
             ${{ steps.changelog.outputs.changes }}
+
+      # A tag pushed with GITHUB_TOKEN does not start new workflow runs, so on
+      # the manual path the tag-driven workflows never fire. Start the two that
+      # publish artefacts. supply-chain.yml is deliberately left out: it signs
+      # as the project's Sigstore identity and is gated behind the `production`
+      # environment's required reviewer, so it stays a human decision.
+      - name: Dispatch the tag-driven workflows
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          IMAGE_TAG: ${{ steps.version.outputs.image_tag }}
+          CHART_VERSION: ${{ steps.version.outputs.chart_version }}
+          REF: ${{ github.ref_name }}
+        run: |
+          gh workflow run build.yml --repo "$REPO" --ref "$REF" -f version="$IMAGE_TAG"
+          gh workflow run release-chart.yml --repo "$REPO" --ref "$REF" -f version="$CHART_VERSION"
+          echo "::notice::Images and chart dispatched. supply-chain.yml (SBOM + cosign) still needs a manual run per image — it requires production-environment approval."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,10 @@ jobs:
           REPO: ${{ github.repository }}
           IMAGE_TAG: ${{ steps.version.outputs.image_tag }}
           CHART_VERSION: ${{ steps.version.outputs.chart_version }}
-          REF: ${{ github.ref_name }}
+          # The tag, not the dispatch branch: a commit landing on the branch
+          # between the tag and this step would otherwise be what gets built,
+          # so the images would not match the commit the release points at.
+          REF: ${{ steps.version.outputs.version }}
         run: |
           gh workflow run build.yml --repo "$REPO" --ref "$REF" -f version="$IMAGE_TAG"
           gh workflow run release-chart.yml --repo "$REPO" --ref "$REF" -f version="$CHART_VERSION"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,8 @@ To release:
 2. Commit: `chore: release vX.X.X.X`.
 3. Tag: `git tag vX.X.X.X && git push origin main --tags`.
 
+If the environment cannot push a tag — Claude Code on the web restricts git pushes to the working branch — run the **Release** workflow manually instead (`gh workflow run release.yml -f version=vX.X.X.X`, or the Actions tab). It validates the version, refuses to tag a version with no `CHANGELOG.md` heading, creates the tag, cuts the GitHub Release, and dispatches the image build and chart publish. `supply-chain.yml` (SBOM + cosign signing) stays manual either way: it signs as the project's Sigstore identity and requires `production`-environment approval.
+
 The `next/v1` branch will define its own versioning scheme in an ADR; until then it carries no tagged releases.
 
 ---


### PR DESCRIPTION
## Summary

Releases currently require `git push origin --tags`. Claude Code on the web [restricts git pushes to the working branch](https://code.claude.com/docs/en/claude-code-on-the-web) for safety, so a cloud session cannot cut a release at all — v0.10.2.0 merged in #354 and then sat untagged for exactly this reason.

This adds `workflow_dispatch` to **Release** so the tag is created by Actions instead of by a developer's shell.

## Changes

**`release.yml` — manual entry point.** Takes a `version` input and, before doing anything irreversible:
- validates the 4-segment scheme (`vX.Y.Z.W`, optional pre-release suffix);
- refuses to tag a version with no `## <version>` heading in `CHANGELOG.md`, so a release can't be published with no record of what's in it;
- refuses to overwrite a tag that already exists on the remote.

Then it creates the annotated tag, pushes it, and cuts the release. The tag-push path is unchanged — only the manual path validates the version, because older releases used a 3-segment scheme this pattern would reject.

**Explicit fan-out.** A tag pushed with `GITHUB_TOKEN` does not start new workflow runs (GitHub's recursion guard), so on the manual path the tag-driven workflows would never fire and the dispatch would produce a release with no images. `release.yml` now dispatches `build.yml` and `release-chart.yml`.

**`build.yml` — `workflow_dispatch` plus a `type=raw` version tag.** `type=match,pattern=v(.*)` reads the ref, and on a dispatch the ref is not a tag, so the version has to arrive as an explicit input. Applied to all four images.

**`supply-chain.yml` is deliberately not dispatched.** It signs as the project's Sigstore identity and is gated behind the `production` environment's required reviewer — the workflow's own comments call out identity laundering as the reason. Automating it around that gate would defeat it. `release.yml` emits a `::notice::` that it still needs a manual run per image.

**Incidental fix.** The release notes told users to `docker pull ghcr.io/…:v0.10.2.0` while `build.yml` publishes the tag with the `v` stripped (`0.10.2.0`), so every release so far has documented an image tag that does not exist. Both paths now derive the image tag from one resolved value. Flagging it rather than burying it — it is a behaviour change to the release body, in the same lines this PR was already parameterising.

## Usage

```bash
gh workflow run release.yml -f version=v0.10.2.0
```

Or the Actions tab → Release → Run workflow. `CLAUDE.md`'s release procedure documents this as the fallback when the environment cannot push a tag.

## Testing

- [x] `./tests/test-project-structure.sh` passes (24 passed, 0 failed)
- [x] `./tests/test-no-cyrillic.sh` passes
- [x] `scripts/docs-lint/wc-budget.sh`, `scripts/docs-lint/ai-slop-detector.sh` pass
- [x] Both workflow files parse as YAML; triggers resolve to `push`/`workflow_dispatch` and `push`/`pull_request`/`workflow_dispatch`
- [x] Every `${{ }}` value used in a `run:` block is bound to an `env:` var and referenced as `"$VAR"`, per the repo's semgrep `run-shell-injection` rule
- [ ] The dispatch path itself is not exercised here — it can only be tested by running it, and its first real run is the v0.10.2.0 release. The guards fail closed (bad version, missing CHANGELOG heading, existing tag all `exit 1` before the tag is created), so a misfire does not publish anything.

## Note for reviewers

The `type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}` line is inert on push and pull_request events, where `inputs.version` is empty. I chose it over `type=match,…,value=…` because metadata-action's docs only commit to `type=match` behaviour "on a push tag event" and say nothing about a dispatch at a tag ref — I did not want the version tag to depend on undocumented behaviour.

## ADRs reviewed (for `docs/future-architecture/` phase work)
- [x] N/A — this PR is not phase-execution work

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANrjgvAsVWTf66NBHi5i5G)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manual triggering for builds with optional version-based Docker image tagging.
  * Enhanced release automation to support manual tag creation/release when direct tag pushes are unavailable.
  * Added version resolution, duplicate-tag prevention, and changelog heading verification before releases.

* **Documentation**
  * Updated fallback manual release instructions, including how version validation and approval requirements work.
  * Refreshed version references for dispatched releases and downstream release/chart runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->