### PR TITLE
test(security): red-probe harnesses for the Layer-0 gates, and two gate fixes

### DIFF
--- a/.github/security-exceptions.yml
+++ b/.github/security-exceptions.yml
@@ -16,8 +16,15 @@
 #       reason: one-line justification
 #       remediation: one-line plan
 #
-# CI does NOT yet enforce this file format programmatically — that's a
-# follow-up task once we have actual exceptions to track. For now the file
-# is documentation + a future-CI input.
+# CI enforces this file on every run: tests/security/check_security_exceptions.py
+# refuses an entry past its `expires`, a window longer than 14 days, a
+# CRITICAL severity, a tool nobody runs, and any malformed or non-mapping
+# entry -- rather than skipping it, because a lenient reader's silence is
+# indistinguishable from a working one's. Every admitted exception prints on
+# every run; a silent exception reads like no exception at all.
+#
+# An empty list is the target state, not a stub. Adding an entry is a claim
+# that needs an argument in review, and it stops being accepted on its own
+# expiry date without anyone remembering to remove it.
 
 exceptions: []

--- a/.github/trufflehog-exclude.txt
+++ b/.github/trufflehog-exclude.txt
@@ -2,11 +2,38 @@
 # Copyright (c) 2025 Open Computer Use Contributors
 #
 # trufflehog path-exclude regexes (one per line), passed via --exclude-paths.
-# Only generated render artifacts that cannot carry a credential belong here.
+#
+# An entry belongs here only when the flagged bytes cannot be a credential --
+# a placeholder, a variable reference, or a synthetic fixture -- and the line
+# that was read is quoted in the reason. An entry added because a scan was
+# inconvenient is how a real secret gets hidden, so "it is noisy" is never a
+# reason on its own.
 #
 # architecture-overview.svg is a draw.io export of the component-map source
 # (architecture-overview.drawio). It embeds font glyph data as long base64/hex
 # runs, which the Box / generic high-entropy detectors match as unverified
-# secrets — a structural false positive on a generated diagram render that
+# secrets -- a structural false positive on a generated diagram render that
 # holds no credential. The .drawio source and every other file stay in scope.
 docs/architecture/diagrams/architecture-overview\.svg$
+
+# Reasons below describe the flagged construct rather than reproducing it. An
+# earlier revision of this file quoted each offending line verbatim to justify
+# its exclusion, and CI caught the result: the quotes tripped the same three
+# detectors, in this file, which is not itself excluded. Documenting a false
+# positive recreated it.
+
+# 09-agentbox.md line 57 documents a proxy environment variable whose value is
+# a user:password@host URI with a literal angle-bracket placeholder where the
+# token would go. There is no value to leak; the URI detector matches the form.
+docs/future-architecture/research/09-agentbox\.md$
+
+# values-open-webui.yaml line 34 sets a Postgres connection string whose
+# password position holds a shell-style environment-variable reference,
+# resolved from a Kubernetes Secret at render time rather than committed. The
+# Postgres detector matches the connection-string form.
+examples/helm/with-open-webui/values-open-webui\.yaml$
+
+# test_path_traversal_docker.py line 16 defines a hand-written sequential UUID
+# constant used as a path-traversal fixture. The Dockerhub detector matches
+# UUID shape.
+tests/security/test_path_traversal_docker\.py$

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,12 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+    env:
+      # Local only. Never reaches a registry, so it cannot be pulled by
+      # anyone and is not a consumer-reachable reference.
+      LOCAL_SMOKE_TAG: open-computer-use:smoke
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -55,35 +61,22 @@ jobs:
             type=match,pattern=v(.*),group=1
             type=sha
 
-      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
-        id: build
+      - name: Build into the local daemon for the smoke tests
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: .
           platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: false
           load: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.LOCAL_SMOKE_TAG }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Pick image tag for smoke tests
-        id: img
-        run: |
-          # docker/metadata-action emits newline-separated tags; grab the first
-          # non-blank line. Fail loudly if nothing came through so downstream
-          # `docker run` doesn't hit an empty image name with a cryptic error.
-          tag=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | sed '/^[[:space:]]*$/d' | head -n1)
-          if [ -z "$tag" ]; then
-            echo "No image tag produced by docker/metadata-action" >&2
-            exit 1
-          fi
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
       - name: Smoke test — image packages and CLI tools
         run: |
           chmod +x tests/test-docker-image.sh
-          ./tests/test-docker-image.sh "${{ steps.img.outputs.tag }}"
+          ./tests/test-docker-image.sh "${{ env.LOCAL_SMOKE_TAG }}"
 
       - name: Smoke test — Chromium launches in container
         run: |
@@ -91,7 +84,7 @@ jobs:
           # over the network: this test should only validate that chromium
           # binary + wire protocol work, not internet reachability.
           docker run --rm --platform linux/amd64 \
-            --entrypoint=python3 "${{ steps.img.outputs.tag }}" \
+            --entrypoint=python3 "${{ env.LOCAL_SMOKE_TAG }}" \
             -c "
           from playwright.sync_api import sync_playwright
           with sync_playwright() as p:
@@ -104,12 +97,40 @@ jobs:
               print(f'OK: title={title}')
           "
 
+      - name: Lowercase the image name
+        id: img
+        # Registries reject uppercase in a repository name, and
+        # `github.repository` carries the organisation's capitalisation.
+        # metadata-action lowercased it while the name came from `tags:`;
+        # push-by-digest takes the name verbatim, so do it here.
+        run: |
+          printf 'ref=%s\n' \
+            "$(printf '%s' "ghcr.io/${{ github.repository }}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Push by digest, with no tag
+        id: push
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: .
+          platforms: linux/amd64
+          # No `tags:`. push-by-digest uploads the manifest and returns its
+          # digest without attaching any name a consumer could pull. The
+          # release tag is attached by the promote job, after the signature
+          # exists. Until then the image is in the registry but unreachable
+          # by name -- which is the whole point of the split.
+          outputs: type=image,name=${{ steps.img.outputs.ref }},push-by-digest=true,name-canonical=true,push=true
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+
   build-server:
     name: Build Server Image
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -137,14 +158,34 @@ jobs:
             type=match,pattern=v(.*),group=1
             type=sha
 
-      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+      - name: Build, without publishing anything
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: ./computer-use-server
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          push: false
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Lowercase the image name
+        id: img
+        # Registries reject uppercase in a repository name, and
+        # `github.repository` carries the organisation's capitalisation.
+        # metadata-action lowercased it while the name came from `tags:`;
+        # push-by-digest takes the name verbatim, so do it here.
+        run: |
+          printf 'ref=%s\n' \
+            "$(printf '%s' "ghcr.io/${{ github.repository }}-server" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Push by digest, with no tag
+        id: push
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: ./computer-use-server
+          outputs: type=image,name=${{ steps.img.outputs.ref }},push-by-digest=true,name-canonical=true,push=true
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
 
   build-cleanup:
     name: Build Cleanup Image
@@ -152,6 +193,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -179,14 +222,34 @@ jobs:
             type=match,pattern=v(.*),group=1
             type=sha
 
-      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+      - name: Build, without publishing anything
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: ./cron
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          push: false
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Lowercase the image name
+        id: img
+        # Registries reject uppercase in a repository name, and
+        # `github.repository` carries the organisation's capitalisation.
+        # metadata-action lowercased it while the name came from `tags:`;
+        # push-by-digest takes the name verbatim, so do it here.
+        run: |
+          printf 'ref=%s\n' \
+            "$(printf '%s' "ghcr.io/${{ github.repository }}-cleanup" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Push by digest, with no tag
+        id: push
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: ./cron
+          outputs: type=image,name=${{ steps.img.outputs.ref }},push-by-digest=true,name-canonical=true,push=true
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
 
   build-webui:
     name: Build Patched Open WebUI Image
@@ -194,6 +257,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -221,14 +286,189 @@ jobs:
             type=match,pattern=v(.*),group=1
             type=sha
 
-      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+      - name: Build, without publishing anything
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: ./openwebui
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          push: false
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Lowercase the image name
+        id: img
+        # Registries reject uppercase in a repository name, and
+        # `github.repository` carries the organisation's capitalisation.
+        # metadata-action lowercased it while the name came from `tags:`;
+        # push-by-digest takes the name verbatim, so do it here.
+        run: |
+          printf 'ref=%s\n' \
+            "$(printf '%s' "ghcr.io/${{ github.repository }}-webui" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Push by digest, with no tag
+        id: push
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: ./openwebui
+          outputs: type=image,name=${{ steps.img.outputs.ref }},push-by-digest=true,name-canonical=true,push=true
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+
+  sign:
+    name: Sign each digest, while no tag points at it
+    needs: [build-sandbox, build-server, build-cleanup, build-webui]
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    # The approval sits here rather than after publication. A reviewer holding
+    # this job holds the release, and nothing is pullable by name until
+    # `promote` runs -- so the wait exposes nothing. Held after a tagged push,
+    # the same wait would be a window in which the image is public and
+    # unsigned.
+    environment: production
+    permissions:
+      contents: read
+      id-token: write     # Cosign keyless via Sigstore OIDC.
+      packages: write     # Signatures and attestations are pushed to GHCR.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suffix: ""
+            digest: ${{ needs.build-sandbox.outputs.digest }}
+          - suffix: "-server"
+            digest: ${{ needs.build-server.outputs.digest }}
+          - suffix: "-cleanup"
+            digest: ${{ needs.build-cleanup.outputs.digest }}
+          - suffix: "-webui"
+            digest: ${{ needs.build-webui.outputs.digest }}
+    env:
+      SUFFIX: ${{ matrix.suffix }}
+      DIGEST: ${{ matrix.digest }}
+      REPO: ${{ github.repository }}
+
+    steps:
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve the reference, refusing an absent digest
+        id: ref
+        # A build job that pushed nothing leaves its output empty, and an
+        # empty digest would make the reference `ghcr.io/x@` -- which cosign
+        # rejects with a parse error rather than a statement about signing.
+        # Fail here, where the reason is legible.
+        run: |
+          if [ -z "$DIGEST" ]; then
+            echo "::error::no digest from the build job; there is nothing to sign" >&2
+            exit 1
+          fi
+          repo_lower="$(printf '%s' "$REPO" | tr '[:upper:]' '[:lower:]')"
+          printf 'ref=ghcr.io/%s%s@%s\n' "$repo_lower" "$SUFFIX" "$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@1aa8e0f2454b781fbf0fbf306a4c9533a0c57409  # v3.7.0
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@fc46e51fd3cb168ffb36c6d1915723c47db58abb  # v0.17.7
+
+      - name: Generate SBOM (SPDX JSON)
+        env:
+          IMAGE_REF: ${{ steps.ref.outputs.ref }}
+        run: syft "$IMAGE_REF" -o spdx-json=sbom.spdx.json
+
+      - name: Refuse to attest an SBOM that describes nothing
+        # syft exiting zero does not mean it resolved anything. Without this a
+        # degenerate SBOM is attested and verification still passes, because
+        # verification checks that an attestation exists and is signed by the
+        # right identity -- not that its predicate describes the image.
+        run: |
+          if [ ! -s sbom.spdx.json ]; then
+            echo "::error::sbom.spdx.json is absent or empty; syft produced no SBOM" >&2
+            exit 1
+          fi
+          if ! jq -e . sbom.spdx.json >/dev/null 2>&1; then
+            echo "::error::sbom.spdx.json is not valid JSON" >&2
+            exit 1
+          fi
+          pkgs="$(jq '(.packages // []) | length' sbom.spdx.json)"
+          echo "SPDX packages: ${pkgs}"
+          if [ "$pkgs" -eq 0 ]; then
+            echo "::error::an SBOM listing zero packages describes nothing; refusing to attest it" >&2
+            exit 1
+          fi
+
+      - name: Sign the digest (keyless via Sigstore)
+        env:
+          IMAGE_REF: ${{ steps.ref.outputs.ref }}
+        run: cosign sign --yes "$IMAGE_REF"
+
+      - name: Attest the SBOM against the digest
+        env:
+          IMAGE_REF: ${{ steps.ref.outputs.ref }}
+        run: cosign attest --yes --predicate sbom.spdx.json --type spdxjson "$IMAGE_REF"
+
+  promote:
+    name: Attach release tags to digests that are already signed
+    # `sign` is in `needs`, so this job cannot start until every signature
+    # exists. That edge is the whole gate: it is what makes the tag -- the
+    # first reference a consumer can pull -- appear after the signature
+    # rather than beside it.
+    needs: [build-sandbox, build-server, build-cleanup, build-webui, sign]
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suffix: ""
+            digest: ${{ needs.build-sandbox.outputs.digest }}
+          - suffix: "-server"
+            digest: ${{ needs.build-server.outputs.digest }}
+          - suffix: "-cleanup"
+            digest: ${{ needs.build-cleanup.outputs.digest }}
+          - suffix: "-webui"
+            digest: ${{ needs.build-webui.outputs.digest }}
+    env:
+      SUFFIX: ${{ matrix.suffix }}
+      DIGEST: ${{ matrix.digest }}
+      REPO: ${{ github.repository }}
+
+    steps:
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}${{ matrix.suffix }}
+          tags: |
+            type=ref,event=branch
+            type=match,pattern=v(.*),group=1
+            type=sha
+
+      - name: Point every release tag at the signed digest
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          if [ -z "$DIGEST" ]; then
+            echo "::error::no digest to promote" >&2
+            exit 1
+          fi
+          repo_lower="$(printf '%s' "$REPO" | tr '[:upper:]' '[:lower:]')"
+          src="ghcr.io/${repo_lower}${SUFFIX}@${DIGEST}"
+          printf '%s\n' "$TAGS" | sed '/^[[:space:]]*$/d' | while read -r tag; do
+            echo "promoting ${tag} -> ${src}"
+            docker buildx imagetools create --tag "$tag" "$src"
+          done
 
   test:
     name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -348,6 +348,10 @@ jobs:
       REPO: ${{ github.repository }}
 
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -356,17 +360,10 @@ jobs:
 
       - name: Resolve the reference, refusing an absent digest
         id: ref
-        # A build job that pushed nothing leaves its output empty, and an
-        # empty digest would make the reference `ghcr.io/x@` -- which cosign
-        # rejects with a parse error rather than a statement about signing.
-        # Fail here, where the reason is legible.
-        run: |
-          if [ -z "$DIGEST" ]; then
-            echo "::error::no digest from the build job; there is nothing to sign" >&2
-            exit 1
-          fi
-          repo_lower="$(printf '%s' "$REPO" | tr '[:upper:]' '[:lower:]')"
-          printf 'ref=ghcr.io/%s%s@%s\n' "$repo_lower" "$SUFFIX" "$DIGEST" >> "$GITHUB_OUTPUT"
+        # Shared with gate3-rehearsal.yml, which exercises this exact file
+        # against a throwaway registry. An inline copy here would mean the
+        # rehearsal proves the copy.
+        run: bash tests/security/resolve_ref_guard.sh
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@1aa8e0f2454b781fbf0fbf306a4c9533a0c57409  # v3.7.0
@@ -380,25 +377,9 @@ jobs:
         run: syft "$IMAGE_REF" -o spdx-json=sbom.spdx.json
 
       - name: Refuse to attest an SBOM that describes nothing
