### PR TITLE
docs(roadmap): G1's gate half landed; the wire half is a decision

### DIFF
--- a/docs/NEXT-V1-GA-ROADMAP.md
+++ b/docs/NEXT-V1-GA-ROADMAP.md
@@ -83,7 +83,7 @@ The honest read: the platform is a strong, well-tested PoC for the minimal shelf
 ### Theme G — Frozen contracts + ratification
 | Gap | Component / ADR | What is missing | Effort |
 |---|---|---|---|
-| G1. Control frozen OpenAPI/gRPC + buf/oasdiff CI | 02, #205, NFR-IC-04 | Wire is HTTP/newline-JSON-over-UDS handlers, not the frozen operator-REST/SOAR OpenAPI 3.1 + session_setup.proto; no buf breaking / oasdiff gate. | M |
+| G1. **PARTIAL 2026-08-07 — the gate enforces; the wire is still hand-written.** | 02, #205, NFR-IC-04 | The buf/oasdiff half is done and is a required context: `rpc-version` runs `buf breaking` over `contracts/proto` and `oasdiff` over every `contracts/openapi/*.openapi.yaml`, with a red-probe riding the same job. It had been reporting a green that measured nothing — it probed `buf.yaml` at the repo root and `contracts/operator/openapi.yaml`, neither of which is where the contracts landed, so NFR-IC-04 went unenforced from the moment they were committed. The wire half stands: no generated `.pb.go` exists, and the operator transport is hand-written JSON whose structs are now bound to the frozen `session_setup.proto` by a field-parity test rather than by a doc comment. Remaining work: generate from the contract, or keep the hand-written wire and accept the parity test as the binding — an open call, not unbuilt code. | S (decision) then M (code) |
 | G2. ADR ratification (proposed→accepted) | all ADRs | Egress cluster (0005/6/7/8/11/16/19/21) + storage (0010/0013/0015/0029/0030) + sandbox (0003/0017/0018) + 0002/0009/0012 all `proposed`. Owner batch sign-off + write-down reconciliations. | S–M (per cluster) |
 
 ### Theme H — Image provisioning (ADR-0020, the one genuine open decision)


### PR DESCRIPTION
## What

Rewrites the **G1** row: its gate half landed, its wire half is a decision rather than missing code.

## The gate half — done, and it had been lying

The row read *"no buf breaking / oasdiff gate"*. There was one, wired as a **required context** — and it had been reporting a green that measured nothing.

It probed `buf.yaml` at the repo root and `contracts/operator/openapi.yaml`. The contracts landed at `contracts/proto/buf.yaml` and `contracts/openapi/*.openapi.yaml`, so detection never matched and every run printed *"no operator proto/OpenAPI wire surface present yet"* before exiting 0.

**NFR-IC-04 was unenforced from the moment those contracts were committed**, under a check whose own notice said there was nothing to check. Fixed in ocu-control#102, with a red-probe on the same job so the enforcement is proven rather than assumed.

## The wire half — verified, not generated

No `.pb.go` exists; the operator transport is hand-written JSON. Its structs previously carried doc comments *claiming* they followed the frozen `session_setup.proto`, with nothing checking that. ocu-control#103 binds them by a field-parity test in both directions.

## What remains is a call

Generate the wire from the contract, or keep the hand-written wire with the parity test as the binding. The row now says that, rather than describing the state as unbuilt — the distinction matters because "unbuilt" invites someone to start coding when the blocking step is a decision.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnjoUdMzCzQpqc3gKZchNd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the v1 GA roadmap to reflect that the buf/oasdiff CI contract gate is implemented and required.
  * Clarified that the operator wire remains hand-written JSON, with corrected contract paths and field-parity testing documented.
  * Added the remaining decision regarding generated code versus retaining the current hand-written wire.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->