### PR TITLE
ci(security): pin the scanner builds the Layer-0 gates run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -370,6 +370,11 @@ jobs:
 
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@fc46e51fd3cb168ffb36c6d1915723c47db58abb  # v0.17.7
+        with:
+          # Pinning `uses:` pins the action, not the scanner it fetches.
+          # Held at the build the pipeline already resolved to, so this
+          # changes determinism and not the SBOM's contents.
+          syft-version: v1.16.0
 
       - name: Generate SBOM (SPDX JSON)
         env:

--- a/.github/workflows/gate3-rehearsal.yml
+++ b/.github/workflows/gate3-rehearsal.yml
@@ -77,6 +77,11 @@ jobs:
 
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@fc46e51fd3cb168ffb36c6d1915723c47db58abb  # v0.17.7
+        with:
+          # Pinning `uses:` pins the action, not the scanner it fetches.
+          # Held at the build the pipeline already resolved to, so this
+          # changes determinism and not the SBOM's contents.
+          syft-version: v1.16.0
 
       - name: Wait for the throwaway registry
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -238,6 +238,14 @@ jobs:
       - name: Trivy filesystem scan
         uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
+          # Pinning the action pins the wrapper, not the scanner. Without
+          # this input the action fetches whatever release its own default
+          # names, so two runs over an unchanged tree can reach different
+          # verdicts and neither is reproducible from the repository. Held
+          # at the value that default resolves to today, so this commit
+          # changes determinism and nothing else; moving the scanner is a
+          # separate decision that can change findings.
+          version: v0.70.0
           scan-type: fs
           scan-ref: .
           # Block merge on CRITICAL. HIGH gets a 14-day grace via the
@@ -276,6 +284,10 @@ jobs:
       - name: Trivy filesystem scan (HIGH, informational)
         uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
+          # Same scanner build as the CRITICAL pass above. If the two passes
+          # drift apart, the exception ledger starts describing findings the
+          # blocking pass never produced.
+          version: v0.70.0
           scan-type: fs
           scan-ref: .
           severity: HIGH

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -141,6 +141,11 @@ jobs:
 
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@fc46e51fd3cb168ffb36c6d1915723c47db58abb  # v0.17.7
+        with:
+          # Pinning `uses:` pins the action, not the scanner it fetches.
+          # Held at the build the pipeline already resolved to, so this
+          # changes determinism and not the SBOM's contents.
+          syft-version: v1.16.0
 
       - name: Generate SBOM (SPDX JSON + CycloneDX JSON)
         env:

--- a/tests/security/test_scanner_version_pinned.py
+++ b/tests/security/test_scanner_version_pinned.py
@@ -71,6 +71,65 @@ SCANNER_BINARIES = ("trivy", "syft", "grype")
 
 SCRIPT_SUFFIXES = (".sh", ".bash")
 