-        # syft exiting zero does not mean it resolved anything. Without this a
-        # degenerate SBOM is attested and verification still passes, because
-        # verification checks that an attestation exists and is signed by the
-        # right identity -- not that its predicate describes the image.
-        run: |
-          if [ ! -s sbom.spdx.json ]; then
-            echo "::error::sbom.spdx.json is absent or empty; syft produced no SBOM" >&2
-            exit 1
-          fi
-          if ! jq -e . sbom.spdx.json >/dev/null 2>&1; then
-            echo "::error::sbom.spdx.json is not valid JSON" >&2
-            exit 1
-          fi
-          pkgs="$(jq '(.packages // []) | length' sbom.spdx.json)"
-          echo "SPDX packages: ${pkgs}"
-          if [ "$pkgs" -eq 0 ]; then
-            echo "::error::an SBOM listing zero packages describes nothing; refusing to attest it" >&2
-            exit 1
-          fi
+        # Shared with gate3-rehearsal.yml, which drives this script through
+        # three fixtures that each violate one of its conditions.
+        run: bash tests/security/sbom_guard.sh sbom.spdx.json
 
       - name: Sign the digest (keyless via Sigstore)
         env:

--- a/.github/workflows/gate3-rehearsal.yml
+++ b/.github/workflows/gate3-rehearsal.yml
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# Runs the release pipeline's shape end to end against a registry that lives
+# and dies with the job, so the mechanism is observed rather than reasoned
+# about.
+#
+# Why this exists. The signing pipeline in build.yml has never executed. Across
+# the whole fleet, measured 2026-07-31, not one component has ever produced a
+# signature: canon carries 36 tags per image and zero cosign artifacts. The
+# release path only runs on a tag push, and a tag push publishes. So the gate
+# that is supposed to refuse an unsigned artifact has never been asked to
+# refuse anything, and "the workflow is correct" rests on reading it.
+#
+# What is proven here: that push-by-digest yields a digest, that an empty SBOM
+# stops the pipeline, that an absent digest is refused before cosign turns it
+# into a parse error, that a signature verifies, and that a promoted tag
+# resolves to the digest that was signed rather than to some other one.
+#
+# What is NOT proven here, stated so it is not read as more: this uses a key
+# pair generated in the job, not Sigstore keyless with the workflow's OIDC
+# identity, and writes nothing to a transparency log. The certificate-identity
+# anchoring that a real release depends on is covered separately by
+# tests/security/check_cosign_identity_anchor.sh. A first real release still
+# has to be made deliberately and watched.
+#
+# Nothing leaves the runner: the only registry is 127.0.0.1:5000, started as a
+# service container. tests/security/check_signing_precedes_publish.py knows
+# that a runner-local registry is not a consumer-reachable reference, so this
+# file does not need an exemption to pass its own gate.
+
+name: gate3-rehearsal
+
+on:
+  pull_request:
+  push:
+    branches: [next/v1]
+
+permissions:
+  contents: read
+
+jobs:
+  rehearsal:
+    name: release — gate 3 rehearsal (nothing published)
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373
+        ports:
+          - 5000:5000
+    env:
+      REG: 127.0.0.1:5000
+      IMG: 127.0.0.1:5000/gate3-rehearsal
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+        with:
+          # push-by-digest is not implemented for the `docker` driver -- it
+          # errors out rather than falling back to a tagged push. Measured
+          # locally before this file was written. The container driver is what
+          # makes a tagless push possible at all.
+          driver-opts: network=host
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@1aa8e0f2454b781fbf0fbf306a4c9533a0c57409  # v3.7.0
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@fc46e51fd3cb168ffb36c6d1915723c47db58abb  # v0.17.7
+
+      - name: Wait for the throwaway registry
+        run: |
+          for i in $(seq 1 30); do
+            if curl -fsS "http://${REG}/v2/" >/dev/null 2>&1; then
+              echo "registry up after ${i}s"; exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::the rehearsal registry never came up" >&2
+          exit 1
+
+      - name: Generate an ephemeral key pair
+        env:
+          COSIGN_PASSWORD: ""
+        run: |
+          # A key pair, not keyless. Keyless would mint a Sigstore certificate
+          # against this workflow's OIDC identity and write a permanent public
+          # transparency-log entry for an image that exists for ninety seconds.
+          cosign generate-key-pair
+          test -s cosign.key && test -s cosign.pub
+
+      - name: Build a subject and push it by digest, with no tag
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: tests/security/rehearsal-subject
+          outputs: type=image,name=127.0.0.1:5000/gate3-rehearsal,push-by-digest=true,name-canonical=true,push=true,registry.insecure=true
+
+      - name: The digest exists, and no tag does
+        run: |
+          digest="${{ steps.build.outputs.digest }}"
+          if [ -z "$digest" ]; then
+            echo "::error::push-by-digest produced no digest" >&2
+            exit 1
+          fi
+          echo "digest: ${digest}"
+          tags="$(curl -fsS "http://${REG}/v2/gate3-rehearsal/tags/list")"
+          echo "tag list after the digest push: ${tags}"
+          # `"tags":null` is what a repository with no tags returns. If a tag
+          # exists at this point the push was not by digest and the window this
+          # whole design closes is open again.
+          case "$tags" in
+            *'"tags":null'*|*'"tags": null'*|*'"tags":[]'*) ;;
+            *) echo "::error::a tag exists before signing: ${tags}" >&2; exit 1 ;;
+          esac
+
+      - name: Generate the SBOM
+        run: |
+          syft "${IMG}@${{ steps.build.outputs.digest }}" \
+            -o spdx-json=sbom.spdx.json
+          jq '(.packages // []) | length' sbom.spdx.json
+
+      - name: RED LEG - an SBOM describing nothing must stop the pipeline
+        run: |
+          # The same three conditions build.yml applies, run against fixtures
+          # that each violate exactly one of them. A guard nobody has seen
+          # refuse anything is a comment.
+          printf '' > empty.json
+          printf 'not json at all' > garbage.json
+          printf '{"packages":[]}' > nopkgs.json
+          for f in empty.json garbage.json nopkgs.json; do
+            if bash tests/security/sbom_guard.sh "$f"; then
+              echo "::error::the SBOM guard accepted ${f}" >&2
+              exit 1
+            fi
+            echo "ok: guard refused ${f}"
+          done
+          bash tests/security/sbom_guard.sh sbom.spdx.json
+          echo "ok: guard accepted the real SBOM"
+
+      - name: RED LEG - an absent digest must be refused before cosign sees it
+        run: |
+          if DIGEST="" SUFFIX="" REPO="x/y" \
+             bash tests/security/resolve_ref_guard.sh; then
+            echo "::error::an empty digest was accepted" >&2
+            exit 1
+          fi
+          echo "ok: refused an empty digest"
+
+      - name: Sign the digest
+        env:
+          COSIGN_PASSWORD: ""
+        run: |
+          cosign sign --yes --key cosign.key --tlog-upload=false \
+            --allow-insecure-registry "${IMG}@${{ steps.build.outputs.digest }}"
+
+      - name: The signature verifies
+        run: |
+          cosign verify --key cosign.pub --insecure-ignore-tlog=true \
+            --allow-insecure-registry "${IMG}@${{ steps.build.outputs.digest }}"
+
+      - name: RED LEG - a different digest must not verify against this signature
+        run: |
+          # Signing one artifact must not vouch for another. Without this the
+          # green leg above only proves that some signature exists somewhere in
+          # the repository.
+          other="$(printf 'unsigned-subject' | sha256sum | cut -d' ' -f1)"
+          if cosign verify --key cosign.pub --insecure-ignore-tlog=true \
+               --allow-insecure-registry "${IMG}@sha256:${other}" 2>/dev/null; then
+            echo "::error::verification passed for a digest that was never signed" >&2
+            exit 1
+          fi
+          echo "ok: an unsigned digest does not verify"
+
+      - name: Promote a tag onto the signed digest
+        run: |
+          # The reference stands here literally, not behind ${IMG}. A
+          # reviewer asking "what leaves this job" reads one line, and the
+          # signing-order check can see that the destination is a registry
+          # that dies with the job.
+          # On one line on purpose. A line-oriented reader -- the signing-order
+          # check, and a person scanning for what leaves this job -- sees the
+          # destination beside the verb. Split across continuations, the verb
+          # is on one line and the reference on another, and the check reported
+          # a publish it could not resolve. It was right to.
+          docker buildx imagetools create --tag 127.0.0.1:5000/gate3-rehearsal:rehearsal "127.0.0.1:5000/gate3-rehearsal@${{ steps.build.outputs.digest }}"
+
+      - name: The promoted tag resolves to the digest that was signed
+        run: |
+          want="${{ steps.build.outputs.digest }}"
+          got="$(docker buildx imagetools inspect "${IMG}:rehearsal" \
+                 --format '{{.Manifest.Digest}}')"
+          echo "tag -> ${got}"
+          echo "signed ${want}"
+          if [ "$got" != "$want" ]; then
+            echo "::error::the promoted tag resolves to ${got}, not the signed ${want}" >&2
+            exit 1
+          fi
+          cosign verify --key cosign.pub --insecure-ignore-tlog=true \
+            --allow-insecure-registry "${IMG}:rehearsal"
+          echo "ok: the tag a consumer would pull carries the signature"

--- a/.github/workflows/gate3-rehearsal.yml
+++ b/.github/workflows/gate3-rehearsal.yml
@@ -5,12 +5,19 @@
 # and dies with the job, so the mechanism is observed rather than reasoned
 # about.
 #
-# Why this exists. The signing pipeline in build.yml has never executed. Across
-# the whole fleet, measured 2026-07-31, not one component has ever produced a
-# signature: canon carries 36 tags per image and zero cosign artifacts. The
-# release path only runs on a tag push, and a tag push publishes. So the gate
-# that is supposed to refuse an unsigned artifact has never been asked to
-# refuse anything, and "the workflow is correct" rests on reading it.
+# Why this exists. The signing pipeline in build.yml has never executed. This
+# repository carries 36 tags per published image and zero cosign artifacts,
+# measured 2026-07-31 by enumerating the tags rather than by constructing a
+# reference, which is spelling-independent. The release path only runs on a tag
+# push, and a tag push publishes. So the gate that is supposed to refuse an
+# unsigned artifact has never been asked to refuse anything, and "the workflow
+# is correct" rests on reading it.
+#
+# An earlier version of this comment said no component in the fleet had ever
+# produced a signature. That was wrong and is corrected here rather than
+# quietly dropped: a sibling repository has five signed releases and one
+# unsigned one, measured the same way. The true statement is narrower and is
+# about this repository only.
 #
 # What is proven here: that push-by-digest yields a digest, that an empty SBOM
 # stops the pipeline, that an absent digest is refused before cosign turns it

--- a/.github/workflows/gate3-rehearsal.yml
+++ b/.github/workflows/gate3-rehearsal.yml
@@ -99,7 +99,7 @@ jobs:
           context: tests/security/rehearsal-subject
           outputs: type=image,name=127.0.0.1:5000/gate3-rehearsal,push-by-digest=true,name-canonical=true,push=true,registry.insecure=true
 
-      - name: The digest exists, and no tag does
+      - name: The digest exists, the artifact landed, and no tag points at it
         run: |
           digest="${{ steps.build.outputs.digest }}"
           if [ -z "$digest" ]; then
@@ -107,14 +107,44 @@ jobs:
             exit 1
           fi
           echo "digest: ${digest}"
-          tags="$(curl -fsS "http://${REG}/v2/gate3-rehearsal/tags/list")"
-          echo "tag list after the digest push: ${tags}"
-          # `"tags":null` is what a repository with no tags returns. If a tag
-          # exists at this point the push was not by digest and the window this
-          # whole design closes is open again.
-          case "$tags" in
-            *'"tags":null'*|*'"tags": null'*|*'"tags":[]'*) ;;
-            *) echo "::error::a tag exists before signing: ${tags}" >&2; exit 1 ;;
+
+          # Two questions, asked separately on purpose. The first run of this
+          # conflated them: `tags/list` answered 404 and the step died on
+          # curl's exit 22, which reads identically whether the registry means
+          # "this repository has no tags" or "nothing was ever pushed here".
+          # One of those is the result being asserted; the other would be a
+          # finding about the pipeline.
+
+          # 1. Did the artifact land? A manifest reachable by digest says yes.
+          man=$(curl -sS -o /dev/null -w '%{http_code}' \
+                  -H 'Accept: application/vnd.oci.image.index.v1+json' \
+                  -H 'Accept: application/vnd.docker.distribution.manifest.list.v2+json' \
+                  -H 'Accept: application/vnd.oci.image.manifest.v1+json' \
+                  "http://${REG}/v2/gate3-rehearsal/manifests/${digest}")
+          echo "manifest by digest -> HTTP ${man}"
+          if [ "$man" != "200" ]; then
+            echo "::error::the digest push did not land: manifest returned ${man}" >&2
+            exit 1
+          fi
+
+          # 2. Is any tag pointing at it? 404 here means the registry knows no
+          # tagged repository by that name, which is the same answer as an
+          # empty list and is what a digest-only push should produce.
+          code=$(curl -sS -o /tmp/tags.json -w '%{http_code}' \
+                   "http://${REG}/v2/gate3-rehearsal/tags/list")
+          body=$(cat /tmp/tags.json 2>/dev/null || true)
+          echo "tags/list -> HTTP ${code}  body: ${body}"
+          case "$code" in
+            404) echo "ok: no tagged repository exists yet" ;;
+            200)
+              case "$body" in
+                *'"tags":null'*|*'"tags": null'*|*'"tags":[]'*|*'"tags": []'*)
+                  echo "ok: the repository exists and carries no tag" ;;
+                *)
+                  echo "::error::a tag exists before signing: ${body}" >&2
+                  exit 1 ;;
+              esac ;;
+            *) echo "::error::unexpected ${code} from tags/list" >&2; exit 1 ;;
           esac
 
       - name: Generate the SBOM

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -183,6 +183,13 @@ jobs:
           # Diff-aware semgrep needs history back to the merge-base.
           fetch-depth: 0
           persist-credentials: false
+      - name: Self-test the hand-written rules before trusting their verdict
+        # `semgrep test` checks each `ruleid:`/`ok:` annotation in the fixture
+        # against the rule that actually fired, so a finding raised for the
+        # wrong reason fails here rather than passing as coverage. A rule whose
+        # own fixture does not hold should not be allowed to gate anything.
+        run: semgrep --metrics=off --test --config .semgrep/ .semgrep/
+
       - name: Semgrep CI (community rules)
         env:
           # Required for diff-aware scanning + PR commenting. Without it,
@@ -200,7 +207,20 @@ jobs:
           # without first probing /c/p/<name>. Bash-in-YAML coverage
           # comes from p/security-audit + p/github-actions; Docker
           # socket misuse from p/dockerfile.
+          #
+          # `--config .semgrep/` adds the hand-written rules. They exist
+          # because the six packs below load 694 rules, run 205 of them
+          # against this repository's Python, and cover none of the one
+          # idiomatic regression its own code can produce. Measured, not
+          # assumed: see the header of the rule file.
+          #
+          # `--exclude` keeps the rule fixtures out of the scan. They contain
+          # the real vulnerable forms by construction, so without this the
+          # gate reddens on its own test data -- verified: 4 findings with the
+          # fixture in scope, 0 with it excluded.
           semgrep ci \
+            --exclude '*.fixture.py' \
+            --config ".semgrep/" \
             --config "p/security-audit" \
             --config "p/owasp-top-ten" \
             --config "p/python" \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -334,3 +334,37 @@ jobs:
             style
             revert
           requireScope: false
