### PR TITLE
ci(security): make the semgrep and trivy gates non-blocking, temporarily

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -172,6 +172,9 @@ jobs:
 
   sast-semgrep:
     name: SAST — semgrep
+    # Temporarily non-blocking by owner direction 2026-08-01. Remove this flag and
+    # the line below to restore the gate; the job still runs and still reports.
+    continue-on-error: true
     runs-on: ubuntu-latest
     container:
       # Org renamed from `returntocorp/semgrep` to `semgrep/semgrep`. Same
@@ -230,6 +233,9 @@ jobs:
 
   sca-trivy-fs:
     name: SCA — trivy (filesystem)
+    # Temporarily non-blocking by owner direction 2026-08-01. Remove this flag and
+    # the line below to restore the gate; the job still runs and still reports.
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4


### PR DESCRIPTION
Temporary, by owner direction: the semgrep and trivy gates stop failing pull requests.

## What changed

One line per job in `.github/workflows/security.yml`, plus a two-line comment above each:

| Job key | Reports as (branch-protection context) | Runs |
|---|---|---|
| `sast-semgrep` | `SAST — semgrep` | `semgrep --test --config .semgrep/`, then `semgrep ci` |
| `sca-trivy-fs` | `SCA — trivy (filesystem)` | two `aquasecurity/trivy-action` filesystem scans (CRITICAL blocking, HIGH informational) + SARIF uploads |

Both jobs keep their triggers, steps, severity thresholds and SARIF uploads. They still run on every pull request, on push to `main` and `next/v1`, and on the nightly schedule, and every finding still appears in the run log and in code scanning. They just no longer turn the pull request red.

## Assurance impact

This lowers assurance. While the flag is in place, the CLAUDE.md gate "SAST/SCA CRITICAL blocks merge" is not enforced: a CRITICAL semgrep finding or a CRITICAL dependency CVE can merge into `next/v1` without a red required check. Reverting is one flag and its comment per job.

If branch protection lists either context as a required check, the check will now report success rather than failure; the context names above are byte-exact for that configuration.

## Not changed

- No job, step, or trigger removed.
- `.github/security-exceptions.yml` untouched; no `.trivyignore` exists in this repo.
- Severity thresholds untouched (`severity: CRITICAL` / `exit-code: "1"` on the blocking trivy pass, `SEMGREP_SUPPRESS_ERRORS: "false"` on semgrep) — the scanners still detect and report at the same level.

## Jobs deliberately left alone

- `secrets — gitleaks`, `secrets — trufflehog`, `IaC — checkov`, `commits — conventional-commits`, `release — pipeline integrity (signing order, cross-job wiring)` — not semgrep, not trivy.
- `Analyze` in `codeql.yml` — CodeQL is a different SAST engine and was not in scope of the direction.
- `SBOM + sign + attest (...)` in `supply-chain.yml`, `sign` in `build.yml`, `release — gate 3 rehearsal (nothing published)` in `gate3-rehearsal.yml` — these run syft/cosign for SBOM and signing, not a vulnerability scan. Trivy appears in `supply-chain.yml` only inside a comment naming an ADR row.

## Validation

- All eleven workflow files parse as YAML; only the two intended jobs carry `continue-on-error`.
- `actionlint .github/workflows/security.yml` exits `0`.
- `actionlint` over the whole workflow directory exits `1` both before and after this change, with byte-identical diagnostics (pre-existing shellcheck `info`/`style` notes in `helm.yml`, `release-chart.yml`, `release.yml`, `supply-chain.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144JnqqdqnJ3JdsbNA84uXC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Security scanning jobs now continue running and report findings without failing the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->