### PR TITLE
docs(adr): ADR-0031 guest write-back delay bounded by the teardown window

### DIFF
--- a/contracts/storage/mount-config.schema.json
+++ b/contracts/storage/mount-config.schema.json
@@ -49,6 +49,13 @@
       "examples": ["1G", "512M"]
     },
 
+    "WriteBackDelay": {
+      "description": "How long the guest VFS holds a dirty file before writing it back. Bounded from above by the guest teardown window: whatever is still queued when a session is torn down is discarded, so a delay at or above that window loses the most recent write of every session.",
+      "type": "string",
+      "pattern": "^[0-9]+(\\.[0-9]+)?(ms|s|m|h)$",
+      "examples": ["500ms", "1s"]
+    },
+
     "VfsCacheMode": {
       "description": "Page-cache policy for the mount.",
       "type": "string",
@@ -97,6 +104,7 @@
           "type": "boolean"
         },
         "vfs_cache_mode": { "$ref": "#/$defs/VfsCacheMode" },
+        "vfs_write_back": { "$ref": "#/$defs/WriteBackDelay" },
         "cache_duration_s": { "$ref": "#/$defs/CacheDurationSeconds" },
         "vfs_cache_max_size": {
           "description": "Local VFS cache cap per mount. Files over the cap stream rather than cache.",

--- a/docs/architecture/adr/0031-guest-write-back-delay-bounded-by-teardown.md
+++ b/docs/architecture/adr/0031-guest-write-back-delay-bounded-by-teardown.md
@@ -1,0 +1,97 @@
+<!-- SPDX-License-Identifier: FSL-1.1-Apache-2.0 -->
+<!-- Copyright (c) 2025 Open Computer Use Contributors -->
+
+---
+status: proposed
+last-reviewed: 2026-08-05
+owner: "@Wide-Moat/architects"
+applies-to: next/v1
+supersedes: []
+superseded-by: null
+amends: []
+compliance-impact: []
+license-impact: none
+threat-mitigation-link: ../06-threat-model.md
+---
+
+# ADR-0031: Guest write-back delay bounded by the teardown window
+
+## Status
+
+Proposed.
+
+## Context
+
+A storage-scoped session mounts its filesystems inside the guest through a mount
+process the guest agent starts as a boot-child. The mount holds a written file in
+its local cache for a delay before writing it back to the broker. The delay is a
+throughput choice: longer batches more, shorter uploads sooner.
+
+Session teardown bounds that delay from above. The guest agent forwards SIGTERM to
+its boot-child and then stops waiting for it after a fixed window, roughly two
+seconds, which no host-side stop grace extends — the cap belongs to the agent. A
+boot-child that drains inside the window exits cleanly; one that needs longer is
+killed part-way through, and whatever the queue still held is gone. The agent
+reports success either way, so the truncation raises nothing by itself.
+
+The two values are therefore coupled, and nothing expressed the coupling. The
+mount-config contract carried no write-back field at all, while the guest mount
+implementation accepted one — so the delay every deployment ran on was the mount
+implementation's own default, which exceeds the teardown window. The result is that
+the most recently written file of a session does not reach storage when that session
+is released.
+
+The `Mount` object is `additionalProperties: false`, so the absent field was not an
+omission a producer could route around: no component could send the value, and the
+CI identity gate that pins each vendored copy to this contract kept it that way.
+
+## Decision
+
+The mount-config contract carries `vfs_write_back` as an OPTIONAL per-mount string.
+
+A producer that sets it MUST choose a value below the guest teardown window, so a
+file closed immediately before a release still has room to upload. A producer that
+omits the key leaves the guest on its own default and accepts that a write made
+close to release may not survive it.
+
+The key stays outside `required`. A config that omits it is valid and renders
+exactly as it did before the field existed, which is what lets each component adopt
+the field independently of the others.
+
+Zero is not a legal value. An object store is asynchronous by construction, and the
+guest mount refuses a non-positive delay outright — emitting one stops the mount
+coming up rather than merely flushing late, so producers validate positivity before
+the value leaves the host.
+
+## Consequences
+
+Storage-scoped sessions lose less on release, bounded by how long an upload takes
+rather than by how long the queue waits before starting one.
+
+Write-back runs more often per session. The trade is deliberate: a sandbox session
+writes few files, and losing the last one is worse than uploading it twice as
+eagerly.
+
+The bound is a cross-component invariant with no compile-time enforcement. The guest
+teardown window lives outside this repository, so a producer's value can only be
+justified against a measured window, and a change to either side has to re-measure
+the other.
+
+Read-after-write across contexts becomes visible sooner, since the same delay
+governs when a written file appears to a reader that does not share the writer's
+cache.
+
+## Alternatives
+
+Drain and wait at teardown, host-side: the session driver would signal the mount and
+block until it finished before stopping the container. This is a guarantee rather
+than a shrunken race, and it is rejected here only because the driver's substrate
+surface is deliberately narrow and reaching into a running guest widens it. It
+remains the stronger option if the narrow surface is ever revisited.
+
+Widen the teardown window: not available. The window belongs to the guest agent and
+is not configurable through any interface it exposes.
+
+Leave the delay at the guest default and treat the loss as accepted behaviour: this
+is the status quo, and it is rejected because the loss is silent — no error, no
+non-zero exit, nothing an operator can alert on.


### PR DESCRIPTION
## What is broken

The mount-config contract carries no write-back field, while the guest mount implementation accepts one. Its `Mount` object is `additionalProperties: false`, so this is not an omission a producer could route around — no component may send the value, and the vendored-copy identity gate in each consumer repo keeps it that way. Every deployment therefore runs on the mount implementation's own default.

That default exceeds the window a session actually gets. The guest agent forwards SIGTERM to its mount boot-child and then stops waiting for it:

| boot-child drain | receives SIGTERM | finishes draining | container stop took |
|---|---|---|---|
| 1s | yes | yes | 1100 ms |
| 2s | yes | yes | 2101 ms |
| 3s | yes | **no** | 2090 ms |
| 4s / 5s / 8s | yes | **no** | ~2080 ms |

Measured with the agent alone — no mount, no control plane, no storage — driving a boot-child that announces its own signal, stopped with a 30-second grace. The grace never binds; the cap belongs to the agent. The agent exits 0 in every row, including the ones where it killed its child part-way through, so the truncated drain raises nothing on its own.

Consequence: the most recently written file of a storage-scoped session does not reach storage when that session is released.

## What this changes

`vfs_write_back` joins the `Mount` object as an OPTIONAL string with a duration pattern, outside `required`. A config that omits it stays valid and renders exactly as before, which is what lets each component adopt the field independently.

Zero is not expressible. An object store is asynchronous by construction and the guest mount refuses a non-positive delay outright — emitting one stops the mount coming up rather than merely flushing late.

ADR-0031 records the bound and both rejected alternatives: host-side drain-and-wait at teardown (a guarantee rather than a shrunken race, rejected here only because it widens the session driver's deliberately narrow substrate surface, and named as the stronger option if that surface is revisited), and widening the teardown window (not ours to set).

## Consumer side

`Wide-Moat/ocu-control#96` carries the producer half and is a draft until this lands. Its schema hunk is byte-identical to the one here, so re-vendoring after this merges is a copy, and the contract-identity pin bump then imports only this change — the four vendored contracts are byte-identical between the current pin `099d3d7` and `next/v1`, so nothing else rides along.

## Not claimed here

That any particular value closes the loss end to end. A shorter delay makes an item eligible for write-back sooner; whether the upload then completes inside the remaining window is a race, and it has to be measured against a live stand before a producer's default is trusted. This PR makes the value expressible and records what bounds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional per-mount setting to configure the delay before guest VFS writes are committed.
  * Supports duration values in milliseconds, seconds, minutes, or hours.

* **Documentation**
  * Documented configuration requirements, including valid positive delays and teardown-window limits.
  * Clarified that omitting the setting preserves existing defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->