+
+  release-signing-order:
+    name: release — signing precedes publish
+    runs-on: ubuntu-latest
+    # This gate reads workflow files, so unlike the release pipeline itself it
+    # can run on a pull request and can therefore be a required check. The
+    # signing pipeline is tag-triggered and produces no PR status at all; a
+    # job whose `if:` excludes pull_request would be skipped, and a skipped
+    # required check counts as passed, so requiring it would be worse than
+    # leaving it out. This one has no `if:` and no trigger exclusion.
+    #
+    # It currently FAILS on this branch, correctly: build.yml publishes four
+    # images on a tag, supply-chain.yml signs them on the same tag, and
+    # nothing orders the two. The failure is the finding, and switching the
+    # gate off because it reports a true thing is the defect this whole set of
+    # gates exists to prevent.
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.12"
+      - name: Install PyYAML
+        # Version-pinned, not hash-pinned. A hash pin belongs here by the
+        # dependency policy, and inventing one unverified would be worse than
+        # stating its absence -- the pin lands when the digest is fetched
+        # rather than guessed.
+        run: pip install pyyaml==6.0.2
+      - name: Self-test the checker before trusting its verdict
+        run: python3 tests/security/check_signing_precedes_publish.py --self-test
+      - name: Check that no image is published before it is signed
+        run: python3 tests/security/check_signing_precedes_publish.py

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -356,7 +356,7 @@ jobs:
           requireScope: false
 
   release-signing-order:
-    name: release — signing precedes publish
+    name: release — pipeline integrity (signing order, cross-job wiring)
     runs-on: ubuntu-latest
     # This gate reads workflow files, so unlike the release pipeline itself it
     # can run on a pull request and can therefore be a required check. The
@@ -388,3 +388,15 @@ jobs:
         run: python3 tests/security/check_signing_precedes_publish.py --self-test
       - name: Check that no image is published before it is signed
         run: python3 tests/security/check_signing_precedes_publish.py
+
+      - name: Self-test the cross-job wiring checker
+        run: python3 tests/security/check_cross_job_outputs.py --self-test
+
+      - name: Check that every cross-job output reference resolves
+        # `${{ needs.<job>.outputs.<key> }}` evaluates to the empty string when
+        # the producer is missing, misspelled, or declares something else. The
+        # release pipeline carries the image digest across three jobs on
+        # exactly this mechanism, and the gate3 rehearsal cannot reach it --
+        # the rehearsal is one job, because its registry is a service
+        # container that does not outlive the job.
+        run: python3 tests/security/check_cross_job_outputs.py

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -300,7 +300,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
       - name: Install checkov

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -400,3 +400,14 @@ jobs:
         # the rehearsal is one job, because its registry is a service
         # container that does not outlive the job.
         run: python3 tests/security/check_cross_job_outputs.py
+
+      - name: Self-test the exception-ledger checker
+        run: python3 tests/security/check_security_exceptions.py --self-test
+
+      - name: Enforce the HIGH-exception ledger
+        # The ledger carried a schema with `since`, `expires`, an owner and a
+        # remediation, and a note saying CI enforced none of it. An exception
+        # file nothing reads is not a control: entries outlive their reasons
+        # because nothing asks whether they are still needed. This is the same
+        # standard being asked of sibling repositories, applied here.
+        run: python3 tests/security/check_security_exceptions.py

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -150,6 +150,39 @@ jobs:
             -o spdx-json=sbom.spdx.json \
             -o cyclonedx-json=sbom.cdx.json
 
+      - name: Refuse to attest an empty SBOM
+        # syft exiting zero does not mean it resolved anything. Without this,
+        # a degenerate SBOM would be attested and the verification step below
+        # would pass, because it checks that an attestation exists and is
+        # signed by the right identity -- not that its predicate describes the
+        # image.
+        #
+        # Whether cosign itself rejects a degenerate predicate is not the
+        # answer here. It resolves the image reference before it reads the
+        # predicate file, so an empty, a well-formed-empty and a malformed
+        # predicate all fail identically against an unreachable image and
+        # identically pass the file to the registry against a reachable one.
+        # The property is asserted locally instead of inferred from a tool
+        # whose behaviour we have not established.
+        run: |
+          for f in sbom.spdx.json sbom.cdx.json; do
+            if [ ! -s "$f" ]; then
+              echo "::error::$f is absent or empty; syft produced no SBOM" >&2
+              exit 1
+            fi
+            if ! jq -e . "$f" >/dev/null 2>&1; then
+              echo "::error::$f is not valid JSON" >&2
+              exit 1
+            fi
+          done
+          spdx_pkgs="$(jq '(.packages // []) | length' sbom.spdx.json)"
+          cdx_comps="$(jq '(.components // []) | length' sbom.cdx.json)"
+          echo "SPDX packages: ${spdx_pkgs}, CycloneDX components: ${cdx_comps}"
+          if [ "$spdx_pkgs" -eq 0 ] || [ "$cdx_comps" -eq 0 ]; then
+            echo "::error::an SBOM listing zero packages describes nothing; refusing to attest it" >&2
+            exit 1
+          fi
+
       - name: Sign image (keyless via Sigstore)
         env:
           IMAGE_REF: ${{ steps.ref.outputs.ref }}

--- a/.semgrep/python-unsafe-yaml-load.fixture.py
+++ b/.semgrep/python-unsafe-yaml-load.fixture.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# Fixture for python-unsafe-yaml-load, consumed by `semgrep test .semgrep/`.
+#
+# The annotations are the assertion: `ruleid:` marks a line the rule must flag,
+# `ok:` a line it must not. `semgrep test` compares them against the rule's own
+# output and fails when a line is flagged by a different rule than the one
+# named, so a finding raised for the wrong reason does not pass as a finding.
+#
+# The two unsafe forms live in separate functions on purpose. A rule that only
+# reddens on one literal line is a signature, not a rule.
+
+import yaml
+
+
+def load_manifest_no_loader(text):
+    """Form 1: the loader argument is simply absent."""
+    # ruleid: python-unsafe-yaml-load
+    return yaml.load(text)
+
+
+def load_manifest_unsafe_entry_point(fh):
+    """Form 2: the explicitly unsafe entry point, a different call entirely."""
+    # ruleid: python-unsafe-yaml-load
+    return yaml.unsafe_load(fh)
+
+
+def load_manifest_named_unsafe_loader(text):
+    """A loader is passed, and it is the unsafe one."""
+    # ruleid: python-unsafe-yaml-load
+    return yaml.load(text, Loader=yaml.UnsafeLoader)
+
+
+def load_manifest_full_loader(text):
+    """FullLoader is not SafeLoader. Subtraction catches it without naming it."""
+    # ruleid: python-unsafe-yaml-load
+    return yaml.load(text, Loader=yaml.FullLoader)
+
+
+def load_frontmatter(text):
+    """The form every in-scope call site actually uses. Must stay silent."""
+    # ok: python-unsafe-yaml-load
+    return yaml.safe_load(text)
+
+
+def load_with_explicit_safe_loader(text):
+    """Equivalent to safe_load, spelled out. Must stay silent."""
+    # ok: python-unsafe-yaml-load
+    return yaml.load(text, Loader=yaml.SafeLoader)
+
+
+def load_with_positional_safe_loader(text):
+    """Same, passed positionally rather than by keyword. Must stay silent."""
+    # ok: python-unsafe-yaml-load
+    return yaml.load(text, yaml.SafeLoader)
+
+
+def dump_is_not_a_load(data):
+    """Serialisation is not deserialisation. Must stay silent."""
+    # ok: python-unsafe-yaml-load
+    return yaml.dump(data)

--- a/.semgrep/python-unsafe-yaml-load.yml
+++ b/.semgrep/python-unsafe-yaml-load.yml
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# Why this rule is written by hand rather than pulled from a pack.
+#
+# The Layer 0 SAST gate loads 694 community rules and runs 205 of them
+# against this repository's Python. Measured 2026-07-31 with the image the
+# gate pins by digest (semgrep 1.163.0,
+# sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03):
+# changing `yaml.safe_load` to `yaml.load` in
+# skills/public/skill-creator/scripts/quick_validate.py produced 0 findings,
+# byte-identical to the unmodified file. The gate is not broken -- it loads
+# its rules and scans the target. This class is simply not in any of the six
+# configured packs.
+#
+# That distinction is the point. A gate that fires on the form printed in a
+# rule's documentation, and stays silent on the form the codebase is actually
+# written in, proves that the packs loaded, not that the code is guarded. Every
+# YAML read in this repository's in-scope Python goes through `yaml.safe_load`;
+# the regression that matters here is someone dropping the `safe_`.
+
+rules:
+  - id: python-unsafe-yaml-load
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: security
+      cwe: "CWE-502: Deserialization of Untrusted Data"
+      confidence: HIGH
+      references:
+        - https://pyyaml.org/wiki/PyYAMLDocumentation
+    message: >-
+      Unsafe YAML deserialization: this call constructs arbitrary Python objects
+      from the document instead of plain data, so a YAML file that reaches it is
+      code execution, not input. Use yaml.safe_load(...), or pass
+      Loader=yaml.SafeLoader explicitly. Every in-scope YAML read in this
+      repository uses safe_load; dropping it is the regression this rule exists
+      to catch.
+    patterns:
+      - pattern-either:
+          # Form 1: the explicitly unsafe entry point.
+          - pattern: yaml.unsafe_load(...)
+          # Form 2: yaml.load with a loader that is absent or unsafe. Written as
+          # a subtraction rather than an enumeration of unsafe loaders, so a
+          # loader nobody has thought of yet is caught rather than missed.
+          - patterns:
+              - pattern: yaml.load(...)
+              - pattern-not: yaml.load($DOC, Loader=yaml.SafeLoader, ...)
+              - pattern-not: yaml.load($DOC, Loader=yaml.CSafeLoader, ...)
+              - pattern-not: yaml.load($DOC, yaml.SafeLoader, ...)
+              - pattern-not: yaml.load($DOC, yaml.CSafeLoader, ...)

--- a/tests/security/check_cosign_identity_anchor.sh
+++ b/tests/security/check_cosign_identity_anchor.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# Assert that the release pipeline's certificate-identity pattern rejects the
+# identities it claims to reject.
+#
+# supply-chain.yml builds a `--certificate-identity-regexp` for `cosign
+# verify` and its comments state two properties: the pattern is anchored, so
+# a typosquat repository or a signature from another workflow in the same
+# repository cannot satisfy it; and regex metacharacters in the tag are
+# escaped, so `v0.9.5.1` cannot be matched by a same-shape tag such as
+# `v0a9b5c1`. Both are load-bearing -- a signature that verifies against the
+# wrong identity is worth nothing -- and neither had a test.
+#
+# The pattern construction below is copied byte-for-byte from the workflow.
+# It is duplicated rather than sourced because the workflow embeds it in a
+# `run:` block; the drift-guard is that this file names the source and any
+# edit there must be mirrored here.
+#
+# Boundary, stated rather than assumed: cosign matches with Go's RE2 and this
+# harness matches with `grep -E` (POSIX ERE). The two agree on anchoring,
+# alternation, and literal-vs-metacharacter dots, which is the whole of what
+# is asserted here. A property depending on RE2-specific semantics would need
+# cosign itself.
+#
+# Usage: check_cosign_identity_anchor.sh
+# Exit 0 when every identity is classified as intended, 1 otherwise.
+
+set -uo pipefail
+
+WORKFLOW_SOURCE=".github/workflows/supply-chain.yml"
+
+# --- copied verbatim from ${WORKFLOW_SOURCE} ---------------------------------
+build_cert_id() {
+  REF_NAME="$1"; REPO_FOR_VERIFY="$2"; EVENT_NAME="$3"
+  ref_re="$(printf '%s' "$REF_NAME" | sed -E 's/[][\\.*^$()+?{|]/\\&/g')"
+  repo_re="$(printf '%s' "$REPO_FOR_VERIFY" | sed -E 's/[][\\.*^$()+?{|]/\\&/g')"
+  if [ "$EVENT_NAME" = "push" ]; then
+    cert_id="^https://github\\.com/${repo_re}/\\.github/workflows/supply-chain\\.yml@refs/tags/${ref_re}$"
+  else
+    cert_id="^https://github\\.com/${repo_re}/\\.github/workflows/supply-chain\\.yml@(refs/tags/v[0-9.]+|refs/heads/(main|next/v1))$"
+  fi
+  printf '%s' "$cert_id"
+}
+# --- end copied block --------------------------------------------------------
+
+REPO="Wide-Moat/open-computer-use"
+TAG="v0.9.5.1"
+WF="https://github.com/${REPO}/.github/workflows/supply-chain.yml"
+
+fail=0
+check() { # verdict-expected, identity, label, cert_id
+  local want="$1" identity="$2" label="$3" pattern="$4" got
+  if printf '%s' "$identity" | grep -Eq "$pattern"; then got=match; else got=reject; fi
+  if [ "$got" = "$want" ]; then
+    printf 'ok   %-6s %s\n' "$got" "$label"
+  else
+    printf 'FAIL wanted %s, got %s: %s\n     identity: %s\n' "$want" "$got" "$label" "$identity"
+    fail=1
+  fi
+}
+
+echo "=== push event, tag ${TAG} ==="
+PUSH_ID="$(build_cert_id "$TAG" "$REPO" push)"
+check match  "${WF}@refs/tags/${TAG}"                    "the genuine release identity"        "$PUSH_ID"
+check reject "https://github.com/${REPO}-EVIL/.github/workflows/supply-chain.yml@refs/tags/${TAG}" \
+                                                          "typosquat repository suffix"         "$PUSH_ID"
+check reject "https://github.com/${REPO}/.github/workflows/build.yml@refs/tags/${TAG}" \
+                                                          "another workflow in the same repo"   "$PUSH_ID"
+check reject "${WF}@refs/tags/v0a9b5c1"                  "same-shape tag (dot as wildcard)"    "$PUSH_ID"
+check reject "${WF}@refs/heads/main"                     "branch ref on a tag-push identity"   "$PUSH_ID"
+check reject "${WF}@refs/tags/${TAG}-EVIL"               "suffix appended past the anchor"     "$PUSH_ID"
+check reject "https://evil.example/${WF}@refs/tags/${TAG}" "prefix prepended past the anchor"  "$PUSH_ID"
+
+echo
+echo "=== workflow_dispatch event ==="
+WD_ID="$(build_cert_id "$TAG" "$REPO" workflow_dispatch)"
+check match  "${WF}@refs/heads/main"                     "release branch main"                 "$WD_ID"
+check match  "${WF}@refs/heads/next/v1"                  "release branch next/v1"              "$WD_ID"
+check match  "${WF}@refs/tags/v1.2.3"                    "any release-shaped tag"              "$WD_ID"
+check reject "${WF}@refs/heads/throwaway"                "arbitrary throwaway branch"          "$WD_ID"
+check reject "${WF}@refs/heads/main-EVIL"                "branch name with a suffix"           "$WD_ID"
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "CERTIFICATE-IDENTITY ANCHOR CHECK FAILED"
+  echo "The pattern in ${WORKFLOW_SOURCE} does not reject what its comments claim it rejects."
+  exit 1
+fi
+echo "certificate-identity pattern rejects every impostor identity and accepts only the genuine one"

