### PR TITLE
fix(openwebui): give the chat download link its scope segment

### DIFF
--- a/openwebui/functions/computer_link_filter.py
+++ b/openwebui/functions/computer_link_filter.py
@@ -119,6 +119,16 @@ OPENWEBUI_TEMPLATE_VARS = [
 # Pattern: {{ VAR }} or {{VAR}} (with/without spaces, Jinja2-style)
 TEMPLATE_PATTERN = r"^.*\{\{\s*(?:" + "|".join(OPENWEBUI_TEMPLATE_VARS) + r")\s*\}\}.*$"
 
+# File-download marker the model emits per the <sharing_files> prompt block
+# (#191, ADR-0034): [[ocu-download:report.docx]]. outlet() rewrites each into a
+# markdown download link. The capture excludes "]" (so a markdown label built
+# from it cannot be broken) and newlines (a marker is a single-line token), and
+# is length-bounded to a filename. The quantifier is {0,255} so an EMPTY marker
+# [[ocu-download:]] still matches and is caught by the fail-closed validation
+# in _replace_marker (empty name -> plain text) rather than leaking the literal
+# sentinel to the user; {1,255} would let the empty marker slip through unmatched.
+_DOWNLOAD_MARKER_RE = re.compile(r"\[\[ocu-download:([^\]\n]{0,255})\]\]")
+
 # Cache TTL and size (module-level so tests can patch them)
 _PROMPT_TTL_SECONDS = 300
 _PROMPT_CACHE_MAX_SIZE = 100
@@ -207,6 +217,32 @@ class Filter:
         ARCHIVE_BUTTON_TEXT: str = Field(
             default="📦 Download all files as archive",
             description="Text for the archive-download button (when ARCHIVE_BUTTON is on).",
+        )
+        DOWNLOAD_BASE_URL: str = Field(
+            default="",
+            description=(
+                "Browser-facing base of the File Pane origin that serves "
+                "/download/{scope}/{filename} (#191, ADR-0034, shape per "
+                "ADR-0035). outlet() rewrites the model's [[ocu-download:NAME]] "
+                "markers into a markdown link under this base; the model never "
+                "authors the base. Trailing slash tolerated. Empty -> markers "
+                "degrade to the bare filename as plain text (broken links are "
+                "worse than no links)."
+            ),
+        )
+        DOWNLOAD_SCOPE: str = Field(
+            default="",
+            description=(
+                "The storage scope handle that becomes the {scope} path segment "
+                "of a download link. It must equal the filesystem_id claim the "
+                "pane's own session carries -- the download route rejects a "
+                "mismatch with 401, and the value the pane holds is the one the "
+                "portal minted into the embed token, not one this filter can "
+                "derive. init.sh seeds it from OCU_FILESYSTEM_ID, the same base "
+                "the tool sends on X-OCU-Filesystem-Id. Empty -> markers degrade "
+                "to the bare filename, because a one-segment path is not a route "
+                "the pane serves."
+            ),
         )
 
     def __init__(self):
@@ -385,74 +421,70 @@ class Filter:
         __user__: Optional[dict] = None,
         __metadata__: Optional[dict] = None,
     ) -> dict:
-        """Append preview button and/or archive button to assistant messages with file links.
+        """Rewrite [[ocu-download:NAME]] markers into download links (#191, ADR-0034).
 
-        - PREVIEW_MODE="button" (default): markdown link to the preview page. The
-          frontend fix_preview_url_detection patch rewrites this URL into an inline
-          artifact; stock Open WebUI leaves it as a plain clickable link.
-        - PREVIEW_MODE="off":      no preview link.
-        - ARCHIVE_BUTTON="on" (default): markdown link to the archive endpoint (only when files exist).
+        The model, per the <sharing_files> system-prompt block, emits a marker
+        [[ocu-download:report.docx]] naming a file it saved. This turns each valid
+        marker into a markdown link to
+        DOWNLOAD_BASE_URL/download/{scope}/{urlencoded-name} — a top-level
+        first-party link that opens under the user's existing pane session (the
+        /download route authorizes on the same attested cookie the File Pane
+        established). The URL carries a SELECTOR (filename) and zero authority;
+        the model contributes only the name, this filter contributes the base and
+        the scope (a model-authored base would be a prompt-injection vector).
 