+# Tokens that stand before a command without being the command: the
+# Dockerfile instruction, its flags, and a privilege wrapper. A matcher
+# written for shell command position alone misses `RUN trivy ...`, which is
+# the idiomatic form in exactly the files this walk was added to cover --
+# the enumeration was wider than the language the pattern was written in.
+COMMAND_PREFIX = r"((RUN|sudo)\s+|--[\w=/,.:@-]+\s+)*"
+
+
+def command_position(binary):
+    """Pattern matching `binary` where it is invoked, not merely named."""
+    return rf"(^|[|;&]|\$\()\s*{COMMAND_PREFIX}{re.escape(binary)}\s"
+
+
+MATCHER_CASES = (
+    ("trivy fs --format cyclonedx .", True),
+    ("RUN trivy fs --format cyclonedx .", True),
+    ("RUN --mount=type=cache trivy image x", True),
+    ("RUN --mount=type=cache,target=/usr/local/bin/trivy trivy image y", True),
+    ("sudo trivy image x", True),
+    ("cat x | trivy sbom -", True),
+    ("$(trivy --version)", True),
+    # The binary's name inside a flag value is not a call. Without these the
+    # positive case above passes for the wrong reason -- a matcher that took
+    # the flag value for the command would satisfy it just as well.
+    ("RUN --mount=type=cache,target=/usr/local/bin/trivy echo hi", False),
+    ("RUN --mount=target=/opt/trivy/bin npm ci", False),
+    # Installing the tool is not running it.
+    ("RUN apt-get install -y trivy", False),
+    # A mention is not a call, in either comment form.
+    ("# trivy fs .", False),
+    ("# RUN trivy fs .", False),
+    ("echo trivy is nice", False),
+    ("RUN echo trivy", False),
+)
+
+
+def self_test():
+    """Pin the matcher's own behaviour.
+
+    Without this the next widening silently drops a form, and the guard goes
+    on reporting a subset as the whole -- the defect it exists to catch.
+    """
+    failures = []
+    for text, want in MATCHER_CASES:
+        stripped = text.strip()
+        got = False if stripped.startswith("#") else bool(
+            re.search(command_position("trivy"), stripped)
+        )
+        if got != want:
+            failures.append(f"{text!r} -- expected {want}, got {got}")
+    for failure in failures:
+        print(f"FAIL matcher {failure}", file=sys.stderr)
+    print(
+        f"self-test: {len(MATCHER_CASES)} command-position cases; a Dockerfile "
+        f"`RUN` form and a flagged `RUN` form count as calls, while installing "
+        f"the tool, naming it, and both comment forms do not"
+    )
+    return 1 if failures else 0
+
 
 def bare_invocations(root=REPO_ROOT):
     """Yield (file, line, binary) for scanner calls made outside a workflow.
@@ -102,9 +161,7 @@ def bare_invocations(root=REPO_ROOT):
                 if not stripped or stripped.startswith("#"):
                     continue
                 for binary in SCANNER_BINARIES:
-                    # A command position: start of line, or after a pipe,
-                    # `&&`, `;` or `$(`. Not a substring of another word.
-                    if re.search(rf"(^|[|;&]|\$\()\s*{re.escape(binary)}\s", stripped):
+                    if re.search(command_position(binary), stripped):
                         found.append(
                             (os.path.relpath(path, root), lineno, binary)
                         )
@@ -167,5 +224,12 @@ def test_scanner_version_pinned():
     assert check() == 0
 
 
+def test_matcher_self_test():
+    assert self_test() == 0
+
+
 if __name__ == "__main__":
-    sys.exit(check())
+    if "--self-test" in sys.argv[1:]:
+        sys.exit(self_test())
+    rc = self_test()
+    sys.exit(rc or check())

--- a/tests/security/test_scanner_version_pinned.py
+++ b/tests/security/test_scanner_version_pinned.py
@@ -20,9 +20,13 @@ import yaml
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 WORKFLOW_DIR = os.path.join(REPO_ROOT, ".github", "workflows")
 
-# action name fragment -> the input that names the tool build it fetches
+# action name fragment -> the input that names the tool build it fetches.
+# Every entry is read from the action definition at the pinned SHA, never
+# guessed: an input name that does not exist is accepted silently by Actions
+# and pins nothing.
 PINNED_INPUT = {
     "aquasecurity/trivy-action": "version",
+    "anchore/sbom-action/download-syft": "syft-version",
 }
 
 
@@ -84,6 +88,30 @@ def command_position(binary):
     return rf"(^|[|;&]|\$\()\s*{COMMAND_PREFIX}{re.escape(binary)}\s"
 
 
+def outside_quotes(line):
+    """Blank out quoted spans, keeping length so nothing else shifts.
+
+    `;` and `|` are command separators in shell and ordinary punctuation
+    inside a string. An error message reading `... is empty; syft produced
+    no SBOM` puts a separator immediately before the tool's name and turns a
+    sentence into an apparent invocation. The distinction is whether the
+    separator is quoted, so the quoted spans go before the match runs.
+    """
+    out = []
+    quote = None
+    for ch in line:
+        if quote:
+            out.append(" ")
+            if ch == quote:
+                quote = None
+        elif ch in ("'", '"'):
+            quote = ch
+            out.append(" ")
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
 MATCHER_CASES = (
     ("trivy fs --format cyclonedx .", True),
     ("RUN trivy fs --format cyclonedx .", True),
@@ -97,6 +125,13 @@ MATCHER_CASES = (
     # the flag value for the command would satisfy it just as well.
     ("RUN --mount=type=cache,target=/usr/local/bin/trivy echo hi", False),
     ("RUN --mount=target=/opt/trivy/bin npm ci", False),
+    # A separator inside a quoted string is punctuation, not a pipeline.
+    # This exact shape fired against the real tree before quotes were read.
+    ('  echo "::error::${f} is absent or empty; syft produced no SBOM" >&2',
+     False, "syft"),
+    ("  echo 'scan failed; trivy found nothing' >&2", False),
+    # ... while the same separator unquoted really does start a command.
+    ("false; trivy image x", True),
     # Installing the tool is not running it.
     ("RUN apt-get install -y trivy", False),
     # A mention is not a call, in either comment form.
@@ -114,10 +149,12 @@ def self_test():
     on reporting a subset as the whole -- the defect it exists to catch.
     """
     failures = []
-    for text, want in MATCHER_CASES:
+    for case in MATCHER_CASES:
+        text, want = case[0], case[1]
+        probe = case[2] if len(case) > 2 else "trivy"
         stripped = text.strip()
         got = False if stripped.startswith("#") else bool(
-            re.search(command_position("trivy"), stripped)
+            re.search(command_position(probe), outside_quotes(stripped))
         )
         if got != want:
             failures.append(f"{text!r} -- expected {want}, got {got}")