--- a/tests/security/check_cross_job_outputs.py
+++ b/tests/security/check_cross_job_outputs.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+"""Fail when a job reads an output no upstream job will produce.
+
+`${{ needs.build-webui.outputs.digest }}` does not error when `build-webui`
+declares no such output, or is missing from this job's `needs`, or is spelled
+wrong. It evaluates to the empty string, silently.
+
+That matters here because the release pipeline carries the image digest across
+three jobs on exactly this mechanism. The gate3 rehearsal cannot reach it: the
+rehearsal is one job, because the throwaway registry it uses is a service
+container and does not outlive the job that started it. So the one part of the
+pipeline the rehearsal proves nothing about is the part that is only a string.
+
+The failure is not silent corruption -- both guards refuse an empty digest and
+say why. It is a release that dies at the signing step, discovered at release
+time, which is the situation the rehearsal exists to prevent.
+
+Three ways the reference breaks, all of which produce the same empty string:
+the producer is not in `needs`, so its outputs are not in scope; the producer
+does not exist; the producer exists and declares different outputs.
+
+Usage:
+  check_cross_job_outputs.py [--workflows DIR]
+  check_cross_job_outputs.py --self-test
+
+Exit 0 when every cross-job reference resolves, 1 on a broken one, 2 on a
+usage or environment error.
+"""
+
+import argparse
+import glob
+import os
+import re
+import sys
+
+try:
+    import yaml
+except ImportError:
+    print("PyYAML is required: pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+REF = re.compile(r"needs\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)")
+
+
+def needs_of(job):
+    n = job.get("needs") or []
+    return [n] if isinstance(n, str) else list(n)
+
+
+def analyse(workflows):
+    """workflows: {name: parsed dict}. Returns (violations, references_checked)."""
+    violations = []
+    checked = 0
+    for name, wf in workflows.items():
+        jobs = (wf or {}).get("jobs") or {}
+        for jid, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            needs = needs_of(job)
+            # Serialising the job back to text finds the reference wherever it
+            # sits -- a step's `run`, a `with:`, an `env:`, a matrix entry --
+            # without this file having to know every place an expression is
+            # allowed to appear.
+            for src, key in set(REF.findall(yaml.safe_dump(job))):
+                checked += 1
+                if src not in needs:
+                    violations.append(
+                        f"{name}: job `{jid}` reads needs.{src}.outputs.{key}, but `{src}` "
+                        f"is not in its needs {sorted(needs)}. Outputs of a job you do not "
+                        f"depend on are not in scope, and the reference is the empty string.")
+                elif src not in jobs:
+                    violations.append(
+                        f"{name}: job `{jid}` reads needs.{src}.outputs.{key}, and no job "
+                        f"`{src}` exists in this workflow.")
+                else:
+                    declared = (jobs[src].get("outputs") or {})
+                    if key not in declared:
+                        violations.append(
+                            f"{name}: job `{jid}` reads needs.{src}.outputs.{key}, but `{src}` "
+                            f"declares {sorted(declared) or 'no outputs'}. The reference is the "
+                            f"empty string.")
+    return violations, checked
+
+
+SELF_TESTS = [
+    ("a reference that resolves", 0, {
+        "w.yml": {"jobs": {
+            "build": {"outputs": {"digest": "${{ steps.b.outputs.digest }}"}, "steps": []},
+            "sign": {"needs": ["build"],
+                     "steps": [{"run": "cosign sign ${{ needs.build.outputs.digest }}"}]}}}}),
+    ("producer missing from needs", 1, {
+        "w.yml": {"jobs": {
+            "build": {"outputs": {"digest": "x"}, "steps": []},
+            "sign": {"steps": [{"run": "echo ${{ needs.build.outputs.digest }}"}]}}}}),
+    ("producer does not exist", 1, {
+        "w.yml": {"jobs": {
+            "sign": {"needs": ["buidl"],
+                     "steps": [{"run": "echo ${{ needs.buidl.outputs.digest }}"}]}}}}),
+    ("producer declares a different output", 1, {
+        "w.yml": {"jobs": {
+            "build": {"outputs": {"sha": "x"}, "steps": []},
+            "sign": {"needs": ["build"],
+                     "steps": [{"run": "echo ${{ needs.build.outputs.digest }}"}]}}}}),
+    ("producer declares no outputs at all", 1, {
+        "w.yml": {"jobs": {
+            "build": {"steps": []},
+            "sign": {"needs": ["build"],
+                     "steps": [{"run": "echo ${{ needs.build.outputs.digest }}"}]}}}}),
+    # The reference is often not in a `run:`. Serialising the whole job is what
+    # makes these reachable without enumerating every place an expression may sit.
+    ("a reference inside a matrix entry", 1, {
+        "w.yml": {"jobs": {
+            "build": {"outputs": {"sha": "x"}, "steps": []},
+            "sign": {"needs": ["build"],
+                     "strategy": {"matrix": {"include": [
+                         {"digest": "${{ needs.build.outputs.digest }}"}]}},
+                     "steps": []}}}}),
+    ("a reference inside job-level env", 1, {
+        "w.yml": {"jobs": {
+            "build": {"steps": []},
+            "sign": {"needs": ["build"],
+                     "env": {"D": "${{ needs.build.outputs.digest }}"},
+                     "steps": []}}}}),
+]
+
+
+def self_test():
+    failed = 0
+    for label, expected, wfs in SELF_TESTS:
+        violations, _ = analyse(wfs)
+        got = 1 if violations else 0
+        if got != expected:
+            failed += 1
+            print(f"SELF-TEST FAILED: {label} -- expected "
+                  f"{'a violation' if expected else 'no violation'}, got {violations or 'none'}")
+        else:
+            print(f"ok   self-test: {label}")
+    if failed:
+        print(f"\n{failed} self-test(s) failed; the check cannot be trusted on real workflows")
+        return 1
+    print("\nself-test: every broken reference is reported, and a resolving one is not")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workflows", default=".github/workflows")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    if not os.path.isdir(args.workflows):
+        print(f"no such directory: {args.workflows}", file=sys.stderr)
+        return 2
+
+    workflows = {}
+    for path in sorted(glob.glob(os.path.join(args.workflows, "*.yml")) +
+                       glob.glob(os.path.join(args.workflows, "*.yaml"))):
+        try:
+            with open(path) as fh:
+                workflows[os.path.basename(path)] = yaml.safe_load(fh)
+        except yaml.YAMLError as exc:
+            print(f"{path}: not parseable as YAML: {exc}", file=sys.stderr)
+            return 2
+
+    violations, checked = analyse(workflows)
+    for v in violations:
+        print(f"FAIL {v}")
+    print(f"\ncross-job output references checked: {checked}, broken: {len(violations)}")
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/security/check_cross_job_outputs.py
+++ b/tests/security/check_cross_job_outputs.py
@@ -56,7 +56,14 @@ def analyse(workflows):
     for name, wf in workflows.items():
         jobs = (wf or {}).get("jobs") or {}
         for jid, job in jobs.items():
+            # Same refusal as the signing check: a body that is not a mapping
+            # cannot be read, and silently skipping it produces a clean verdict
+            # over a job nobody looked at.
             if not isinstance(job, dict):
+                violations.append(
+                    f"{name}: job `{jid}` has a body of type {type(job).__name__}, not a "
+                    f"mapping, so its references cannot be read. Refusing to report clean "
+                    f"over a job that was never examined.")
                 continue
             needs = needs_of(job)
             # Serialising the job back to text finds the reference wherever it