-        The public URL used in browser-facing links comes from the cached
-        X-Public-Base-URL response header captured by inlet()/_fetch_system_prompt().
-        If no cache entry exists (outlet without prior inlet, e.g. re-render of an
-        old message after server restart), decoration is skipped — broken links are
-        worse than no links.
+        The {scope} segment is load-bearing, not decoration: the route is
+        /download/{scope}/{filename} and its parser returns null for anything
+        else, the retired one-segment form included (ADR-0035). A link without it
+        is a 404, which is how this filter shipped -- a marker the model emitted
+        correctly, rewritten into a link that could never resolve. The value must
+        equal the filesystem_id claim on the pane's session, so it comes from the
+        DOWNLOAD_SCOPE valve (seeded from the same OCU_FILESYSTEM_ID the portal
+        mints into the embed token) and never from anything the model wrote.
+
+        Security (Fable-ruled): the marker is the same decision as
+        _content_has_browser_tool — a defined sentinel, never a scan of free prose,
+        so a filename mentioned in passing does NOT mint a link. Per-capture
+        validation is fail-closed (a traversal/separator/empty name drops the
+        marker to plain text, no link). urllib.parse.quote(safe="") encodes spaces
+        AND parens so the URL cannot break out of the markdown link syntax.
 
         Invariants:
-        1. Only role=="assistant" messages are touched.
+        1. Only role=="assistant" messages are touched (a user-authored marker is
+           left intact — the mint is scoped to assistant output).
         2. Non-string content is skipped.