@@ -160,8 +197,9 @@ def bare_invocations(root=REPO_ROOT):
                 stripped = line.strip()
                 if not stripped or stripped.startswith("#"):
                     continue
+                bare = outside_quotes(stripped)
                 for binary in SCANNER_BINARIES:
-                    if re.search(command_position(binary), stripped):
+                    if re.search(command_position(binary), bare):
                         found.append(
                             (os.path.relpath(path, root), lineno, binary)
                         )

--- a/tests/security/test_scanner_version_pinned.py
+++ b/tests/security/test_scanner_version_pinned.py
@@ -12,6 +12,7 @@ under pytest. Exit 0 = every invocation is pinned, 1 = at least one is not.
 """
 
 import os
+import re
 import sys
 
 import yaml
@@ -63,6 +64,54 @@ def invocations(workflow_dir=WORKFLOW_DIR):
     return found
 
 
+# Scanner binaries a script can call directly. An action's `version:` input
+# has no equivalent here: a bare `trivy ...` runs whatever build is on PATH,
+# and the repository does not say which.
+SCANNER_BINARIES = ("trivy", "syft", "grype")
+
+SCRIPT_SUFFIXES = (".sh", ".bash")
+
+
+def bare_invocations(root=REPO_ROOT):
+    """Yield (file, line, binary) for scanner calls made outside a workflow.
+
+    Walking only `.github/workflows` answers a narrower question than the one
+    a reader takes from a green result. A scan driven from a shell script or
+    a Dockerfile is a scan, and its build is no more pinned for living
+    somewhere the workflow walk does not reach.
+    """
+    found = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [
+            d for d in dirnames if d not in (".git", "node_modules", ".venv")
+        ]
+        # Workflow files are the other arm's business.
+        if os.path.relpath(dirpath, root).startswith(os.path.join(".github", "workflows")):
+            continue
+        for name in filenames:
+            if not (name.endswith(SCRIPT_SUFFIXES) or name.startswith("Dockerfile")):
+                continue
+            path = os.path.join(dirpath, name)
+            try:
+                with open(path, errors="replace") as fh:
+                    lines = fh.readlines()
+            except OSError:
+                continue
+            for lineno, line in enumerate(lines, 1):
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+                for binary in SCANNER_BINARIES:
+                    # A command position: start of line, or after a pipe,
+                    # `&&`, `;` or `$(`. Not a substring of another word.
+                    if re.search(rf"(^|[|;&]|\$\()\s*{re.escape(binary)}\s", stripped):
+                        found.append(
+                            (os.path.relpath(path, root), lineno, binary)
+                        )
+                        break
+    return sorted(found)
+
+
 def check(workflow_dir=WORKFLOW_DIR):
     calls = invocations(workflow_dir)
     if not calls:
@@ -94,11 +143,22 @@ def check(workflow_dir=WORKFLOW_DIR):
                 f"{sorted(versions)}"
             )
 
+    # A scanner called from a script runs whatever build is on PATH. The
+    # repository cannot say which, so the pin above describes a subset while
+    # reading as the whole.
+    bare = bare_invocations()
+    for path, lineno, binary in bare:
+        problems.append(
+            f"{path}:{lineno} calls {binary} directly; the build it runs comes "
+            f"from PATH and is not stated anywhere in the repository"
+        )
+
     for problem in problems:
         print(f"FAIL {problem}", file=sys.stderr)
+    unpinned = len([p for p in problems if "without naming" in p])
     print(
-        f"ok {len(calls)} scanner invocation(s) examined; "
-        f"{len(calls) - len([p for p in problems if 'without naming' in p])} pinned"
+        f"ok {len(calls)} action invocation(s) examined, {len(calls) - unpinned} "
+        f"pinned; {len(bare)} direct call(s) outside a workflow"
     )
     return 1 if problems else 0
 

--- a/tests/security/test_scanner_version_pinned.py
+++ b/tests/security/test_scanner_version_pinned.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+"""Every scanner invocation names the scanner build it runs.
+
+Pinning `uses:` to a commit pins the action, not the tool the action
+downloads. A gate whose scanner floats can reach two different verdicts over
+an unchanged tree, and neither verdict is reproducible from the repository --
+which is the first property an audit asks a security gate to have.
+
+Run directly (`python3 tests/security/test_scanner_version_pinned.py`) or
+under pytest. Exit 0 = every invocation is pinned, 1 = at least one is not.
+"""
+
+import os
+import sys
+
+import yaml
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+WORKFLOW_DIR = os.path.join(REPO_ROOT, ".github", "workflows")
+
+# action name fragment -> the input that names the tool build it fetches
+PINNED_INPUT = {
+    "aquasecurity/trivy-action": "version",
+}
+
+
+def invocations(workflow_dir=WORKFLOW_DIR):
+    """Yield (file, job, step_name, action, pinned_value_or_None) per call."""
+    found = []
+    if not os.path.isdir(workflow_dir):
+        raise SystemExit(f"no workflow directory at {workflow_dir}; nothing was checked")
+    names = sorted(
+        n for n in os.listdir(workflow_dir) if n.endswith((".yml", ".yaml"))
+    )
+    if not names:
+        raise SystemExit(f"{workflow_dir} holds no workflow files; nothing was checked")
+    for name in names:
+        path = os.path.join(workflow_dir, name)
+        with open(path) as fh:
+            doc = yaml.safe_load(fh)
+        if not isinstance(doc, dict):
+            continue
+        for job_name, job in (doc.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            for step in job.get("steps") or []:
+                if not isinstance(step, dict):
+                    continue
+                uses = step.get("uses") or ""
+                for action, input_name in PINNED_INPUT.items():
+                    if action in uses:
+                        with_block = step.get("with") or {}
+                        found.append(
+                            (
+                                name,
+                                job_name,
+                                step.get("name") or uses,
+                                action,
+                                with_block.get(input_name),
+                            )
+                        )
+    return found
+
+
+def check(workflow_dir=WORKFLOW_DIR):
+    calls = invocations(workflow_dir)
+    if not calls:
+        # An empty set would pass every assertion below. Absence of a scanner
+        # is a different problem from an unpinned one, and it is not this
+        # check's business to be silent about it.
+        raise SystemExit(
+            "no scanner invocation found in any workflow; this check verified nothing"
+        )
+
+    problems = []
+    for fname, job, step, action, pinned in calls:
+        if not pinned:
+            problems.append(
+                f"{fname}: job {job!r} step {step!r} runs {action} without naming a "
+                f"scanner build; the action fetches whatever its default resolves to"
+            )
+
+    # Two passes of the same scanner that run different builds produce an
+    # exception ledger describing findings the blocking pass never emitted.
+    by_action = {}
+    for _, _, _, action, pinned in calls:
+        if pinned:
+            by_action.setdefault(action, set()).add(pinned)
+    for action, versions in by_action.items():
+        if len(versions) > 1:
+            problems.append(
+                f"{action} runs more than one build across the workflows: "
+                f"{sorted(versions)}"
+            )
+
+    for problem in problems:
+        print(f"FAIL {problem}", file=sys.stderr)
+    print(
+        f"ok {len(calls)} scanner invocation(s) examined; "
+        f"{len(calls) - len([p for p in problems if 'without naming' in p])} pinned"
+    )
+    return 1 if problems else 0
+
+
+def test_scanner_version_pinned():
+    assert check() == 0
+
+
+if __name__ == "__main__":
+    sys.exit(check())


### PR DESCRIPTION
Pinning `uses:` to a commit pins the action, not the tool the action downloads. Both trivy and syft were reached through SHA-pinned actions that then fetched whatever build their own default named, so a gate could reach two different verdicts over an unchanged tree and neither verdict was reproducible from this repository.

Held at the builds the pipeline already resolved to -- trivy `v0.70.0` from the action definition at its pinned SHA, syft `v1.16.0` read from the rehearsal run's own log. Determinism changes; findings and SBOM contents do not. Moving either scanner forward is a separate decision that can turn a gate red, and is deliberately not made here.

A guard (`tests/security/test_scanner_version_pinned.py`) fails when an invocation names no build, when two passes of the same scanner name different builds, and when a scanner is called directly from a script or Dockerfile where the repository states no version at all.

Found by running the guard against this tree:

- `download-syft` named no syft build in `build.yml`, `gate3-rehearsal.yml` and `supply-chain.yml`. The SBOM feeding gate 3's signature was generated by a floating release.
- The guard itself read an error message -- `... is absent or empty; syft produced no SBOM` -- as an invocation, because `;` separates commands in shell and punctuates sentences inside strings. Quoted spans are now blanked before matching.

The matcher's behaviour is pinned by a 17-case self-test covering `RUN` and flagged-`RUN` forms, a privilege wrapper, pipelines and substitution, against negatives for installing the tool, naming it in a flag value, naming it in either comment form, and a separator inside quotes -- with an unquoted control beside it so the distinction is measured in both directions. Removing the command-prefix set reddens four cases; the next widening cannot drop a form in silence.

Pre-existing and untouched: two `SC2016` shellcheck notes in `supply-chain.yml`, present identically on `next/v1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Pinned Syft and Trivy scanner versions for consistent software composition and vulnerability scanning.
  * Added validation to detect missing, inconsistent, or unpinned scanner versions across security workflows and build files.

* **Tests**
  * Added automated checks covering scanner version declarations and direct scanner invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->