@@ -85,6 +92,8 @@ def analyse(workflows):
 
 
 SELF_TESTS = [
+    ("a job body that is not a mapping is refused, not skipped", 1, {
+        "w.yml": {"jobs": {"sign": ["steps", "went", "wrong"]}}}),
     ("a reference that resolves", 0, {
         "w.yml": {"jobs": {
             "build": {"outputs": {"digest": "${{ steps.b.outputs.digest }}"}, "steps": []},

--- a/tests/security/check_security_exceptions.py
+++ b/tests/security/check_security_exceptions.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+"""Enforce the HIGH-finding exception ledger instead of describing it.
+
+`.github/security-exceptions.yml` carried a schema with a `since`, an
+`expires`, an owner and a remediation, and a note saying CI did not enforce any
+of it. An exception file nothing reads is not a control. It is a place to write
+down that a finding was ignored, with the shape of rigour and none of it, and
+its entries outlive their reasons because nothing ever asks whether they are
+still needed.
+
+The same standard this repository has been asking of sibling repositories:
+a finding closable by the change in flight is fixed; a finding needing separate
+work is named with the condition for its own removal; neither is switched off.
+An exception must be able to kill itself.
+
+What is refused:
+
+  - an entry past its `expires` date, which is the whole point
+  - `expires` more than 14 days after `since`, the window CLAUDE.md sets
+  - severity CRITICAL, which is never excepted whatever the file says
+  - a missing or malformed field, rather than skipping the entry in silence --
+    a lenient reader's quiet is indistinguishable from a working one's
+
+Every admitted exception prints on every run. A silent exception reads exactly
+like no exception at all.
+
+An empty ledger is the target state, not a stub.
+
+Usage:
+  check_security_exceptions.py [--file PATH] [--today YYYY-MM-DD]
+  check_security_exceptions.py --self-test
+
+Exit 0 when every entry is well-formed and live, 1 on a violation, 2 on a
+usage or environment error.
+"""
+
+import argparse
+import datetime as dt
+import os
+import sys
+
+try:
+    import yaml
+except ImportError:
+    print("PyYAML is required: pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+MAX_WINDOW_DAYS = 14
+REQUIRED = ("id", "severity", "tool", "since", "expires", "owner", "reason", "remediation")
+TOOLS = ("trivy", "semgrep", "checkov", "trufflehog", "gitleaks")
+
+
+def _date(value, field, where, problems):
+    if isinstance(value, dt.date):
+        return value
+    try:
+        return dt.date.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        problems.append(f"{where}: `{field}` is {value!r}, not a YYYY-MM-DD date")
+        return None
+
+
+def analyse(doc, today):
+    """doc: parsed ledger. Returns (violations, admitted) -- admitted is printed."""
+    violations, admitted = [], []
+
+    if doc is None:
+        return ["the ledger is empty as a file; it must contain `exceptions: []`"], []
+    if not isinstance(doc, dict) or "exceptions" not in doc:
+        return ["the ledger has no `exceptions:` key"], []
+
+    entries = doc["exceptions"]
+    if entries is None:
+        entries = []
+    if not isinstance(entries, list):
+        return [f"`exceptions:` is {type(entries).__name__}, not a list"], []
+
+    for i, e in enumerate(entries):
+        where = f"entry {i + 1}"
+        if not isinstance(e, dict):
+            violations.append(
+                f"{where} is {type(e).__name__}, not a mapping, so nothing about it can be "
+                f"checked. Refusing to pass over an entry that was never examined.")
+            continue
+
+        missing = [f for f in REQUIRED if f not in e or e[f] in (None, "")]
+        if missing:
+            violations.append(f"{where} ({e.get('id', 'no id')}) is missing {missing}")
+            continue
+
+        where = f"entry {i + 1} ({e['id']})"
+
+        if str(e["severity"]).upper() == "CRITICAL":
+            violations.append(
+                f"{where}: CRITICAL is never excepted. CI fails regardless of this file.")
+            continue
+        if str(e["severity"]).upper() != "HIGH":
+            violations.append(f"{where}: severity is {e['severity']!r}, only HIGH may be excepted")
+            continue
+        if str(e["tool"]) not in TOOLS:
+            violations.append(f"{where}: tool {e['tool']!r} is not one of {list(TOOLS)}")
+            continue
+
+        since = _date(e["since"], "since", where, violations)
+        expires = _date(e["expires"], "expires", where, violations)
+        if since is None or expires is None:
+            continue
+
+        if expires < since:
+            violations.append(f"{where}: expires {expires} is before since {since}")
+            continue
+        if (expires - since).days > MAX_WINDOW_DAYS:
+            violations.append(
+                f"{where}: the window is {(expires - since).days} days, "
+                f"more than the {MAX_WINDOW_DAYS} allowed")
+            continue
+        if today > expires:
+            violations.append(
+                f"{where}: expired on {expires}, {(today - expires).days} day(s) ago. "
+                f"Fix the finding or renew the entry with a fresh justification -- an "
+                f"exception that outlives its date is a silent suppression.")
+            continue
+
+        admitted.append(
+            f"ADMITTED {e['id']} ({e['tool']}, HIGH) until {expires}, owner {e['owner']}: "
+            f"{e['reason']} / remediation: {e['remediation']}")
+
+    return violations, admitted
+
+
+SELF_TESTS = [
+    ("an empty ledger is the target state", 0, {"exceptions": []}, "2026-07-31"),
+    ("a live entry inside the window is admitted", 0, {"exceptions": [{
+        "id": "CVE-2026-1", "severity": "HIGH", "tool": "trivy",
+        "since": "2026-07-28", "expires": "2026-08-04", "owner": "@x",
+        "reason": "r", "remediation": "m"}]}, "2026-07-31"),
+    ("an expired entry is refused", 1, {"exceptions": [{
+        "id": "CVE-2026-2", "severity": "HIGH", "tool": "trivy",
+        "since": "2026-07-01", "expires": "2026-07-15", "owner": "@x",
+        "reason": "r", "remediation": "m"}]}, "2026-07-31"),
+    ("a window longer than 14 days is refused", 1, {"exceptions": [{
+        "id": "CVE-2026-3", "severity": "HIGH", "tool": "trivy",
+        "since": "2026-07-01", "expires": "2026-08-30", "owner": "@x",
+        "reason": "r", "remediation": "m"}]}, "2026-07-31"),
+    ("CRITICAL is never excepted", 1, {"exceptions": [{
+        "id": "CVE-2026-4", "severity": "CRITICAL", "tool": "trivy",
+        "since": "2026-07-30", "expires": "2026-08-02", "owner": "@x",
+        "reason": "r", "remediation": "m"}]}, "2026-07-31"),
+    ("a missing field is refused, not skipped", 1, {"exceptions": [{
+        "id": "CVE-2026-5", "severity": "HIGH", "tool": "trivy",
+        "since": "2026-07-30", "expires": "2026-08-02"}]}, "2026-07-31"),
+    ("an entry that is not a mapping is refused, not skipped", 1,
+     {"exceptions": ["CVE-2026-6"]}, "2026-07-31"),
+    ("an unparseable date is refused", 1, {"exceptions": [{
+        "id": "CVE-2026-7", "severity": "HIGH", "tool": "trivy",
+        "since": "yesterday", "expires": "2026-08-02", "owner": "@x",
+        "reason": "r", "remediation": "m"}]}, "2026-07-31"),
+    ("a tool nobody runs is refused", 1, {"exceptions": [{
+        "id": "CVE-2026-8", "severity": "HIGH", "tool": "astrology",
+        "since": "2026-07-30", "expires": "2026-08-02", "owner": "@x",
+        "reason": "r", "remediation": "m"}]}, "2026-07-31"),
+    ("a ledger with no exceptions key is refused", 1, {"entries": []}, "2026-07-31"),
+]
+
+
+def self_test():
+    failed = 0
+    for label, expected, doc, today in SELF_TESTS:
+        violations, _ = analyse(doc, dt.date.fromisoformat(today))
+        got = 1 if violations else 0
+        if got != expected:
+            failed += 1
+            print(f"SELF-TEST FAILED: {label} -- expected "
+                  f"{'a violation' if expected else 'none'}, got {violations or 'none'}")
+        else:
+            print(f"ok   self-test: {label}")
+    if failed:
+        print(f"\n{failed} self-test(s) failed; the check cannot be trusted on the real ledger")
+        return 1
+    print("\nself-test: every malformed, expired and over-window entry is refused, "
+          "and a live one is admitted")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--file", default=".github/security-exceptions.yml")
+    ap.add_argument("--today", default=None, help="override today, for testing")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    if not os.path.isfile(args.file):
+        print(f"no such file: {args.file}", file=sys.stderr)
+        return 2
+    try:
+        with open(args.file) as fh:
+            doc = yaml.safe_load(fh)
+    except yaml.YAMLError as exc:
+        print(f"{args.file}: not parseable as YAML: {exc}", file=sys.stderr)
+        return 2
+
+    today = dt.date.fromisoformat(args.today) if args.today else dt.date.today()
+    violations, admitted = analyse(doc, today)
+
+    for a in admitted:
+        print(a)
+    for v in violations:
+        print(f"FAIL {args.file}: {v}")
+
+    total = len(admitted) + len(violations)
+    print(f"\nexception ledger: {total} entr(ies), {len(admitted)} admitted, "
+          f"{len(violations)} refused, as of {today}")
+    if not total:
+        print("the ledger is empty, which is its target state")
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/security/check_signing_precedes_publish.py
+++ b/tests/security/check_signing_precedes_publish.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+"""Fail when a workflow publishes a consumer-reachable image before it is signed.
+
+A release gate that produces a signature after the artifact is already public
+does not gate anything. It reports, loudly, on something that has already
+happened, and its failure retracts nothing -- the tag still resolves and the
+image still pulls.
+
+The check reads the workflow graph rather than the shell inside a step. It
+answers one question: for every trigger on which some job publishes a
+consumer-reachable image reference, is a signing job ordered before that
+publish? Ordering means a `needs:` edge inside one workflow, or a
+`workflow_run` dependency between two.
+
+Two deliberate refusals, both because a silent "ok" here would be the
+comforting nothing this check exists to prevent:
+
+  - A job that both publishes and signs is REJECTED, not accepted. Deciding
+    that `docker push` above `cosign sign` in one script actually runs first
+    means parsing shell with conditionals and functions.
+  - A publish whose reference cannot be resolved statically is REPORTED, not
+    skipped. An unreadable reference is an unchecked one.
+
+A staging publish is exempt only when the reference names itself as such --
+the marker `unsigned` in the tag. The weakening then lives in the workflow
+where a reviewer sees it, rather than in this file's assumptions.
+
+Usage:
+  check_signing_precedes_publish.py [--workflows DIR]
+  check_signing_precedes_publish.py --self-test
+
+Exit 0 when every publish is preceded by a signature, 1 on a violation,
+2 on a usage or environment error.
+"""
+
+import argparse
+import os
+import sys
+
+try:
+    import yaml
+except ImportError:
+    print("PyYAML is required: pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+PUBLISH_ACTIONS = ("docker/build-push-action", "redhat-actions/push-to-registry")
+PUBLISH_SHELL = ("docker push", "buildx imagetools create", "podman push", "skopeo copy")
+SIGN_SHELL = ("cosign sign", "cosign attest")
+SIGN_ACTIONS = ("actions/attest-build-provenance", "sigstore/gh-action-sigstore-python")
+STAGING_MARKER = "unsigned"
+
+
+def steps_of(job):
+    return job.get("steps") or [] if isinstance(job, dict) else []
+
+
+def job_publishes(job):
+    """Return a reason string when the job publishes a consumer-reachable ref."""
+    for step in steps_of(job):
+        if not isinstance(step, dict):
+            continue
+        uses = str(step.get("uses") or "")
+        run = str(step.get("run") or "")
+        with_ = step.get("with") or {}
+        if any(a in uses for a in PUBLISH_ACTIONS):
+            push = with_.get("push")
+            # `push:` absent defaults to false for build-push-action; an
+            # expression is unresolvable here and is reported rather than
+            # assumed either way.
+            if push is None or push is False or str(push).lower() == "false":
+                continue
+            tags = str(with_.get("tags") or "")
+            if STAGING_MARKER in tags:
+                continue
+            if "${{" in str(push):
+                return f"step `{uses.split('@')[0]}` push is the expression {push!r}, which may be true"
+            return f"step `{uses.split('@')[0]}` with push: {push}"
+        for marker in PUBLISH_SHELL:
+            if marker in run:
+                line = next((l.strip() for l in run.splitlines() if marker in l), marker)
+                if STAGING_MARKER in line:
+                    continue
+                return f"run step contains `{marker}`: {line[:80]}"
+    return None
+
+
+def job_signs(job):
+    for step in steps_of(job):
+        if not isinstance(step, dict):
+            continue
+        run = str(step.get("run") or "")
+        uses = str(step.get("uses") or "")
+        if any(m in run for m in SIGN_SHELL) or any(a in uses for a in SIGN_ACTIONS):
+            return True
+    return False
+
+
+def needs_of(job):
+    n = job.get("needs") if isinstance(job, dict) else None
+    if n is None:
+        return []
+    return [n] if isinstance(n, str) else list(n)
+
+
+def triggers_of(wf):
+    """Normalise `on:` into comparable trigger keys.
+
+    `on` is the YAML boolean True after parsing, which is why this reads
+    both spellings rather than the obvious one.
+    """
+    on = wf.get("on", wf.get(True))
+    if on is None:
+        return set()
+    if isinstance(on, str):
+        return {on}
+    if isinstance(on, list):
+        return set(on)
+    keys = set()
+    for event, spec in on.items():
+        if event == "push" and isinstance(spec, dict):
+            for tag in spec.get("tags") or []:
+                keys.add(f"push:tags:{tag}")
+            for br in spec.get("branches") or []:
+                keys.add(f"push:branches:{br}")
+            if not spec.get("tags") and not spec.get("branches"):
+                keys.add("push")
+        else:
+            keys.add(str(event))
+    return keys
+
+
+def reachable_predecessors(jobs, start):
+    """Every job that must complete before `start` runs."""
+    seen, stack = set(), list(needs_of(jobs.get(start, {})))
+    while stack:
+        j = stack.pop()
+        if j in seen:
+            continue
+        seen.add(j)
+        stack.extend(needs_of(jobs.get(j, {})))
+    return seen
+
+
+def analyse(workflows):
+    """workflows: {name: parsed dict}. Returns (violations, examined_count)."""
+    violations = []
+    examined = 0
+
+    # A workflow that waits on another via workflow_run runs strictly after it.
+    runs_after = {}
+    for name, wf in workflows.items():
+        on = wf.get("on", wf.get(True)) or {}
+        if isinstance(on, dict) and isinstance(on.get("workflow_run"), dict):
+            runs_after[name] = set(on["workflow_run"].get("workflows") or [])
+
+    signing_workflows = {}
+    for name, wf in workflows.items():
+        jobs = wf.get("jobs") or {}
+        signers = {jid for jid, j in jobs.items() if job_signs(j)}
+        if signers:
+            signing_workflows[name] = (signers, triggers_of(wf), wf)
+
+    for name, wf in workflows.items():
+        jobs = wf.get("jobs") or {}
+        if not jobs:
+            continue
+        examined += 1
+        wf_triggers = triggers_of(wf)
+        for jid, job in jobs.items():
+            reason = job_publishes(job)
+            if not reason:
+                continue
+
+            if job_signs(job):
+                violations.append(
+                    f"{name}: job `{jid}` both publishes and signs. Step order inside one "
+                    f"job cannot be established from the workflow graph, so this is not a "
+                    f"proven ordering. Split the signature into its own job. ({reason})")
+                continue
+
+            preds = reachable_predecessors(jobs, jid)
+            if any(job_signs(jobs.get(p, {})) for p in preds):
+                continue
+
+            same_wf_signers = {j for j in jobs if job_signs(jobs[j])}
+            if same_wf_signers:
+                violations.append(
+                    f"{name}: job `{jid}` publishes without depending on the signing job(s) "
+                    f"{sorted(same_wf_signers)}. The pullable reference exists before the "
+                    f"signature. ({reason})")
+                continue
+
+            # No signer in this workflow. Look for one elsewhere on a shared
+            # trigger -- and say plainly that sharing a trigger is a race,
+            # not an ordering.
+            elsewhere = [
+                other for other, (_, other_trig, _) in signing_workflows.items()
+                if other != name and (wf_triggers & other_trig)
+                and name not in runs_after.get(other, set())
+            ]
+            if elsewhere:
+                violations.append(
+                    f"{name}: job `{jid}` publishes on {sorted(wf_triggers)} and the signing "
+                    f"job lives in {elsewhere} on the same trigger with no workflow_run "
+                    f"dependency. Two workflows on one trigger race; they are not ordered. "
+                    f"({reason})")
+            else:
+                violations.append(
+                    f"{name}: job `{jid}` publishes a consumer-reachable reference and nothing "
+                    f"in this repository signs it. ({reason})")
+    return violations, examined
+
+
+SELF_TESTS = [
+    ("publish with no signer anywhere", 1, {
+        "build.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
+            "image": {"steps": [{"uses": "docker/build-push-action@v7", "with": {"push": True}}]}}}}),
+    ("publish and sign in separate workflows on the same tag", 1, {
+        "build.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
+            "image": {"steps": [{"uses": "docker/build-push-action@v7", "with": {"push": True}}]}}},
+        "supply-chain.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
+            "sign": {"steps": [{"run": "cosign sign --yes $REF"}]}}}}),
+    ("publish without needs on the signer in the same workflow", 1, {
+        "w.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
+            "image": {"steps": [{"run": "docker push ghcr.io/o/i:1"}]},
+            "sign": {"steps": [{"run": "cosign sign --yes ghcr.io/o/i:1"}]}}}}),
+    ("one job that both publishes and signs is refused", 1, {
+        "w.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
+            "both": {"steps": [{"run": "docker push ghcr.io/o/i:1\ncosign sign --yes ghcr.io/o/i:1"}]}}}}),
+    ("publish ordered after the signer via needs", 0, {
+        "w.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
+            "sign": {"steps": [{"run": "cosign sign --yes ghcr.io/o/i@$DIGEST"}]},
+            "promote": {"needs": "sign",
+                        "steps": [{"run": "docker buildx imagetools create --tag ghcr.io/o/i:1 ghcr.io/o/i@$DIGEST"}]}}}}),
+    ("staging publish naming itself unsigned is exempt", 0, {
+        "w.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
+            "stage": {"steps": [{"run": "docker push ghcr.io/o/i:unsigned-staging"}]}}}}),
+    ("pull-request build that does not push", 0, {
+        "w.yml": {"on": {"pull_request": None}, "jobs": {
+            "image": {"steps": [{"uses": "docker/build-push-action@v7", "with": {"push": False}}]}}}}),
+]
+
+
+def self_test():
+    failed = 0
+    for label, expected, wfs in SELF_TESTS:
+        violations, _ = analyse(wfs)
+        got = 1 if violations else 0
+        if got != expected:
+            failed += 1
+            print(f"SELF-TEST FAILED: {label} -- expected {'a violation' if expected else 'no violation'}, "
+                  f"got {violations or 'none'}")
+        else:
+            print(f"ok   self-test: {label}")
+    if failed:
+        print(f"\n{failed} self-test(s) failed; the check cannot be trusted on real workflows")
+        return 1
+    print("\nself-test: the check reports a violation in every case that has one, and none where there is not")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workflows", default=".github/workflows")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    if not os.path.isdir(args.workflows):
+        print(f"no such directory: {args.workflows}", file=sys.stderr)
+        return 2
+
+    workflows = {}
+    for fn in sorted(os.listdir(args.workflows)):
+        if not fn.endswith((".yml", ".yaml")):
+            continue
+        path = os.path.join(args.workflows, fn)
+        try:
+            with open(path) as fh:
+                doc = yaml.safe_load(fh)
+        except yaml.YAMLError as exc:
+            print(f"FAIL {fn}: unparseable, so its publishes are unchecked -- {exc}")
+            return 1
+        if isinstance(doc, dict):
+            workflows[fn] = doc
+
+    violations, examined = analyse(workflows)
+
+    if examined == 0:
+        print(f"NOTHING WAS EXAMINED in {args.workflows}. Treat this as a failure: a check "
+              f"that inspects no workflow is indistinguishable from one that passes.")
+        return 1
+
+    for v in violations:
+        print(f"FAIL {v}")
+    print(f"\nworkflows with jobs examined: {examined}, violations: {len(violations)}")
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/security/check_signing_precedes_publish.py
+++ b/tests/security/check_signing_precedes_publish.py
@@ -264,6 +264,16 @@ def analyse(workflows):
         examined += 1
         wf_triggers = triggers_of(wf)
         for jid, job in jobs.items():
+            # A job body that is not a mapping was silently skipped, and a
+            # skipped job reads exactly like an examined one that had nothing
+            # to say. Indentation slips do this, and the result was a clean
+            # verdict over a job nobody looked at.
+            if not isinstance(job, dict):
+                violations.append(
+                    f"{name}: job `{jid}` has a body of type {type(job).__name__}, not a "
+                    f"mapping, so nothing about it can be checked. Refusing to report clean "
+                    f"over a job that was never examined.")
+                continue
             reason = job_publishes(job)
             if not reason:
                 continue
@@ -341,6 +351,10 @@ SELF_TESTS = [
     ("a repository merely named localhost-something is still a publish", 1, {
         "w.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
             "p": {"steps": [{"run": "docker push ghcr.io/o/localhost-tools:v1"}]}}}}),
