### PR TITLE
docs: keep chat.yambr.com only, add transformation notice

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -33,4 +33,4 @@ https://github.com/Wide-Moat/open-computer-use in any copies or
 substantial portions of the Licensed Work.
 
 For licensing inquiries (e.g. permission to operate a competing hosted
-service), contact https://t.me/yambrcom.
+service), contact developer@widemoat.ai.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ MCP server that gives any LLM its own computer — managed Docker workspaces wit
 
 > **Online demo:** **[chat.yambr.com](https://chat.yambr.com)** — Open WebUI with Computer Use already set up, sign in with GitHub or Google. ([More ways to try it](#ways-to-try-it) below.)
 >
-> **Transformation in progress:** the project is being reorganised. The managed dashboard, the hosted MCP endpoint and the cloud docs are offline and their links have been removed from this repository. `chat.yambr.com` stays up and may be interrupted while the move is in progress.
+> **Transformation in progress:** the project is being reorganised. The managed dashboard, the hosted MCP endpoint and the hosted docs site are offline and their links have been removed from this repository. `chat.yambr.com` stays up and may be interrupted while the move is in progress.
 >
 > If any of this looks useful, a ⭐ on the repo really helps — thanks!
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ MCP server that gives any LLM its own computer — managed Docker workspaces wit
 
 > **Online demo:** **[chat.yambr.com](https://chat.yambr.com)** — Open WebUI with Computer Use already set up, sign in with GitHub or Google. ([More ways to try it](#ways-to-try-it) below.)
 >
-> **See it in action:** **[Demo course on docs.yambr.com](https://docs.yambr.com/demo-course)** — eight live scenarios captured from the chat above (pitch deck, Word doc, Excel, PDF invoice, data chart, live-rendered landing page, web scrape, building a custom skill). Real prompts, real screenshots, copy-pasteable.
+> **Transformation in progress:** the project is being reorganised. The managed dashboard, the hosted MCP endpoint and the cloud docs are offline and their links have been removed from this repository. `chat.yambr.com` stays up and may be interrupted while the move is in progress.
 >
 > If any of this looks useful, a ⭐ on the repo really helps — thanks!
 
@@ -77,7 +77,7 @@ Works with **any MCP-compatible client**: Open WebUI, Claude Desktop, LiteLLM, n
 
 ![Sub-Agent Dashboard](docs/screenshots/06-sub-agent-dashboard.png)
 
-For all eight live scenarios with prompts you can copy-paste, see the **[Demo course](https://docs.yambr.com/demo-course)**. See [docs/FEATURES.md](docs/FEATURES.md) for architecture details and [docs/SCREENSHOTS.md](docs/SCREENSHOTS.md) for all screenshots.
+See [docs/FEATURES.md](docs/FEATURES.md) for architecture details and [docs/SCREENSHOTS.md](docs/SCREENSHOTS.md) for all screenshots.
 
 > **Pro tip**: Create skills with Claude Code in the terminal, then use them with any model in the chat. Skills are model-agnostic — write once, use everywhere.
 
@@ -94,10 +94,9 @@ For all eight live scenarios with prompts you can copy-paste, see the **[Demo co
 | Path | URL | What you need | Best for |
 |------|-----|---------------|----------|
 | **Free online demo** — Open WebUI + Computer Use, models included | **[chat.yambr.com](https://chat.yambr.com)** | GitHub or Google sign-in | Trying it end-to-end in 30 seconds |
-| **Hosted MCP endpoint** — tools only, bring your own LLM | Key at [app.yambr.com](https://app.yambr.com) → connect to `https://api.yambr.com/mcp/computer_use` | GitHub/Google sign-in; your own OpenAI / Anthropic / OpenRouter key | Plugging Computer Use into Claude Desktop, n8n, OpenAI Agents SDK |
 | **Self-host** | [Quick Start](#quick-start) below | Docker, ~15 min first build | Full control, air-gapped, heavy use |
 
-OAuth only — no email/password, no SMS. On `chat.yambr.com` models are bundled as a free convenience; the hosted API is tools-only. Canonical cloud docs: [docs.yambr.com](https://docs.yambr.com). Repo-side orientation: [docs/CLOUD.md](docs/CLOUD.md).
+OAuth only — no email/password, no SMS. On `chat.yambr.com` models are bundled as a free convenience. The hosted MCP endpoint is offline during the transformation; see [docs/CLOUD.md](docs/CLOUD.md).
 
 ## Quick Start
 
@@ -172,9 +171,8 @@ See [docs/SKILLS.md](docs/SKILLS.md) for details.
 
 ## MCP Integration
 
-The server speaks standard MCP over Streamable HTTP. Point any MCP client at it — hosted or self-hosted.
+The server speaks standard MCP over Streamable HTTP. Point any MCP client at your own deployment.
 
-- **Hosted**: `https://api.yambr.com/mcp/computer_use` with `Authorization: Bearer <key from app.yambr.com>`. Client configs and full reference live on [docs.yambr.com](https://docs.yambr.com).
 - **Self-hosted**: `http://localhost:8081/mcp`. Quick sanity check:
   ```bash
   curl -X POST http://localhost:8081/mcp \
@@ -215,13 +213,13 @@ By default, all 13 built-in skills are available to everyone. For per-user skill
 
 The Computer Use Server speaks standard **MCP over Streamable HTTP** — any MCP-compatible client can connect. Open WebUI is the primary tested frontend, but not the only option.
 
-| Client | Self-hosted URL | Hosted URL | Status |
-|--------|-----------------|------------|--------|
-| [**Open WebUI**](https://github.com/open-webui/open-webui) | Docker Compose stack included, auto-configured | n/a — use [chat.yambr.com](https://chat.yambr.com) directly (pointing your own Open WebUI at the hosted API isn't a documented path) | Tested in production |
-| [**Claude Desktop**](https://claude.ai/download) | `http://localhost:8081/mcp` — see [docs/MCP.md](docs/MCP.md) | `https://api.yambr.com/mcp/computer_use` — see [docs/CLOUD.md](docs/CLOUD.md) | Works |
-| [**n8n**](https://n8n.io) | MCP Tool node → `http://computer-use-server:8081/mcp` | MCP Tool node → `https://api.yambr.com/mcp/computer_use` | Works |
-| [**LiteLLM**](https://github.com/BerriAI/litellm) | MCP proxy config — see [docs/MCP.md](docs/MCP.md) | MCP proxy → `https://api.yambr.com/mcp/computer_use` | Works |
-| **Custom client** | Any HTTP client with MCP JSON-RPC — see curl examples in [docs/MCP.md](docs/MCP.md) | Same, with `Authorization: Bearer sk-...` (key from [app.yambr.com](https://app.yambr.com)) | Works |
+| Client | Self-hosted URL | Status |
+|--------|-----------------|--------|
+| [**Open WebUI**](https://github.com/open-webui/open-webui) | Docker Compose stack included, auto-configured | Tested in production |
+| [**Claude Desktop**](https://claude.ai/download) | `http://localhost:8081/mcp` — see [docs/MCP.md](docs/MCP.md) | Works |
+| [**n8n**](https://n8n.io) | MCP Tool node → `http://computer-use-server:8081/mcp` | Works |
+| [**LiteLLM**](https://github.com/BerriAI/litellm) | MCP proxy config — see [docs/MCP.md](docs/MCP.md) | Works |
+| **Custom client** | Any HTTP client with MCP JSON-RPC — see curl examples in [docs/MCP.md](docs/MCP.md) | Works |
 
 ## Open WebUI Integration
 
@@ -476,7 +474,7 @@ We plan to address these in future releases:
 - [ ] **Secret management** — move credentials from headers to encrypted server-side storage
 - [ ] **gVisor (runsc) runtime** — optional container sandboxing for stronger isolation (like Claude.ai)
 
-Ideas? Open a [GitHub Issue](https://github.com/Wide-Moat/open-computer-use/issues). Want to contribute? See [CONTRIBUTING.md](CONTRIBUTING.md) or reach out on Telegram [@yambrcom](https://t.me/yambrcom).
+Ideas? Open a [GitHub Issue](https://github.com/Wide-Moat/open-computer-use/issues). Want to contribute? See [CONTRIBUTING.md](CONTRIBUTING.md) or email developer@widemoat.ai.
 
 ## Development
 
@@ -499,15 +497,15 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). PRs welcome!
 
 ## Community
 
-- **Managed hosting**: [yambr.com](https://yambr.com) — cloud version by the maintainers ([chat.yambr.com](https://chat.yambr.com) for the free demo, [app.yambr.com](https://app.yambr.com) for API keys, [docs.yambr.com](https://docs.yambr.com) for the cloud docs)
+- **Free online demo**: [chat.yambr.com](https://chat.yambr.com) — hosted by the maintainers
 - **Issues & Ideas**: [GitHub Issues](https://github.com/Wide-Moat/open-computer-use/issues)
-- **Telegram**: [@yambrcom](https://t.me/yambrcom)
+- **Contact**: developer@widemoat.ai
 
 ## License
 
 This project uses a multi-license model:
 
-- **Core** (`computer-use-server/`, `openwebui/`, `settings-wrapper/`, Docker configs): [Functional Source License, Version 1.1, Apache 2.0 Future License](LICENSE) (FSL-1.1-Apache-2.0). Free to use, modify, fork, redistribute, and self-host internally. Each release automatically converts to [Apache 2.0](LICENSE-APACHE) two years after publication. Offering a hosted or embedded service that competes with our paid version(s) requires a [commercial agreement](https://t.me/yambrcom).
+- **Core** (`computer-use-server/`, `openwebui/`, `settings-wrapper/`, Docker configs): [Functional Source License, Version 1.1, Apache 2.0 Future License](LICENSE) (FSL-1.1-Apache-2.0). Free to use, modify, fork, redistribute, and self-host internally. Each release automatically converts to [Apache 2.0](LICENSE-APACHE) two years after publication. Offering a hosted or embedded service that competes with our paid version(s) requires a [commercial agreement](mailto:developer@widemoat.ai).
 - **Our skills** (`skills/public/describe-image`, `skills/public/sub-agent`): [MIT](LICENSE-MIT)
 - **Third-party skills**: see individual LICENSE.txt files or original sources.
 

--- a/computer-use-server/static/docs.html
+++ b/computer-use-server/static/docs.html
@@ -95,7 +95,7 @@
         <a href="/mcp">MCP Info</a>
         <a href="/health">Health</a>
         <a href="/system-prompt">System Prompt</a>
-        <a href="https://github.com/Yambr/open-computer-use">GitHub</a>
+        <a href="https://github.com/Wide-Moat/open-computer-use">GitHub</a>
     </div>
 
     <div class="section" style="background: #e8f5e9; padding: 20px; border-radius: 8px; border: 2px solid #4CAF50;">
@@ -147,7 +147,7 @@
         <p>Pass a comma-separated list of MCP server names via the <code>X-MCP-Servers</code> header; the server writes <code>~/.mcp.json</code> inside the sandbox before launching Claude Code. Server URLs are built from <code>ANTHROPIC_BASE_URL</code>; auth reuses <code>ANTHROPIC_AUTH_TOKEN</code>.</p>
         <pre>-H "X-MCP-Servers: confluence,jira" \
 -H "X-User-Email: user@example.com"</pre>
-        <p>Full recipe: <a href="https://github.com/Yambr/open-computer-use/blob/main/docs/MCP.md">docs/MCP.md</a>.</p>
+        <p>Full recipe: <a href="https://github.com/Wide-Moat/open-computer-use/blob/main/docs/MCP.md">docs/MCP.md</a>.</p>
     </div>
 
     <div class="section">
@@ -188,16 +188,16 @@
     <div class="section">
         <h2>Documentation &amp; source</h2>
         <ul class="links">
-            <li>📖 <a href="https://github.com/Yambr/open-computer-use">Repository</a> — README, setup, architecture</li>
-            <li>🔌 <a href="https://github.com/Yambr/open-computer-use/blob/main/docs/MCP.md">docs/MCP.md</a> — MCP tools reference, external MCP servers</li>
-            <li>🔑 <a href="https://github.com/Yambr/open-computer-use/blob/main/docs/claude-code-gateway.md">docs/claude-code-gateway.md</a> — Claude Code auth inside the sandbox (Anthropic / LiteLLM / Bedrock)</li>
-            <li>🧩 <a href="https://github.com/Yambr/open-computer-use/blob/main/docs/openwebui-filter.md">docs/openwebui-filter.md</a> — Open WebUI filter &amp; tool integration</li>
-            <li>🐛 <a href="https://github.com/Yambr/open-computer-use/issues">Issues</a></li>
+            <li>📖 <a href="https://github.com/Wide-Moat/open-computer-use">Repository</a> — README, setup, architecture</li>
+            <li>🔌 <a href="https://github.com/Wide-Moat/open-computer-use/blob/main/docs/MCP.md">docs/MCP.md</a> — MCP tools reference, external MCP servers</li>
+            <li>🔑 <a href="https://github.com/Wide-Moat/open-computer-use/blob/main/docs/claude-code-gateway.md">docs/claude-code-gateway.md</a> — Claude Code auth inside the sandbox (Anthropic / LiteLLM / Bedrock)</li>
+            <li>🧩 <a href="https://github.com/Wide-Moat/open-computer-use/blob/main/docs/openwebui-filter.md">docs/openwebui-filter.md</a> — Open WebUI filter &amp; tool integration</li>
+            <li>🐛 <a href="https://github.com/Wide-Moat/open-computer-use/issues">Issues</a></li>
         </ul>
     </div>
 
     <footer style="margin-top: 40px; padding-top: 20px; border-top: 1px solid #ddd; color: #666; font-size: 14px;">
-        Computer Use Server — <a href="https://github.com/Yambr/open-computer-use" style="color: #1976d2;">github.com/Yambr/open-computer-use</a>
+        Computer Use Server — <a href="https://github.com/Wide-Moat/open-computer-use" style="color: #1976d2;">github.com/Wide-Moat/open-computer-use</a>
     </footer>
 </body>
 </html>

--- a/computer-use-server/static/preview.js
+++ b/computer-use-server/static/preview.js
@@ -822,7 +822,7 @@ function TerminalDashboard({ chatId, dangerousMode, onToggleDangerous, onStartSe
           <button class="dash-btn-secondary" onClick=${uploadFile}>
             <span class="icon-inline" dangerouslySetInnerHTML=${{ __html: icon('upload') }}></span> ${t('upload_file')}
           </button>
-          <a class="dash-link" href="https://github.com/Yambr/open-computer-use/blob/main/docs/TERMINAL-TAB.md" target="_blank">
+          <a class="dash-link" href="https://github.com/Wide-Moat/open-computer-use/blob/main/docs/TERMINAL-TAB.md" target="_blank">
             <span class="icon-inline" dangerouslySetInnerHTML=${{ __html: icon('book') }}></span> ${t('how_to_use')}
           </a>
         </div>

--- a/docs/CLOUD.md
+++ b/docs/CLOUD.md
@@ -1,29 +1,14 @@
-# Cloud (managed Yambr)
+# Cloud (managed)
 
-This page exists so GitHub visitors know a managed version exists. It is intentionally thin — the canonical cloud reference is **[docs.yambr.com](https://docs.yambr.com)** and the source of truth for keys, budgets and limits is **[app.yambr.com](https://app.yambr.com)**. If you self-host, see [INSTALL.md](INSTALL.md) instead.
+This page exists so GitHub visitors know a managed version exists. If you self-host, see [INSTALL.md](INSTALL.md) instead.
 
-## The four Yambr services
+**Transformation in progress:** the project is being reorganised. The managed dashboard, the hosted MCP endpoint and the cloud docs are offline and their links have been removed from this repository. `chat.yambr.com` stays up and may be interrupted while the move is in progress.
 
-| Service | URL | Role |
-|---------|-----|------|
-| Dashboard | [app.yambr.com](https://app.yambr.com) | Sign in (GitHub / Google), manage keys, spend |
-| MCP endpoint | `https://api.yambr.com/mcp/computer_use` | Public Streamable-HTTP MCP — tools only |
-| Hosted chat | [chat.yambr.com](https://chat.yambr.com) | Open WebUI with Computer Use pre-wired, models included |
-| Artifact host | `https://cu.yambr.com` | Sandbox file/preview URLs |
+## What is still up
 
-Yambr publishes the MCP tool endpoint; it is **not** an LLM gateway. On `api.yambr.com` you bring your own model provider. On `chat.yambr.com` models are bundled as a free convenience.
-
-## Which path?
-
-- **Just want to try it?** Open [chat.yambr.com](https://chat.yambr.com), sign in with GitHub or Google.
-- **Want to plug Computer Use into your own agent?** Get a key from [app.yambr.com](https://app.yambr.com), point your MCP client at `https://api.yambr.com/mcp/computer_use` with a `Bearer` header. Per-client configs (Claude Desktop, OpenAI Agents SDK, n8n, LiteLLM, curl) live on [docs.yambr.com](https://docs.yambr.com) under the Integrations section.
-- **Want full control / air-gap / heavy use?** See [INSTALL.md](INSTALL.md).
-
-A bare `GET https://api.yambr.com/mcp/computer_use` returns `500` — that's expected, the endpoint requires `POST` with MCP headers. Not a service outage.
+[chat.yambr.com](https://chat.yambr.com) — Open WebUI with Computer Use pre-wired, models included. Sign in with GitHub or Google; OAuth only, no email/password.
 
 ## See also
 
-- [docs.yambr.com/quickstart](https://docs.yambr.com/quickstart) — the three starting paths, with copy-paste snippets
-- [docs.yambr.com/platform/overview](https://docs.yambr.com/platform/overview) — how the four services fit together
-- [docs.yambr.com/platform/api-keys](https://docs.yambr.com/platform/api-keys) — keys, budgets, rotation
-- [MCP.md](MCP.md) — MCP protocol reference (applies to both hosted and self-hosted)
+- [INSTALL.md](INSTALL.md) — self-hosting with Docker Compose
+- [MCP.md](MCP.md) — MCP protocol reference for your own deployment

--- a/docs/CLOUD.md
+++ b/docs/CLOUD.md
@@ -2,7 +2,7 @@
 
 This page exists so GitHub visitors know a managed version exists. If you self-host, see [INSTALL.md](INSTALL.md) instead.
 
-**Transformation in progress:** the project is being reorganised. The managed dashboard, the hosted MCP endpoint and the cloud docs are offline and their links have been removed from this repository. `chat.yambr.com` stays up and may be interrupted while the move is in progress.
+**Transformation in progress:** the project is being reorganised. The managed dashboard, the hosted MCP endpoint and the hosted docs site are offline and their links have been removed from this repository. `chat.yambr.com` stays up and may be interrupted while the move is in progress.
 
 ## What is still up
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -11,7 +11,7 @@ Claude.ai and OpenAI Operator are cloud-only, not self-hosted — we drew inspir
 | Feature | Open Computer Use | [open-terminal](https://github.com/open-webui/open-terminal) | Claude.ai | OpenAI Operator |
 |---------|-------------------|---------------|-----------|-----------------|
 | **Self-hosted** | Yes | Yes | No | No |
-| **Managed SaaS option** | Yes — [yambr.com](https://yambr.com) (free demo at [chat.yambr.com](https://chat.yambr.com), hosted MCP at `api.yambr.com/mcp/computer_use`) | No | Yes (claude.ai) | Yes (operator) |
+| **Managed SaaS option** | Yes — free demo at [chat.yambr.com](https://chat.yambr.com) | No | Yes (claude.ai) | Yes (operator) |
 | **Any LLM** | Yes (OpenAI-compatible) | Any (via Open WebUI) | Claude only | GPT only |
 | **Code execution** | Full Linux sandbox | Sandbox / bare metal | Sandbox | No |
 | **Live browser** | CDP streaming (shared, interactive) | No | Screenshot-based | Screenshot-based |

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -4,19 +4,7 @@ The Computer Use Server exposes a standard [MCP (Model Context Protocol)](https:
 
 This server is published in the [MCP Registry](https://github.com/modelcontextprotocol/registry) as `io.github.Wide-Moat/open-computer-use`.
 
-## Hosted endpoint (managed)
-
-Skip the self-host deployment and point any MCP client at the managed endpoint:
-
-```
-POST https://api.yambr.com/mcp/computer_use
-Authorization: Bearer <YAMBR_API_KEY>
-X-Chat-Id: <session-id>
-```
-
-Request a key at [app.yambr.com](https://app.yambr.com) (GitHub or Google sign-in). You bring your own model provider — Yambr doesn't resell inference. Per-client configs (Claude Desktop, OpenAI Agents SDK, n8n, LiteLLM) live on [docs.yambr.com](https://docs.yambr.com); repo-side orientation in [CLOUD.md](CLOUD.md).
-
-The rest of this document covers **self-hosting** the same MCP server.
+The managed MCP endpoint is offline while the project is being reorganised — see [CLOUD.md](CLOUD.md). This document covers **self-hosting** the MCP server.
 
 ## Deployment Prerequisite
 

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -113,5 +113,5 @@
   <text x="120" y="485" font-size="9" fill="rgba(255,255,255,0.65)">9222 (CDP browser) · 7681 (ttyd terminal) — proxied through server, not exposed directly</text>
 
   <!-- Footer -->
-  <text x="450" y="512" text-anchor="middle" font-size="10" fill="#9ca3af">open-computer-use · github.com/Yambr/open-computer-use</text>
+  <text x="450" y="512" text-anchor="middle" font-size="10" fill="#9ca3af">open-computer-use · github.com/Wide-Moat/open-computer-use</text>
 </svg>

--- a/docs/sandbox-contents.svg
+++ b/docs/sandbox-contents.svg
@@ -225,5 +225,5 @@
   <text x="470" y="744" class="version">Accessed via Computer Use Server proxy (not directly)</text>
 
   <!-- Footer -->
-  <text x="450" y="798" text-anchor="middle" font-size="11" fill="#9ca3af">open-computer-use · github.com/Yambr/open-computer-use</text>
+  <text x="450" y="798" text-anchor="middle" font-size="11" fill="#9ca3af">open-computer-use · github.com/Wide-Moat/open-computer-use</text>
 </svg>


### PR DESCRIPTION
## Summary
The managed dashboard, hosted MCP endpoint, cloud docs and artifact host are offline while the project is being reorganised. Every link to `app.`/`api.`/`docs.`/`cu.yambr.com` and the `yambr.com` root is removed, so readers are no longer pointed at endpoints that will not answer. `chat.yambr.com` is the only Yambr URL left in the repository, with a short notice next to the demo callout explaining the situation.

## Changes
- **`README.md`** — the demo-course callout is replaced by the transformation notice; the *Hosted MCP endpoint* row is dropped from "Ways to try it"; the `**Hosted**:` bullet and the whole *Hosted URL* column are dropped from the MCP sections; the Community hosting bullet collapses to the free demo.
- **`docs/CLOUD.md`** — rewritten as a thin page: notice, `chat.yambr.com`, and pointers to `INSTALL.md` and `MCP.md`. The file is kept rather than deleted so the inbound relative links from `README.md`, `docs/INSTALL.md` and `docs/MCP.md` still resolve under lychee's `include_fragments = true`.
- **`docs/MCP.md`** — the hosted-endpoint section is removed; the document now covers self-hosting only.
- **`docs/COMPARISON.md`**, **`NOTICE`** — same link removal.
- **Contact links** move from Telegram to `developer@widemoat.ai`, the canonical address already enforced by `scripts/docs-lint/identity-email-detector.sh`.
- **Stale org links** — `github.com/Yambr/open-computer-use` → `github.com/Wide-Moat/open-computer-use` in `computer-use-server/static/docs.html`, `static/preview.js`, and the footers baked into `docs/architecture.svg` and `docs/sandbox-contents.svg`.

Left untouched on purpose: `i@yambr.com` in the lint-policy scripts and pre-push hook (they *define* the banned address), the `sk-yambr-` allowlist in `.gitleaks.toml`, and the two brand mentions in prose/comments — none of these are links.

## Testing
- [x] `./tests/test-no-corporate.sh` passes — n/a, the script is not present in the tree
- [x] `./tests/test-project-structure.sh` passes — 24 passed, 0 failed
- [ ] `./tests/test-docker-image.sh` passes (if Dockerfile changed) — n/a, docs-only change
- [ ] `docker compose up` works end-to-end — n/a, docs-only change

Also run: `scripts/docs-lint/test-linters.sh` (16 passed, 0 failed), `identity-email-detector.sh`, `ai-slop-detector.sh` and `wc-budget.sh` — all clean. A repo-wide grep confirms no `app.`/`api.`/`docs.`/`cu.yambr.com`, `t.me/yambrcom` or `github.com/Yambr` link remains.

## ADRs reviewed (for `docs/future-architecture/` phase work)
- [x] N/A — this PR is not phase-execution work

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mi31tYwAwfLcjbBN9EigHw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated project and repository links throughout the documentation.
  * Clarified that managed cloud and hosted MCP services are being reorganized or are offline.
  * Added guidance for self-hosting and self-hosted MCP usage.
  * Updated licensing and contact information to use email.
  * Updated comparison and community references to reflect current service availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->