-        3. file_url_pattern is scoped to the current chat_id (no cross-chat decoration).
-        4. public_url is rstripped before URL construction (no //preview/ or //files/).
-        5. Substring-based idempotency — repeated outlet() calls do not duplicate.
+        3. The base is outlet-owned; the model never authors it.
+        4. Idempotent: the marker is consumed on the first pass, so a re-render is
+           the identity transform.
+        5. Base-unavailable OR scope-unavailable (empty valve) -> the marker
+           degrades to the bare filename as plain text. Both are the same
+           judgement: a link missing either part cannot resolve, and a broken
+           link is worse than no link.
         """
-        wants_button = self.valves.PREVIEW_MODE == "button"
-        wants_archive = self.valves.ARCHIVE_BUTTON == "on"
+        base = self.valves.DOWNLOAD_BASE_URL.rstrip("/")
+        scope = self.valves.DOWNLOAD_SCOPE.strip().strip("/")
 
-        if not (wants_button or wants_archive):
-            return body
-
-        chat_id = __metadata__.get("chat_id") if __metadata__ else None
-        if not chat_id:
-            return body
-
-        # Pull the public URL from cache (populated by inlet() via the server's
-        # X-Public-Base-URL header). outlet() may run on re-renders where
-        # __user__ isn't passed, so the email-keyed cache entry inlet() wrote
-        # isn't directly reachable. Probe the exact (chat_id, user_email) and
-        # (chat_id, "") keys first, then fall back to ANY same-chat entry —
-        # outlet only needs public_url, not the prompt, so borrowing a URL
-        # from a different user's entry for the same chat is safe (public_url
-        # is chat-independent — it comes from the server's PUBLIC_BASE_URL env).
-        user_email = __user__.get("email", "") if __user__ else ""
-        cached = self._prompt_cache.get((chat_id, user_email)) or self._prompt_cache.get(
-            (chat_id, "")
-        )
-        if not cached:
-            for (cached_chat_id, _), entry in self._prompt_cache.items():
-                if cached_chat_id == chat_id:
-                    cached = entry
-                    break
-        if not cached:
-            # Cold-cache fallback: an Open WebUI restart wipes self._prompt_cache,
-            # and a re-render of an old assistant message can hit outlet() without
-            # inlet() running first (no new user message → no inlet pass). Rather
-            # than silently dropping preview/archive buttons, re-fetch from the
-            # orchestrator. This re-uses _fetch_system_prompt's own stale-cache
-            # fallback and url-scheme validation. Still respects the "broken links
-            # are worse than no links" invariant: if the server is unreachable AND
-            # we have no stale entry, _fetch_system_prompt returns None and we
-            # skip decoration.
-            cached_pair = self._fetch_system_prompt(chat_id, user_email)
-            if not cached_pair:
-                return body
-            public_url, _prompt = cached_pair
-        else:
-            public_url, _prompt = cached[1]
-        base = public_url.rstrip("/")
-        file_url_pattern = re.escape(base) + r"/files/" + re.escape(chat_id) + r"/[^\s\)]+"
-        preview_url = f"{base}/preview/{chat_id}"
-        archive_url = f"{base}/files/{chat_id}/archive"
+        def _replace_marker(match: "re.Match[str]") -> str:
+            name = match.group(1).strip()
+            # Fail-closed basename validation: no separators, traversal, or empty.
+            if (
+                not name
+                or "/" in name
+                or "\\" in name
+                or "\x00" in name
+                or name in (".", "..")
+            ):
+                return name  # drop the marker to plain text, no link
+            if not base or not scope:
+                return name  # incomplete link -> bare filename, never a 404
+            href = (
+                base
+                + "/download/"
+                + urllib.parse.quote(scope, safe="")
+                + "/"
+                + urllib.parse.quote(name, safe="")
+            )
+            return f"[{name}]({href})"
 
         for message in body.get("messages", []):
             if message.get("role") != "assistant":
@@ -460,28 +492,8 @@ class Filter:
             content = message.get("content")
             if not content or not isinstance(content, str):
                 continue
-
-            # Two independent triggers:
-            # 1. A file URL scoped to the current chat_id — legacy v3.2.0 path.
-            # 2. A <details type="tool_calls"> block that references a browser
-            #    tool — covers sessions that exercised playwright/chromium
-            #    without producing a downloadable file (e.g. pure navigation).
-            has_file_link = bool(re.search(file_url_pattern, content))
-            has_browser_tool = _content_has_browser_tool(content)
-            if not (has_file_link or has_browser_tool):
+            if "[[ocu-download:" not in content:
                 continue
-
-            links: list[str] = []
-            if wants_button and preview_url not in content:
-                links.append(f"[{self.valves.PREVIEW_BUTTON_TEXT}]({preview_url})")
-            # Archive download only makes sense when files actually exist for
-            # this chat — gate it on has_file_link, not on the browser-tool
-            # trigger.
-            if wants_archive and has_file_link and archive_url not in content:
-                links.append(f"[{self.valves.ARCHIVE_BUTTON_TEXT}]({archive_url})")
-            if links:
-                content += "\n\n" + "\n".join(links)
-
-            message["content"] = content
+            message["content"] = _DOWNLOAD_MARKER_RE.sub(_replace_marker, content)
 
         return body

--- a/openwebui/functions/test_computer_link_filter_download.py
+++ b/openwebui/functions/test_computer_link_filter_download.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+"""Unit tests for the outlet download-marker mint (#191, ADR-0034, item B).
+
+The outlet rewrites the model's [[ocu-download:NAME]] markers into markdown
+download links under DOWNLOAD_BASE_URL. Fable's two load-bearing assertions plus
+the role-gating and base-unavailable guards.
+
+The link SHAPE is /download/{scope}/{filename} (ADR-0035). Every assertion here
+that names a URL names both segments, because an earlier revision of this file
+pinned the one-segment form the pane retired: the tests were green, the mint was
+wrong, and the only way to notice was to fetch the minted URL. A shape this file
+pins is a shape the pane must serve, so `test_never_mints_the_retired_one_segment_form`
+states that requirement directly rather than leaving it implied by the others.
+
+Run: python3 -m pytest openwebui/functions/test_computer_link_filter_download.py -v
+"""
+
+import importlib.util
+import os
+
+import pytest
+
+_FILTER_PATH = os.path.join(os.path.dirname(__file__), "computer_link_filter.py")
+
+# The scope segment the fleet runs with: the base storage handle the portal mints
+# into the embed token, which is what the pane's session claim carries.
+_SCOPE = "fs-fleet"
+
+
+def _filter(base: str = "http://localhost:3000", scope: str = _SCOPE):
+    spec = importlib.util.spec_from_file_location("clf_download", _FILTER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    f = mod.Filter()
+    f.valves.DOWNLOAD_BASE_URL = base
+    f.valves.DOWNLOAD_SCOPE = scope
+    return f
+
+
+def _assistant(content: str) -> dict:
+    return {"messages": [{"role": "assistant", "content": content}]}
+
+
+def test_exact_mint_roundtrip_and_idempotence():
+    """A1: the marker mints an outlet-based link with parens+spaces encoded, and
+    a second outlet pass is the identity (marker consumed)."""
+    f = _filter()
+    out = f.outlet(_assistant("Saved it.\n[[ocu-download:q1 report(final).docx]]"))
+    c = out["messages"][0]["content"]
+    assert (
+        "[q1 report(final).docx](http://localhost:3000/download/fs-fleet/"
+        "q1%20report%28final%29.docx)"
+    ) in c, c
+    assert "[[ocu-download:" not in c
+    # idempotent: re-render does not double-decorate
+    out2 = f.outlet(_assistant(c))
+    assert out2["messages"][0]["content"] == c
+
+
+def test_never_mints_the_retired_one_segment_form():
+    """The shape is the whole point: /download/{scope}/{filename}.
+
+    parseDownloadPath in the pane returns null for anything else, the retired
+    /download/{filename} form included, so a one-segment link is a 404 and the
+    file never reaches the user. This asserts the scope segment is PRESENT and
+    sits between the prefix and the name -- not merely that some scope string
+    appears somewhere in the URL, which a link ending
+    .../download/report.docx?scope=fs-fleet would also satisfy.
+    """
+    f = _filter()
+    out = f.outlet(_assistant("[[ocu-download:report.docx]]"))
+    c = out["messages"][0]["content"]
+    assert "/download/fs-fleet/report.docx" in c, c
+    assert "/download/report.docx" not in c, f"retired one-segment form minted: {c!r}"
+
+
+def test_scope_is_percent_encoded_like_the_name():
+    """Both segments are selectors the filter writes, so both are encoded.
+
+    An unencoded handle carrying a slash would silently add a path segment and
+    change which route matches; one carrying a space would break the markdown
+    link. The pane decodes each segment exactly once on the raw-pathname side.
+    """
+    f = _filter(scope="fs fleet/x")
+    out = f.outlet(_assistant("[[ocu-download:report.docx]]"))
+    c = out["messages"][0]["content"]
+    assert "/download/fs%20fleet%2Fx/report.docx" in c, c
+
+
+def test_failclosed_traversal_and_never_scrapes_prose():
+    """A2: traversal/separator markers drop to no-link, and a filename mentioned
+    in prose is NEVER turned into a link (the marker is the only trigger)."""
+    f = _filter()
+    out = f.outlet(
+        _assistant(
+            "unlike report.docx which failed\n"
+            "[[ocu-download:../../etc/passwd]]\n"
+            "[[ocu-download:a/b.txt]]"
+        )
+    )
+    c = out["messages"][0]["content"]
+    assert "/download/" not in c, c
+    assert "[[ocu-download:" not in c
+    assert "](http" not in c  # prose report.docx not linked
+    assert "unlike report.docx which failed" in c  # prose byte-preserved
+
+
+def test_empty_marker_is_consumed_not_left_literal():
+    """A2b: an EMPTY marker [[ocu-download:]] must be consumed (no link, no literal
+    sentinel), not left in the chat as raw text. Regression: the regex quantifier
+    was {1,255}, so the empty marker never matched and leaked the literal sentinel
+    to the user -- a parity-breaking artifact. {0,255} makes it match, and the
+    fail-closed empty-name branch drops it to plain (empty) text."""
+    f = _filter()
+    out = f.outlet(_assistant("here is your file [[ocu-download:]] enjoy"))
+    c = out["messages"][0]["content"]
+    assert "[[ocu-download:" not in c, f"empty marker leaked as literal: {c!r}"
+    assert "/download/" not in c, f"empty marker must not mint a link: {c!r}"
+    # the surrounding prose survives
+    assert "here is your file" in c and "enjoy" in c
+
+
+def test_user_role_marker_untouched():
+    """A3: a marker in a user-role message is not minted (assistant-scoped)."""
+    f = _filter()
+    body = {"messages": [{"role": "user", "content": "[[ocu-download:report.docx]]"}]}
+    out = f.outlet(body)
+    assert out["messages"][0]["content"] == "[[ocu-download:report.docx]]"
+
+
+def test_base_unavailable_degrades_to_bare_filename():
+    """A4: with no configured base, the marker degrades to the bare filename as
+    plain text (broken links are worse than no links)."""
+    f = _filter(base="")
+    out = f.outlet(_assistant("[[ocu-download:report.docx]]"))
+    assert out["messages"][0]["content"] == "report.docx"
+
+
+def test_scope_unavailable_degrades_to_bare_filename():
+    """The same judgement as an absent base, for the same reason.
+
+    An unset scope cannot be defaulted to a guess: the route compares the path
+    scope against the session's signed claim and answers 401 on a mismatch, so a
+    wrong handle is not a degraded link but an unauthorized one. Emitting the
+    name as plain text says truthfully that the file is in the panel.
+    """
+    f = _filter(scope="")
+    out = f.outlet(_assistant("[[ocu-download:report.docx]]"))
+    assert out["messages"][0]["content"] == "report.docx"
+
+
+def test_outlet_has_no_session_access():
+    """Fable's outlet-has-no-session guard: the mint is a pure function of the
+    message text + the static base valve. It makes no HTTP/list/content/cookie
+    call. We assert it works with NO __user__ and NO __metadata__ (no session
+    context available at all) — proving the mint never touches the attested
+    plane and cannot regress into a server-side list-and-match."""
+    f = _filter()
+    out = f.outlet(_assistant("[[ocu-download:report.docx]]"), __user__=None, __metadata__=None)
+    c = out["messages"][0]["content"]
+    assert "[report.docx](http://localhost:3000/download/fs-fleet/report.docx)" in c
+
+
+def test_multiple_markers_all_minted():
+    """Replace-all: every valid marker in a message is minted independently."""
+    f = _filter()
+    out = f.outlet(
+        _assistant("[[ocu-download:a.txt]] and [[ocu-download:b.pdf]]")
+    )
+    c = out["messages"][0]["content"]
+    assert "[a.txt](http://localhost:3000/download/fs-fleet/a.txt)" in c
+    assert "[b.pdf](http://localhost:3000/download/fs-fleet/b.pdf)" in c
+    assert "[[ocu-download:" not in c

--- a/openwebui/init.sh
+++ b/openwebui/init.sh
@@ -31,6 +31,21 @@ ADMIN_NAME="${ADMIN_NAME:-Admin}"
 # PUBLIC_BASE_URL env var and is delivered to the filter via response header.
 ORCHESTRATOR_URL="${ORCHESTRATOR_URL:-http://computer-use-server:8081}"
 MCP_API_KEY="${MCP_API_KEY:-}"
+# OCU_FILESYSTEM_ID: the BASE attested storage scope chat attachments are written
+# under (X-OCU-Filesystem-Id). Compose-driven so the deploy pins one base; with
+# control's -derive-chat-scope on, the tool resolves a per-chat "<base>-<hex>"
+# scope from the status verb and writes under that, keeping the base available.
+# Seeded into the Tool Valve so the base is not a dead code-default (D5).
+OCU_FILESYSTEM_ID="${OCU_FILESYSTEM_ID:-fs-fleet}"
+# OCU_DOWNLOAD_BASE_URL: browser-facing base of the File Pane origin that serves
+# /download/{scope}/{filename} (#191, ADR-0034, shape per ADR-0035). The filter's
+# outlet rewrites the model's [[ocu-download:NAME]] markers into a link under this
+# base; the download authorizes on the same attested pane session (SSO), so this
+# must be the SAME origin the pane is embedded under - a different spelling of the
+# same address (127.0.0.1 vs localhost) is a different cookie jar and answers 401.
+# On the stand the pane is on :3000; a real deploy sets the customer pane origin.
+# Empty -> markers degrade to the bare filename (broken links are worse than none).
+OCU_DOWNLOAD_BASE_URL="${OCU_DOWNLOAD_BASE_URL:-http://localhost:3000}"
 MARKER_FILE="/app/backend/data/.computer-use-initialized"
 
 # Sanity checks — run EVERY start (before marker-gate), so stale-default
@@ -167,15 +182,21 @@ else
 fi
 
 # Configure filter valves. ORCHESTRATOR_URL is the internal URL used for
-# server→server fetch of /system-prompt. The public URL (for browser-facing
-# iframe/archive links) lives only on the server as PUBLIC_BASE_URL env and is
-# returned to the filter via the X-Public-Base-URL response header — no Valve
-# for it here.
+# server→server fetch of /system-prompt. In next/v1 there is no orchestrator
+# prompt service (#191, ADR-0034): the system prompt is config-baked into
+# DEFAULT_MODEL_PARAMS.system (below), so INJECT_SYSTEM_PROMPT is false — the
+# dead fetch stays off. DOWNLOAD_BASE_URL is the browser-facing pane base the
+# outlet mints [[ocu-download:NAME]] markers into, and DOWNLOAD_SCOPE is the
+# {scope} segment of that link: the pane serves /download/{scope}/{filename} and
+# binds the path scope against the session's filesystem_id claim, so the value
+# here is the SAME OCU_FILESYSTEM_ID the portal mints into the embed token.
+# ARCHIVE_BUTTON is off (the legacy archive link used the retired capability-URL
+# cache).
 echo "[init] Configuring filter valves..."
 if curl -sf -X POST "$WEBUI_URL/api/v1/functions/id/computer_use_filter/valves/update" \
     -H "$AUTH" -H "Content-Type: application/json" \
-    -d "{\"ORCHESTRATOR_URL\": \"$ORCHESTRATOR_URL\", \"ARCHIVE_BUTTON\": \"on\", \"INJECT_SYSTEM_PROMPT\": true}" >/dev/null 2>&1; then
-    echo "[init] Filter valves set: ORCHESTRATOR_URL=$ORCHESTRATOR_URL"
+    -d "{\"ORCHESTRATOR_URL\": \"$ORCHESTRATOR_URL\", \"ARCHIVE_BUTTON\": \"off\", \"INJECT_SYSTEM_PROMPT\": false, \"DOWNLOAD_BASE_URL\": \"$OCU_DOWNLOAD_BASE_URL\", \"DOWNLOAD_SCOPE\": \"$OCU_FILESYSTEM_ID\"}" >/dev/null 2>&1; then
+    echo "[init] Filter valves set: ORCHESTRATOR_URL=$ORCHESTRATOR_URL DOWNLOAD_BASE_URL=$OCU_DOWNLOAD_BASE_URL DOWNLOAD_SCOPE=$OCU_FILESYSTEM_ID"
 else
     echo "[init] ERROR: Could not seed filter valves — ORCHESTRATOR_URL will fall back to the code default until the next successful init. Init will retry on next restart."
     INIT_FAILED=1


### PR DESCRIPTION
The chat download link has never resolved. The pane serves `/download/{scope}/{filename}` and `parseDownloadPath` returns null for anything else — the retired one-segment form explicitly included. The filter minted that retired form, so every download link a model produced was a 404: the marker emitted correctly, rewritten correctly, pointing at a route that does not exist.

Two things kept it invisible. The pane's download surface lived only on unmerged branches, so a deployed image served no `/download` route at all and the failure read as a missing feature rather than a wrong link. And the filter's own tests pinned the one-segment shape, so they were green while the mint was wrong. Nothing short of fetching the URL the mint produces could have caught it.

## The change

The scope arrives as a new `DOWNLOAD_SCOPE` valve, seeded by `init.sh` from the same `OCU_FILESYSTEM_ID` the portal mints into the embed token. It cannot be derived in the filter: the route compares the path scope against the session's signed `filesystem_id` claim and answers 401 on a mismatch, so a guessed handle is not a degraded link but an unauthorized one. An unset scope degrades the marker to the bare filename, the same judgement already applied to an unset base.

`init.sh` also grows the two variables it never defined on this branch (`OCU_FILESYSTEM_ID`, `OCU_DOWNLOAD_BASE_URL`). The base must be the same origin the pane is embedded under — `localhost` and `127.0.0.1` are different cookie jars, and the download route needs the session cookie set on that origin.

## Tests

The existing file pinned the retired shape. Every URL assertion now names both segments, and `test_never_mints_the_retired_one_segment_form` states the requirement directly instead of leaving it implied — it asserts the scope sits *between* prefix and name, which a `.../download/report.docx?scope=fs-fleet` shape would not satisfy. Two new arms cover scope percent-encoding and the scope-unavailable degrade.

Red-probe: remove the scope segment from the href and 5 of 10 fail, including the dedicated regression test by name. The five fail-closed arms (traversal, empty marker, user-role, base-unavailable, scope-unavailable) do not depend on the shape and stay green — so the probe is not reddening everything indiscriminately.

## Verified live

On the stand, with the pane rebuilt from the branch carrying the download surface: a chat asking for a file produced `http://localhost:3000/download/fs-fleet/poem.txt`, and clicking it downloaded the 301 bytes the agent had written. Controls on the same session: the retired one-segment path answers 401, and a foreign scope answers 401.

## Not in this PR

The pane half is `Wide-Moat/ocu-webui#60` — this filter is inert without it.

The fleet compose pin for `OCU_DOWNLOAD_BASE_URL` could not come along: `deploy/` does not exist on `next/v1` at all. It stays on the main line where the file lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Download markers in assistant messages are now converted into secure, scoped download links.
  - Download filenames are URL-encoded and support multiple files in a single message.
  - Links use configurable browser-facing download settings.

- **Bug Fixes**
  - Invalid, unsafe, or unavailable download configurations now fall back gracefully to plain filenames.
  - Download markers are processed only in assistant messages, preserving surrounding text.
  - Repeated processing no longer alters existing download links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->