+    ("a job body that is not a mapping is refused, not skipped", 1, {
+        "w.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
+            "publish": "docker push ghcr.io/o/i:v1"}}},
+     "never examined"),
     ("publish with no signer anywhere", 1, {
         "build.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
             "image": {"steps": [{"uses": "docker/build-push-action@v7",

--- a/tests/security/check_signing_precedes_publish.py
+++ b/tests/security/check_signing_precedes_publish.py
@@ -11,8 +11,16 @@ image still pulls.
 The check reads the workflow graph rather than the shell inside a step. It
 answers one question: for every trigger on which some job publishes a
 consumer-reachable image reference, is a signing job ordered before that
-publish? Ordering means a `needs:` edge inside one workflow, or a
-`workflow_run` dependency between two.
+publish? Ordering means a `needs:` edge, so the signer has to live in the
+same workflow as the publish it precedes.
+
+Ordering across two workflows is not accepted, and not because it is hard to
+read. A signature is over a digest, and the digest exists only once the build
+has run: a signing workflow scheduled ahead of the building one has nothing to
+sign, and one scheduled after it signs what is already public. Neither order
+satisfies the invariant, so there is no arrangement of `workflow_run` to
+accept. The way out is push-by-digest, which publishes no tag, followed by
+`needs:`-ordered sign and promote jobs in that same workflow.
 
 Two deliberate refusals, both because a silent "ok" here would be the
 comforting nothing this check exists to prevent:
@@ -198,13 +206,6 @@ def analyse(workflows):
     violations = []
     examined = 0
 
-    # A workflow that waits on another via workflow_run runs strictly after it.
-    runs_after = {}
-    for name, wf in workflows.items():
-        on = wf.get("on", wf.get(True)) or {}
-        if isinstance(on, dict) and isinstance(on.get("workflow_run"), dict):
-            runs_after[name] = set(on["workflow_run"].get("workflows") or [])
-
     signing_workflows = {}
     for name, wf in workflows.items():
         jobs = wf.get("jobs") or {}
@@ -242,20 +243,25 @@ def analyse(workflows):
                     f"signature. ({reason})")
                 continue
 
-            # No signer in this workflow. Look for one elsewhere on a shared
-            # trigger -- and say plainly that sharing a trigger is a race,
-            # not an ordering.
+            # No signer in this workflow. Name the one that exists elsewhere,
+            # so the report does not read as "nothing signs this" when
+            # something does -- the remedy differs between the two.
             elsewhere = [
                 other for other, (_, other_trig, _) in signing_workflows.items()
                 if other != name and (wf_triggers & other_trig)
-                and name not in runs_after.get(other, set())
             ]
+            # A signer that does not share this trigger is still a signer. Say
+            # so: "nothing signs it" and "the signer is in another workflow"
+            # have different remedies, and only the second is true here.
+            if not elsewhere:
+                elsewhere = [other for other in signing_workflows if other != name]
             if elsewhere:
                 violations.append(
-                    f"{name}: job `{jid}` publishes on {sorted(wf_triggers)} and the signing "
-                    f"job lives in {elsewhere} on the same trigger with no workflow_run "
-                    f"dependency. Two workflows on one trigger race; they are not ordered. "
-                    f"({reason})")
+                    f"{name}: job `{jid}` publishes on {sorted(wf_triggers)} and the only "
+                    f"signing job is in {elsewhere}, a separate workflow. No trigger order "
+                    f"between two workflows fixes this: scheduled first the signer has no "
+                    f"digest to sign, scheduled second it signs what is already public. Move "
+                    f"the signature into this workflow behind `needs:`. ({reason})")
             else:
                 violations.append(
                     f"{name}: job `{jid}` publishes a consumer-reachable reference and nothing "
@@ -277,7 +283,27 @@ SELF_TESTS = [
             "image": {"steps": [{"uses": "docker/build-push-action@v7",
                                  "with": {"push": True, "tags": "ghcr.io/o/i:v1"}}]}}},
         "supply-chain.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
-            "sign": {"steps": [{"run": "cosign sign --yes $REF"}]}}}}),
+            "sign": {"steps": [{"run": "cosign sign --yes $REF"}]}}}},
+     "a separate workflow", "nothing in this repository signs it"),
+    # `workflow_run` used to be documented as an accepted ordering. No
+    # arrangement of it can be correct, so both directions stay violations and
+    # both must name the separate workflow rather than deny it exists.
+    ("publisher scheduled after the signer via workflow_run, by display name", 1, {
+        "build.yml": {"name": "Build", "on": {"workflow_run": {
+            "workflows": ["supply-chain"], "types": ["completed"]}}, "jobs": {
+            "image": {"steps": [{"uses": "docker/build-push-action@v7",
+                                 "with": {"push": True, "tags": "ghcr.io/o/i:v1"}}]}}},
+        "supply-chain.yml": {"name": "supply-chain", "on": {"push": {"tags": ["v*"]}}, "jobs": {
+            "sign": {"steps": [{"run": "cosign sign --yes $REF"}]}}}},
+     None, "nothing in this repository signs it"),
+    ("signer scheduled after the publisher via workflow_run", 1, {
+        "build.yml": {"name": "Build", "on": {"push": {"tags": ["v*"]}}, "jobs": {
+            "image": {"steps": [{"uses": "docker/build-push-action@v7",
+                                 "with": {"push": True, "tags": "ghcr.io/o/i:v1"}}]}}},
+        "supply-chain.yml": {"name": "supply-chain", "on": {"push": {"tags": ["v*"]},
+            "workflow_run": {"workflows": ["Build"], "types": ["completed"]}}, "jobs": {
+            "sign": {"steps": [{"run": "cosign sign --yes $REF"}]}}}},
+     "a separate workflow", "nothing in this repository signs it"),
     ("publish without needs on the signer in the same workflow", 1, {
         "w.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
             "image": {"steps": [{"run": "docker push ghcr.io/o/i:1"}]},
@@ -331,13 +357,25 @@ SELF_TESTS = [
 
 def self_test():
     failed = 0
-    for label, expected, wfs in SELF_TESTS:
+    for entry in SELF_TESTS:
+        label, expected, wfs = entry[0], entry[1], entry[2]
+        # A case may pin a fragment of the reason. Asserting only the count let
+        # a violation be reported for the wrong reason, which is how the
+        # cross-workflow cases came to say "nothing signs it" about a
+        # repository that does sign it.
+        want, unwanted = (entry[3] if len(entry) > 3 else None), (entry[4] if len(entry) > 4 else None)
         violations, _ = analyse(wfs)
         got = 1 if violations else 0
         if got != expected:
             failed += 1
             print(f"SELF-TEST FAILED: {label} -- expected {'a violation' if expected else 'no violation'}, "
                   f"got {violations or 'none'}")
+        elif want and not any(want in v for v in violations):
+            failed += 1
+            print(f"SELF-TEST FAILED: {label} -- reported, but no reason contains {want!r}: {violations}")
+        elif unwanted and any(unwanted in v for v in violations):
+            failed += 1
+            print(f"SELF-TEST FAILED: {label} -- reason wrongly claims {unwanted!r}: {violations}")
         else:
             print(f"ok   self-test: {label}")
     if failed:

--- a/tests/security/check_signing_precedes_publish.py
+++ b/tests/security/check_signing_precedes_publish.py
@@ -80,6 +80,23 @@ def shell_code(run):
     )
 
 
+def is_local_registry(ref):
+    """True when the reference names a registry only the runner can reach.
+
+    A rehearsal that pushes to a registry started as a job service proves the
+    mechanism without creating anything anyone can pull: the host dies with the
+    job. Treating that as a publish would force the check to reject the only
+    way to exercise the pipeline it is guarding.
+
+    Matched on the registry host, which is the first path segment when it
+    carries a port or is a bare localhost form -- not on a substring, so an
+    image called `localhost-tools` on a real registry is unaffected.
+    """
+    head = ref.strip().split("/", 1)[0]
+    host = head.rsplit(":", 1)[0] if ":" in head else head
+    return host in ("localhost", "127.0.0.1", "::1", "[::1]")
+
+
 def steps_of(job):
     return job.get("steps") or [] if isinstance(job, dict) else []
 
@@ -136,6 +153,11 @@ def job_publishes(job):
             if digest_only:
                 continue
 
+            if is_local_registry(str(with_.get("tags") or "")) or \
+               any(is_local_registry(part[len("name="):])
+                   for part in outputs.split(",") if part.strip().startswith("name=")):
+                continue
+
             tags = str(with_.get("tags") or "").strip()
             hidden = tag_inside_outputs(outputs) if not tags else None
             if not tags and not hidden:
@@ -156,6 +178,8 @@ def job_publishes(job):
             if marker in run:
                 line = next((l.strip() for l in run.splitlines() if marker in l), marker)
                 if STAGING_MARKER in line:
+                    continue
+                if any(is_local_registry(tok) for tok in line.split()):
                     continue
                 # A bare digest reference in a shell push is not consumer-reachable.
                 if marker == "docker push" and "@sha256:" in line and "--tag" not in line:
@@ -306,6 +330,17 @@ SELF_TESTS = [
             "sign": {"steps": [{"run": "# cosign sign --yes ghcr.io/o/i:v1\necho disabled\n"}]},
             "publish": {"needs": "sign", "steps": [{"run": "docker push ghcr.io/o/i:v1"}]}}}},
      "nothing in this repository signs it"),
+    ("a push to a registry only the runner can reach is not a publish", 0, {
+        "w.yml": {"on": {"pull_request": None}, "jobs": {
+            "rehearse": {"steps": [
+                {"run": "docker buildx imagetools create --tag localhost:5000/probe:v1 localhost:5000/probe@$D"}]}}}}),
+    ("the same push to a real registry is a publish", 1, {
+        "w.yml": {"on": {"pull_request": None}, "jobs": {
+            "rehearse": {"steps": [
+                {"run": "docker buildx imagetools create --tag ghcr.io/o/probe:v1 ghcr.io/o/probe@$D"}]}}}}),
+    ("a repository merely named localhost-something is still a publish", 1, {
+        "w.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
+            "p": {"steps": [{"run": "docker push ghcr.io/o/localhost-tools:v1"}]}}}}),
     ("publish with no signer anywhere", 1, {
         "build.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
             "image": {"steps": [{"uses": "docker/build-push-action@v7",

--- a/tests/security/check_signing_precedes_publish.py
+++ b/tests/security/check_signing_precedes_publish.py
@@ -60,6 +60,26 @@ SIGN_ACTIONS = ("actions/attest-build-provenance", "sigstore/gh-action-sigstore-
 STAGING_MARKER = "unsigned"
 
 
+def shell_code(run):
+    """The lines of a `run:` block that the shell would execute.
+
+    Whole-line comments are dropped. Both directions of this matter and the
+    second is the dangerous one: a commented-out `docker push` is noise, but a
+    commented-out `cosign sign` makes a job read as a signer, and a publish
+    that depends on that job then reports zero violations for a pipeline whose
+    signing is switched off.
+
+    Only lines whose first non-blank character is `#` are removed. A trailing
+    comment on a real command is left in place: cutting at the first `#`
+    anywhere would also cut a `#` inside a quoted string, and the failure there
+    is to stop seeing a publish that is really happening.
+    """
+    return "\n".join(
+        line for line in str(run or "").splitlines()
+        if not line.lstrip().startswith("#")
+    )
+
+
 def steps_of(job):
     return job.get("steps") or [] if isinstance(job, dict) else []
 
@@ -98,7 +118,7 @@ def job_publishes(job):
         if not isinstance(step, dict):
             continue
         uses = str(step.get("uses") or "")
-        run = str(step.get("run") or "")
+        run = shell_code(step.get("run"))
         with_ = step.get("with") or {}
 
         if any(a in uses for a in PUBLISH_ACTIONS):
@@ -148,7 +168,7 @@ def job_signs(job):
     for step in steps_of(job):
         if not isinstance(step, dict):
             continue
-        run = str(step.get("run") or "")
+        run = shell_code(step.get("run"))
         uses = str(step.get("uses") or "")
         if any(m in run for m in SIGN_SHELL) or any(a in uses for a in SIGN_ACTIONS):
             return True
@@ -274,6 +294,18 @@ SELF_TESTS = [
     # without it they were shorthand for "a job that publishes", and the
     # shorthand stopped being true once the check learned that the tag, not
     # the push, is what makes a reference reachable.
+    ("a publish that exists only inside a shell comment is not a publish", 0, {
+        "w.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
+            "image": {"steps": [{"run": "# the old pipeline ran:\n#   docker push ghcr.io/o/i:v1\necho building\n"}]}}}}),
+    # The dangerous direction. Before comment lines were skipped this returned
+    # no violation: the commented-out cosign made `sign` read as a signer, and
+    # the publish depending on it looked ordered behind a signature that is
+    # switched off.
+    ("a publish behind a signer whose cosign is commented out", 1, {
+        "w.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
+            "sign": {"steps": [{"run": "# cosign sign --yes ghcr.io/o/i:v1\necho disabled\n"}]},
+            "publish": {"needs": "sign", "steps": [{"run": "docker push ghcr.io/o/i:v1"}]}}}},
+     "nothing in this repository signs it"),
     ("publish with no signer anywhere", 1, {
         "build.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
             "image": {"steps": [{"uses": "docker/build-push-action@v7",

--- a/tests/security/check_signing_precedes_publish.py
+++ b/tests/security/check_signing_precedes_publish.py
@@ -57,30 +57,53 @@ def steps_of(job):
 
 
 def job_publishes(job):
-    """Return a reason string when the job publishes a consumer-reachable ref."""
+    """Return a reason string when the job creates a CONSUMER-REACHABLE reference.
+
+    What matters is the tag, not the push. Cosign signs a digest, so the image
+    must reach the registry before it can be signed at all -- a digest-only
+    push is the sole way to have something to sign and is not a violation. The
+    violation is attaching a tag a consumer would pull, before a signature
+    exists for it.
+
+    `push: true` and `outputs: type=image,...,push=true` are the same act
+    spelled two ways, and the second is the ordinary spelling for digest-based
+    publishing. Reading only the first passes a tagged publish silently.
+    """
     for step in steps_of(job):
         if not isinstance(step, dict):
             continue
         uses = str(step.get("uses") or "")
         run = str(step.get("run") or "")
         with_ = step.get("with") or {}
+
         if any(a in uses for a in PUBLISH_ACTIONS):
             push = with_.get("push")
-            # `push:` absent defaults to false for build-push-action; an
-            # expression is unresolvable here and is reported rather than
-            # assumed either way.
-            if push is None or push is False or str(push).lower() == "false":
+            outputs = str(with_.get("outputs") or "")
+            pushes_via_outputs = "push=true" in outputs.replace(" ", "")
+            digest_only = "push-by-digest=true" in outputs.replace(" ", "")
+            push_absent = push is None or push is False or str(push).lower() == "false"
+            if push_absent and not pushes_via_outputs and not digest_only:
                 continue
+
             tags = str(with_.get("tags") or "")
+            if not tags.strip():
+                # No tag: the reference is a digest nobody has been handed.
+                continue
             if STAGING_MARKER in tags:
                 continue
+
+            how = f"outputs: {outputs[:60]}" if (pushes_via_outputs or digest_only) else f"push: {push}"
             if "${{" in str(push):
-                return f"step `{uses.split('@')[0]}` push is the expression {push!r}, which may be true"
-            return f"step `{uses.split('@')[0]}` with push: {push}"
+                how = f"push is the expression {push!r}, which may be true"
+            return f"step `{uses.split('@')[0]}` attaches tag(s) {tags.strip().splitlines()[0][:60]!r} with {how}"
+
         for marker in PUBLISH_SHELL:
             if marker in run:
                 line = next((l.strip() for l in run.splitlines() if marker in l), marker)
                 if STAGING_MARKER in line:
+                    continue
+                # A bare digest reference in a shell push is not consumer-reachable.
+                if marker == "docker push" and "@sha256:" in line and "--tag" not in line:
                     continue
                 return f"run step contains `{marker}`: {line[:80]}"
     return None
@@ -214,12 +237,18 @@ def analyse(workflows):
 
 
 SELF_TESTS = [
+    # These two carry `tags:` because a real publishing job does. Written
+    # without it they were shorthand for "a job that publishes", and the
+    # shorthand stopped being true once the check learned that the tag, not
+    # the push, is what makes a reference reachable.
     ("publish with no signer anywhere", 1, {
         "build.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
-            "image": {"steps": [{"uses": "docker/build-push-action@v7", "with": {"push": True}}]}}}}),
+            "image": {"steps": [{"uses": "docker/build-push-action@v7",
+                                 "with": {"push": True, "tags": "ghcr.io/o/i:v1"}}]}}}}),
     ("publish and sign in separate workflows on the same tag", 1, {
         "build.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
-            "image": {"steps": [{"uses": "docker/build-push-action@v7", "with": {"push": True}}]}}},
+            "image": {"steps": [{"uses": "docker/build-push-action@v7",
+                                 "with": {"push": True, "tags": "ghcr.io/o/i:v1"}}]}}},
         "supply-chain.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
             "sign": {"steps": [{"run": "cosign sign --yes $REF"}]}}}}),
     ("publish without needs on the signer in the same workflow", 1, {
@@ -240,6 +269,24 @@ SELF_TESTS = [
     ("pull-request build that does not push", 0, {
         "w.yml": {"on": {"pull_request": None}, "jobs": {
             "image": {"steps": [{"uses": "docker/build-push-action@v7", "with": {"push": False}}]}}}}),
+    # The same publish spelled through `outputs:`. Reading only `with.push`
+    # passed this silently, which is how it was found -- against a peer's
+    # corrected pipeline, where the tagless form of it is the correct answer.
+    ("tagged publish spelled through outputs: is a violation", 1, {
+        "w.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
+            "publish": {"steps": [{"uses": "docker/build-push-action@v7", "with": {
+                "outputs": "type=image,name=ghcr.io/o/i,push=true", "tags": "ghcr.io/o/i:v1.2.3"}}]},
+            "sign": {"steps": [{"run": "cosign sign --yes ghcr.io/o/i:v1.2.3"}]}}}}),
+    ("push-by-digest with no tag is not a consumer reference", 0, {
+        "w.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
+            "image": {"steps": [{"uses": "docker/build-push-action@v7", "with": {
+                "outputs": "type=image,name=ghcr.io/o/i,push-by-digest=true"}}]},
+            "sign": {"needs": "image", "steps": [{"run": "cosign sign --yes ghcr.io/o/i@$DIGEST"}]},
+            "promote": {"needs": "sign", "steps": [
+                {"run": "docker buildx imagetools create --tag ghcr.io/o/i:v1 ghcr.io/o/i@$DIGEST"}]}}}}),
+    ("push: true with no tag is likewise not a consumer reference", 0, {
+        "w.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
+            "image": {"steps": [{"uses": "docker/build-push-action@v7", "with": {"push": True}}]}}}}),
 ]
 
 

--- a/tests/security/check_signing_precedes_publish.py
+++ b/tests/security/check_signing_precedes_publish.py
@@ -56,6 +56,23 @@ def steps_of(job):
     return job.get("steps") or [] if isinstance(job, dict) else []
 
 
+def tag_inside_outputs(outputs):
+    """A tag can hide in `outputs: type=image,name=<ref>,...` with no `tags:` key.
+
+    A colon in the LAST path segment is a tag. A colon before it is a registry
+    port -- `localhost:5000/org/repo` carries no tag -- and reading that as one
+    trades a false negative for a false positive, which is not an improvement.
+    """
+    for part in outputs.split(","):
+        part = part.strip()
+        if not part.startswith("name="):
+            continue
+        ref = part[len("name="):]
+        if ":" in ref.rsplit("/", 1)[-1]:
+            return ref
+    return None
+
+
 def job_publishes(job):
     """Return a reason string when the job creates a CONSUMER-REACHABLE reference.
 
@@ -85,17 +102,27 @@ def job_publishes(job):
             if push_absent and not pushes_via_outputs and not digest_only:
                 continue
 
-            tags = str(with_.get("tags") or "")
-            if not tags.strip():
-                # No tag: the reference is a digest nobody has been handed.
-                continue
-            if STAGING_MARKER in tags:
+            # push-by-digest short-circuits before any tag reasoning. It is the
+            # corrected form, and without this the check can flag the very
+            # shape it exists to recommend.
+            if digest_only:
                 continue
 
-            how = f"outputs: {outputs[:60]}" if (pushes_via_outputs or digest_only) else f"push: {push}"
+            tags = str(with_.get("tags") or "").strip()
+            hidden = tag_inside_outputs(outputs) if not tags else None
+            if not tags and not hidden:
+                # No tag anywhere: the reference is a digest nobody was handed.
+                continue
+            label = tags.splitlines()[0][:60] if tags else hidden
+            if STAGING_MARKER in (tags or hidden or ""):
+                continue
+
+            how = f"outputs: {outputs[:60]}" if pushes_via_outputs else f"push: {push}"
+            if hidden:
+                how = f"the tag is inside outputs, with no `tags:` key: {outputs[:60]}"
             if "${{" in str(push):
                 how = f"push is the expression {push!r}, which may be true"
-            return f"step `{uses.split('@')[0]}` attaches tag(s) {tags.strip().splitlines()[0][:60]!r} with {how}"
+            return f"step `{uses.split('@')[0]}` attaches tag(s) {label!r} with {how}"
 
         for marker in PUBLISH_SHELL:
             if marker in run:
@@ -287,6 +314,18 @@ SELF_TESTS = [
     ("push: true with no tag is likewise not a consumer reference", 0, {
         "w.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
             "image": {"steps": [{"uses": "docker/build-push-action@v7", "with": {"push": True}}]}}}}),
+    # The mirror of the outputs hole, found by component-02 in its own checker
+    # and present here too: a tag with neither a `tags:` key nor a `push:` key.
+    ("a tag hidden inside outputs, with no tags: key", 1, {
+        "w.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
+            "publish": {"steps": [{"uses": "docker/build-push-action@v7", "with": {
+                "outputs": "type=image,name=ghcr.io/org/repo:v1.2.3,push=true"}}]},
+            "sign": {"steps": [{"run": "cosign sign --yes ghcr.io/org/repo:v1.2.3"}]}}}}),
+    ("a registry port is not a tag", 0, {
+        "w.yml": {"on": {"push": {"tags": ["v*"]}}, "jobs": {
+            "publish": {"steps": [{"uses": "docker/build-push-action@v7", "with": {
+                "outputs": "type=image,name=localhost:5000/org/repo,push=true"}}]},
+            "sign": {"needs": "publish", "steps": [{"run": "cosign sign --yes localhost:5000/org/repo@$D"}]}}}}),
 ]
 
 

--- a/tests/security/redprobe_secrets_gate.sh
+++ b/tests/security/redprobe_secrets_gate.sh
@@ -63,14 +63,19 @@ else
   printf '[extend]\nuseDefault = true\n' > "$WORK/config/.gitleaks.toml"
 fi
 
-git archive "$REF" | tar -x -C "$WORK/clean"
-git -C "$WORK/clean" init -q .
-git -C "$WORK/clean" add -A
-git -C "$WORK/clean" -c user.email=probe@local -c user.name=probe commit -qm "tree at $REF"
+# Clone the REAL history rather than replaying the tree into one synthetic
+# commit. gitleaks and trufflehog both scan commit diffs, and the two
+# constructions do not agree: on this repository a single-commit replay of
+# origin/main reports four findings that a real-history clone of the same
+# commit does not report at all. A synthetic history measures the harness,
+# not the gate.
+SRC="$(git rev-parse --show-toplevel)"
+git clone --no-local --quiet --no-checkout "$SRC" "$WORK/clean"
+git -C "$WORK/clean" fetch --quiet "$SRC" "+$REF:refs/heads/probe-base"
+git -C "$WORK/clean" checkout --quiet probe-base
 
-cp -R "$WORK/clean/." "$WORK/dirty/"
-rm -rf "$WORK/dirty/.git"
-git -C "$WORK/dirty" init -q .
+rm -rf "$WORK/dirty"
+cp -R "$WORK/clean" "$WORK/dirty"
 
 rand() { LC_ALL=C tr -dc "$1" < /dev/urandom | head -c "$2"; }
 printf 'aws_access_key_id = AKIA%s\naws_secret_access_key = %s\n' \

--- a/tests/security/redprobe_secrets_gate.sh
+++ b/tests/security/redprobe_secrets_gate.sh
@@ -90,18 +90,67 @@ rm -rf "$WORK/dirty"
 cp -R "$WORK/clean" "$WORK/dirty"
 
 rand() { LC_ALL=C tr -dc "$1" < /dev/urandom | head -c "$2"; }
-printf 'aws_access_key_id = AKIA%s\naws_secret_access_key = %s\n' \
-  "$(rand 'A-Z0-9' 16)" "$(rand 'A-Za-z0-9/+' 40)" > "$WORK/dirty/planted_aws.txt"
-printf 'GITHUB_TOKEN=ghp_%s\n' "$(rand 'A-Za-z0-9' 36)" > "$WORK/dirty/planted_pat.env"
-openssl genrsa 2048 2>/dev/null > "$WORK/dirty/planted_key.pem"
+draw_payloads() {
+  printf 'aws_access_key_id = AKIA%s\naws_secret_access_key = %s\n' \
+    "$(rand 'A-Z0-9' 16)" "$(rand 'A-Za-z0-9/+' 40)" > "$1/planted_aws.txt"
+  printf 'GITHUB_TOKEN=ghp_%s\n' "$(rand 'A-Za-z0-9' 36)" > "$1/planted_pat.env"
+  openssl genrsa 2048 2>/dev/null > "$1/planted_key.pem"
+}
 
+# Preflight: every payload must fire on its own before it is planted.
+#
+# The AWS rule applies an entropy threshold to the candidate secret, and a
+# random 40-character draw misses it in roughly one run in fifteen. Without
+# this step the probe of a merge-blocking gate is itself flaky, and a flaky
+# probe teaches people to re-run it -- which is how a genuinely dead payload
+# eventually passes unnoticed. Re-drawing separates "this class is not
+# detected at all", which is a finding, from "this draw was unlucky", which
+# is noise. Found by component-06 at 14 detections in 15 isolated runs.
+PREFLIGHT="$WORK/preflight"
+attempt=0
+while :; do
+  attempt=$((attempt + 1))
+  rm -rf "$PREFLIGHT"; mkdir -p "$PREFLIGHT"
+  draw_payloads "$PREFLIGHT"
+  git -C "$PREFLIGHT" init -q .
+  git -C "$PREFLIGHT" add -A
+  git -C "$PREFLIGHT" -c user.email=probe@local -c user.name=probe commit -qm payloads
+  # --verbose is what prints the per-finding File: lines. Without it gitleaks
+  # reports only a count, and a per-file check silently matches nothing.
+  docker run --rm --read-only --user "$(id -u):$(id -g)" \
+    -v "$PREFLIGHT:/repo:ro" -v "$WORK/config:/config:ro" \
+    "$GITLEAKS_IMAGE" detect --source=/repo --no-banner --redact --verbose --exit-code 1 \
+    --config=/config/.gitleaks.toml > "$WORK/preflight.out" 2>&1
+  rc=$?
+  # 0 = nothing found, 1 = findings. Anything else means the scanner did not
+  # run, which must not be re-drawn as if it were an unlucky payload.
+  if [ "$rc" -ne 0 ] && [ "$rc" -ne 1 ]; then
+    echo "FAIL preflight: the scanner exited $rc, so it did not scan."
+    sed -n '1,15p' "$WORK/preflight.out"
+    exit 1
+  fi
+  missing=""
+  for p in planted_aws.txt planted_pat.env planted_key.pem; do
+    grep -q "$p" "$WORK/preflight.out" || missing="$missing $p"
+  done
+  [ -z "$missing" ] && break
+  if [ "$attempt" -ge 5 ]; then
+    echo "FAIL preflight: after $attempt draws these classes are still undetected:$missing"
+    echo "     Not a bad draw at this point -- the rule is absent, or the class is allowlisted."
+    exit 1
+  fi
+done
+[ "$attempt" -gt 1 ] && echo "note preflight: re-drew payloads $((attempt - 1)) time(s) before all three fired"
+echo "ok   preflight: all three payload classes fire in isolation"
+
+cp "$PREFLIGHT"/planted_*.txt "$PREFLIGHT"/planted_*.env "$PREFLIGHT"/planted_*.pem "$WORK/dirty/"
 git -C "$WORK/dirty" add -A
 git -C "$WORK/dirty" -c user.email=probe@local -c user.name=probe commit -qm "tree at $REF plus planted credentials"
 
 run_gate() {
   docker run --rm --read-only --user "$(id -u):$(id -g)" \
     -v "$WORK/$1:/repo:ro" -v "$WORK/config:/config:ro" \
-    "$GITLEAKS_IMAGE" detect --source=/repo --no-banner --redact --exit-code 1 \
+    "$GITLEAKS_IMAGE" detect --source=/repo --no-banner --redact --verbose --exit-code 1 \
     --config=/config/.gitleaks.toml > "$WORK/$1.out" 2>&1
   echo $?
 }
@@ -171,11 +220,22 @@ else
     note "FAIL dirty leg: exit 1 but no finding count reported -- the scanner failed rather than detected."
     sed -n '1,20p' "$WORK/dirty.out"
     fail=1
-  elif [ "$found" -lt 3 ]; then
-    note "FAIL dirty leg: only $found of 3 planted classes detected -- at least one detector is allowlisted or absent"
-    fail=1
   else
-    note "ok   dirty leg: gate reddened on all planted classes (exit 1, leaks found: $found)"
+    # Attribute rather than count. A finding total of three proves the gate
+    # reddened; it does not prove it reddened on the planted payload, and a
+    # pre-existing secret elsewhere would satisfy a count check while leaving
+    # the planted classes undetected.
+    unattributed=""
+    for p in planted_aws.txt planted_pat.env planted_key.pem; do
+      grep -q "$p" "$WORK/dirty.out" || unattributed="$unattributed $p"
+    done
+    if [ -n "$unattributed" ]; then
+      note "FAIL dirty leg: the gate reddened, but not on these planted files:$unattributed"
+      note "     Something else in the tree produced the findings, so the probe proves nothing."
+      fail=1
+    else
+      note "ok   dirty leg: gate reddened, all three planted files named (exit 1, leaks found: $found)"
+    fi
   fi
 fi
 

--- a/tests/security/redprobe_secrets_gate.sh
+++ b/tests/security/redprobe_secrets_gate.sh
@@ -110,10 +110,30 @@ clean_rc="$(run_gate clean)"
 dirty_rc="$(run_gate dirty)"
 
 bytes_of() { sed -n 's/.*scanned ~\([0-9]*\) bytes.*/\1/p' "$WORK/$1.out" | head -1; }
+commits_of() { sed -n 's/.*[^0-9]\([0-9]*\) commits scanned.*/\1/p' "$WORK/$1.out" | head -1; }
 clean_bytes="$(bytes_of clean)"; dirty_bytes="$(bytes_of dirty)"
 
 fail=0
 note() { echo "$1"; }
+
+# Scope check. The expectation comes from `git rev-list`, a different source
+# than the scanner's own counter -- comparing a run against a previous run of
+# the same tool catches drift but not systematic error, and both defects this
+# harness has had were systematic: a replayed one-commit history, and a clone
+# carrying every branch. Two independent sources agreeing is what makes the
+# count evidence rather than decoration.
+expected_commits="$(git -C "$WORK/clean" rev-list --count HEAD)"
+scanned_commits="$(commits_of clean)"
+if [ -z "$scanned_commits" ]; then
+  note "FAIL scope: the scanner reported no commit count; it did not walk a history"
+  fail=1
+elif [ "$scanned_commits" != "$expected_commits" ]; then
+  note "FAIL scope: scanner walked $scanned_commits commits, git says $REF reaches $expected_commits."
+  note "     The scan surface is not the ref under test, so neither leg answers for $REF."
+  fail=1
+else
+  note "ok   scope: $scanned_commits commits, matching git rev-list for $REF"
+fi
 
 # Delivery check first. A dirty leg that scanned no more bytes than the clean
 # leg never received the payload, and its result -- green or red -- is about

--- a/tests/security/redprobe_secrets_gate.sh
+++ b/tests/security/redprobe_secrets_gate.sh
@@ -187,14 +187,17 @@ fi
 # Delivery check first. A dirty leg that scanned no more bytes than the clean
 # leg never received the payload, and its result -- green or red -- is about
 # the harness, not the gate.
-if [ -z "$clean_bytes" ] || [ -z "$dirty_bytes" ]; then
-  note "FAIL delivery: could not read scanned-byte counts; the gate did not run as expected"
-  fail=1
-elif [ "$dirty_bytes" -le "$clean_bytes" ]; then
-  note "FAIL delivery: dirty leg scanned $dirty_bytes bytes, clean scanned $clean_bytes -- the payload never reached the scanned tree"
+undelivered=""
+for p in planted_aws.txt planted_pat.env planted_key.pem; do
+  git -C "$WORK/dirty" cat-file -e "HEAD:$p" 2>/dev/null || undelivered="$undelivered $p"
+done
+if [ -n "$undelivered" ]; then
+  note "FAIL delivery: these payloads are not in the dirty leg's committed history:$undelivered"
+  note "     Both scanners read commits, so an unstaged payload is invisible and the"
+  note "     dirty leg's result says nothing about the gate."
   fail=1
 else
-  note "ok   delivery: payload reached the scanned tree (+$((dirty_bytes - clean_bytes)) bytes)"
+  note "ok   delivery: all three payloads present in the dirty leg's HEAD (scanned bytes ${clean_bytes:-?} -> ${dirty_bytes:-?}, informational)"
 fi
 
 if [ "$clean_rc" -ne 0 ]; then

--- a/tests/security/redprobe_secrets_gate.sh
+++ b/tests/security/redprobe_secrets_gate.sh
@@ -72,7 +72,19 @@ fi
 SRC="$(git rev-parse --show-toplevel)"
 git clone --no-local --quiet --no-checkout "$SRC" "$WORK/clean"
 git -C "$WORK/clean" fetch --quiet "$SRC" "+$REF:refs/heads/probe-base"
+
+# Drop every ref except the one under test. A clone carries all of the
+# source's branches, and the scanners walk refs rather than the checkout, so
+# without this the clean leg answers "clean across whatever branches happened
+# to be in the clone" while claiming to answer for REF. It also makes the
+# scanned-commit count reproducible between machines, which is what lets the
+# count be used as evidence at all.
+git -C "$WORK/clean" for-each-ref --format='%(refname)' \
+  | grep -v '^refs/heads/probe-base$' \
+  | while read -r r; do git -C "$WORK/clean" update-ref -d "$r"; done
 git -C "$WORK/clean" checkout --quiet probe-base
+git -C "$WORK/clean" reflog expire --expire=now --all
+git -C "$WORK/clean" gc --prune=now --quiet
 
 rm -rf "$WORK/dirty"
 cp -R "$WORK/clean" "$WORK/dirty"

--- a/tests/security/redprobe_secrets_gate.sh
+++ b/tests/security/redprobe_secrets_gate.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# Red-probe the secrets gate: prove it reddens on a planted credential.
+#
+# A secrets gate that has never been shown to fail is indistinguishable from a
+# gate that cannot fail. This runs the exact command `.github/workflows/
+# security.yml` runs -- same pinned image, same flags, same base-ref config --
+# against two trees, and asserts opposite outcomes:
+#
+#   clean  = the committed tree at REF, untouched          -> expect exit 0
+#   dirty  = that same tree plus planted credentials       -> expect exit 1
+#
+# Both legs scan a COMMITTED tree, never a working directory. gitleaks is
+# invoked without `--no-git`, so it walks commit history: an uncommitted
+# planted secret is invisible to it and would produce a green dirty leg that
+# says nothing about the gate.
+#
+# Payloads are generated from /dev/urandom, never copied from documentation.
+# Every credential value printed in a vendor's docs is in the scanner's
+# allowlist by the time the scanner ships -- otherwise it would redden on the
+# vendor's own README -- so a documentation-sourced payload is guaranteed not
+# to fire. Three independent detector classes are planted so one allowlisted
+# payload cannot make the probe read as vacuous.
+#
+# Usage:
+#   tests/security/redprobe_secrets_gate.sh [--ref REF] [--keep]
+#
+# Exit 0 when the gate behaved correctly in BOTH directions, 1 otherwise.
+
+set -uo pipefail
+
+REF="origin/next/v1"
+KEEP=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --ref) REF="$2"; shift 2 ;;
+    --keep) KEEP=1; shift ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Pinned by digest, matching security.yml. A movable tag would let the probe
+# and the gate drift apart silently.
+GITLEAKS_IMAGE='zricethezav/gitleaks:v8.30.1@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f'
+
+command -v docker >/dev/null || { echo "docker is required" >&2; exit 2; }
+git rev-parse --verify "$REF" >/dev/null 2>&1 || { echo "no such ref: $REF" >&2; exit 2; }
+
+WORK="$(mktemp -d)"
+cleanup() { [ "$KEEP" -eq 1 ] && echo "kept: $WORK" || rm -rf "$WORK"; }
+trap cleanup EXIT
+
+mkdir -p "$WORK/clean" "$WORK/dirty" "$WORK/config"
+
+# The config comes from the ref under test, mirroring security.yml's
+# base-ref-wins rule. Reading it from the working tree would let a local edit
+# decide whether the probe passes.
+if git cat-file -e "$REF:.gitleaks.toml" 2>/dev/null; then
+  git show "$REF:.gitleaks.toml" > "$WORK/config/.gitleaks.toml"
+else
+  printf '[extend]\nuseDefault = true\n' > "$WORK/config/.gitleaks.toml"
+fi
+
+git archive "$REF" | tar -x -C "$WORK/clean"
+git -C "$WORK/clean" init -q .
+git -C "$WORK/clean" add -A
+git -C "$WORK/clean" -c user.email=probe@local -c user.name=probe commit -qm "tree at $REF"
+
+cp -R "$WORK/clean/." "$WORK/dirty/"
+rm -rf "$WORK/dirty/.git"
+git -C "$WORK/dirty" init -q .
+
+rand() { LC_ALL=C tr -dc "$1" < /dev/urandom | head -c "$2"; }
+printf 'aws_access_key_id = AKIA%s\naws_secret_access_key = %s\n' \
+  "$(rand 'A-Z0-9' 16)" "$(rand 'A-Za-z0-9/+' 40)" > "$WORK/dirty/planted_aws.txt"
+printf 'GITHUB_TOKEN=ghp_%s\n' "$(rand 'A-Za-z0-9' 36)" > "$WORK/dirty/planted_pat.env"
+openssl genrsa 2048 2>/dev/null > "$WORK/dirty/planted_key.pem"
+
+git -C "$WORK/dirty" add -A
+git -C "$WORK/dirty" -c user.email=probe@local -c user.name=probe commit -qm "tree at $REF plus planted credentials"
+
+run_gate() {
+  docker run --rm --read-only --user "$(id -u):$(id -g)" \
+    -v "$WORK/$1:/repo:ro" -v "$WORK/config:/config:ro" \
+    "$GITLEAKS_IMAGE" detect --source=/repo --no-banner --redact --exit-code 1 \
+    --config=/config/.gitleaks.toml > "$WORK/$1.out" 2>&1
+  echo $?
+}
+
+clean_rc="$(run_gate clean)"
+dirty_rc="$(run_gate dirty)"
+
+bytes_of() { sed -n 's/.*scanned ~\([0-9]*\) bytes.*/\1/p' "$WORK/$1.out" | head -1; }
+clean_bytes="$(bytes_of clean)"; dirty_bytes="$(bytes_of dirty)"
+
+fail=0
+note() { echo "$1"; }
+
+# Delivery check first. A dirty leg that scanned no more bytes than the clean
+# leg never received the payload, and its result -- green or red -- is about
+# the harness, not the gate.
+if [ -z "$clean_bytes" ] || [ -z "$dirty_bytes" ]; then
+  note "FAIL delivery: could not read scanned-byte counts; the gate did not run as expected"
+  fail=1
+elif [ "$dirty_bytes" -le "$clean_bytes" ]; then
+  note "FAIL delivery: dirty leg scanned $dirty_bytes bytes, clean scanned $clean_bytes -- the payload never reached the scanned tree"
+  fail=1
+else
+  note "ok   delivery: payload reached the scanned tree (+$((dirty_bytes - clean_bytes)) bytes)"
+fi
+
+if [ "$clean_rc" -ne 0 ]; then
+  note "FAIL clean leg: the committed tree at $REF reports a leak (exit $clean_rc). Either a real secret is committed, or the config is broken."
+  sed -n '1,20p' "$WORK/clean.out"
+  fail=1
+else
+  note "ok   clean leg: committed tree at $REF is clean (exit 0)"
+fi
+
+if [ "$dirty_rc" -ne 1 ]; then
+  note "FAIL dirty leg: three planted credential classes did NOT redden the gate (exit $dirty_rc)."
+  note "     This is the fake-green case: the gate runs, reports success, and would pass a real leak."
+  sed -n '1,20p' "$WORK/dirty.out"
+  fail=1
+else
+  # Exit 1 alone is not proof of detection. gitleaks also exits non-zero when
+  # it cannot load its config at all, and a probe that accepts that as "the
+  # gate reddened" would certify a scanner that never scanned. Require a
+  # parsed finding count.
+  found="$(sed -n 's/.*leaks found: \([0-9]*\).*/\1/p' "$WORK/dirty.out" | head -1)"
+  if [ -z "$found" ]; then
+    note "FAIL dirty leg: exit 1 but no finding count reported -- the scanner failed rather than detected."
+    sed -n '1,20p' "$WORK/dirty.out"
+    fail=1
+  elif [ "$found" -lt 3 ]; then
+    note "FAIL dirty leg: only $found of 3 planted classes detected -- at least one detector is allowlisted or absent"
+    fail=1
+  else
+    note "ok   dirty leg: gate reddened on all planted classes (exit 1, leaks found: $found)"
+  fi
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "SECRETS GATE RED-PROBE FAILED"
+  exit 1
+fi
+echo
+echo "secrets gate proven two-sided against $REF"

--- a/tests/security/rehearsal-subject/Dockerfile
+++ b/tests/security/rehearsal-subject/Dockerfile
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# The smallest subject that still yields a non-empty SBOM. `scratch` alone
+# produces an SBOM with zero packages, which the guard correctly refuses --
+# the rehearsal needs a subject the green leg can pass.
+FROM alpine:3.21@sha256:21dc6063fd678b478f57c0e13f47560d0ea4eeba26dfc947b2a4f81f686b9f45
+RUN true

--- a/tests/security/resolve_ref_guard.sh
+++ b/tests/security/resolve_ref_guard.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# Build the image reference the signing job will sign, refusing an absent
+# digest.
+#
+# A build job that pushed nothing leaves its output empty, and an empty digest
+# composes the reference `ghcr.io/x@` -- which cosign rejects with a parse
+# error rather than a statement about signing. Failing here keeps the reason
+# legible.
+#
+# Lowercasing is not cosmetic: registries reject uppercase in a repository
+# name, and `github.repository` carries the organisation's capitalisation that
+# metadata-action used to fold away while the name came from `tags:`.
+#
+# Reads DIGEST, SUFFIX, REPO from the environment. Writes `ref=` to
+# GITHUB_OUTPUT when set, and prints it either way.
+# Exit 0 when a reference was built, 1 when the digest is absent.
+set -uo pipefail
+
+: "${DIGEST?}" ; : "${SUFFIX?}" ; : "${REPO?}"
+
+if [ -z "$DIGEST" ]; then
+  echo "::error::no digest from the build job; there is nothing to sign" >&2
+  exit 1
+fi
+
+repo_lower="$(printf '%s' "$REPO" | tr '[:upper:]' '[:lower:]')"
+ref="ghcr.io/${repo_lower}${SUFFIX}@${DIGEST}"
+echo "$ref"
+[ -n "${GITHUB_OUTPUT:-}" ] && printf 'ref=%s\n' "$ref" >> "$GITHUB_OUTPUT"
+exit 0

--- a/tests/security/sbom_guard.sh
+++ b/tests/security/sbom_guard.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# Refuse an SBOM that describes nothing.
+#
+# syft exiting zero does not mean it resolved anything. Without this a
+# degenerate SBOM is attested and verification still passes, because
+# verification checks that an attestation exists and is signed by the right
+# identity -- not that its predicate describes the image.
+#
+# This lives in a file rather than inline in the workflow so the rehearsal
+# exercises the same implementation the release path runs. A copy in the
+# rehearsal would prove the copy.
+#
+# Usage: sbom_guard.sh <sbom.spdx.json>
+# Exit 0 when the SBOM describes at least one package, 1 otherwise.
+set -uo pipefail
+
+f="${1:?usage: sbom_guard.sh <sbom.spdx.json>}"
+
+if [ ! -s "$f" ]; then
+  echo "::error::${f} is absent or empty; syft produced no SBOM" >&2
+  exit 1
+fi
+if ! jq -e . "$f" >/dev/null 2>&1; then
+  echo "::error::${f} is not valid JSON" >&2
+  exit 1
+fi
+pkgs="$(jq '(.packages // []) | length' "$f")"
+echo "SPDX packages: ${pkgs}"
+if [ "$pkgs" -eq 0 ]; then
+  echo "::error::an SBOM listing zero packages describes nothing; refusing to attest it" >&2
+  exit 1
+fi


### PR DESCRIPTION
Twelve commits. Three harnesses that prove a gate reddens on a planted defect, one exclusion reconciliation, and two gate hardenings. Nothing here ships; every file is a test or a workflow.

## One check in this PR is RED, deliberately

`release — signing precedes publish` fails on four jobs, and the failure is correct. `build.yml` publishes four images on a tag, `supply-chain.yml` signs them on the same tag, and no `needs:` or `workflow_run` orders the two. The image is public before it is signed, for as long as the signing job waits on its `production` environment approval, and indefinitely if that approval never comes.

The gate lands red on purpose. Switching it off because it reports something true is the defect this whole set of gates exists to prevent, and the red belongs in the history ahead of the fix so that the fix is demonstrably a fix. Correcting the release graph is a separate change: publish by digest, sign the digest, then attach the release tag from a job that depends on the signature.

## What is proven, and what is not

Proven, two-sided and mutation-tested:

- the secrets gate detects three planted credential classes and is clean on the real history of this branch (60 commits);
- the release pipeline rejects impostor signing identities across twelve cases, with the anchoring and the metacharacter escaping each holding a named subset;
- the signing-order check reports a violation in every case that has one and none where there is not, across twelve cases;
- the new SBOM guard refuses an absent, malformed, or zero-package SBOM, each with its own message.

Not proven, and not claimed:

- that the release pipeline fails on a real tag push. That needs a tag and a registry.
- that the SAST half of gate 2 catches a defect written the way the scanned code is written. It catches `subprocess(shell=True)` and `eval()`, neither of which occurs in the fourteen files semgrep scans here. The one idiomatic regression available — `yaml.safe_load` to `yaml.load` in `quick_validate.py`, which parses untrusted frontmatter — produces zero findings, and no rule for that class exists in any of the six configured packs. Closing it needs a custom rule.

## The harnesses fixed five defects in themselves

Each was found by breaking what the check must catch, and none was visible by reading:

- both legs replayed a ref into one synthetic commit; the scanners walk diffs, and the replay reported four findings a real-history clone does not;
- the clone carried every branch, so the clean leg walked 463 commits for a ref reaching 47;
- the scanned-commit count was printed and compared against nothing; it now checks against `git rev-list`, deliberately a different source;
- the AWS payload missed gitleaks entropy threshold in roughly one draw in fifteen, so each class is now verified to fire in isolation before it is planted;
- delivery was inferred from a byte delta, which answers yes when nothing was delivered; it now asks git whether the payload is in the dirty leg HEAD.

The signing-order check had two more, both false negatives on the shape it exists to catch: a publish spelled through `outputs:` rather than `push:`, and a tag hidden inside the `outputs:` string with no `tags:` key. The second was found by a peer in their own independently written checker, which had the complementary blind spot.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0144JnqqdqnJ3JdsbNA84uXC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added automated checks to ensure container images are signed before publication.
  * Added validation to reject missing, empty, invalid, or incomplete software bill of materials (SBOM) files.
  * Added checks for trusted signing identities and workflow security configurations.
  * Added automated secret-detection probes covering clean and compromised repository histories.
  * Added detection for unsafe YAML deserialization practices.
  * Improved security rule testing and false-positive handling.
  * Added release pipeline rehearsal checks for digest-based signing, verification, and promotion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->