### PR TITLE
docs(contracts): the gateway channel gains Authentication (1.2.0)

### DIFF
--- a/contracts/audit/audit-fanin.asyncapi.yaml
+++ b/contracts/audit/audit-fanin.asyncapi.yaml
@@ -16,7 +16,7 @@ asyncapi: 3.0.0
 
 info:
   title: OCU Audit Fan-in
-  version: 1.1.0
+  version: 1.2.0
   description: >-
     One-directional fan-in from the five emitting host-side components — MCP
     gateway, Control / operator API, Egress trust-edge, Object-store service,
@@ -47,10 +47,20 @@ servers:
 channels:
   mcpGatewayAudit:
     address: audit.ingest.mcp-gateway
-    description: GATEWAY — API Activity for MCP tool-call ingress at the gateway.
+    description: >-
+      GATEWAY — API Activity for MCP tool-call ingress, and caller-key
+      authentication, at the gateway.
     messages:
       apiActivity:
         $ref: '#/components/messages/ApiActivity'
+      # The sk-ocu- caller key is validated AT THE GATEWAY (ADR-0027); Control
+      # only ever sees the gateway's own mTLS identity, so a failed caller key
+      # is observable nowhere but here. Same emission discipline as the
+      # control-plane channel (NFR-SEC-88): one logon per accepted
+      # connection/session, every failure with its cause, fail-open with
+      # counted loss.
+      authentication:
+        $ref: '#/components/messages/Authentication'
 
   controlPlaneAudit:
     address: audit.ingest.control-plane
@@ -126,6 +136,7 @@ operations:
       - $ref: '#/components/securitySchemes/sourceMtls'
     messages:
       - $ref: '#/channels/mcpGatewayAudit/messages/apiActivity'
+      - $ref: '#/channels/mcpGatewayAudit/messages/authentication'
 
   receiveControlPlane:
     action: receive
@@ -281,7 +292,10 @@ components:
     Authentication:
       name: Authentication
       title: Authentication (OCSF 3002)
-      summary: Session JWT issue and operator authentication.
+      summary: >-
+        Authentication acts: session-JWT issue and operator authentication at the
+        Control plane, caller-key logons at the gateway. The publishing channel
+        names which.
       contentType: application/json
       traits:
         - $ref: '#/components/messageTraits/auditEnvelope'


### PR DESCRIPTION
## What

The contract half of ocu-control#118: the gateway fan-in channel gains the `Authentication` message. Additive, **1.1.0 → 1.2.0**.

## Why the gateway channel

The `sk-ocu-` caller key is validated **at the gateway** (ADR-0027); Control only ever sees the gateway's own mTLS identity. So a failed caller key is observable nowhere but at the gateway — and the gateway channel declared only `ApiActivity`, leaving it no message to emit. A failed caller key today produces no 3002 anywhere.

## Shape

Same as the control-plane channel's `ApiActivity` addition in 1.1.0:

- channel **and** its `receive` operation gain the message (the operation enumerates its messages, so declaring on the channel alone is not enough)
- the `Authentication` summary stops naming one channel now that two publish it — the publishing channel is the discriminator (ADR-0044)
- the emission discipline is stated **on the channel** so the gateway-side implementer inherits NFR-SEC-88 rather than re-deriving it: one logon per accepted connection/session, every failure with its cause, fail-open with counted loss

## Sequencing

The emitter itself is the gateway's follow-up (tracked in ocu-control#118); the contract ships first so the consumer precedes the producer — the same order the 1.1.0 change followed.

Validated with the pinned `@asyncapi/cli@6.0.0`: 0 errors; channel and operation message sets confirmed identical.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the audit contract to version 1.2.0.
  * Documented caller-key authentication handling for the MCP gateway.
  * Added authentication message details and linked them to the relevant receive operation.
  * Expanded authentication documentation to include gateway caller-key logons, Control-plane authentication, and session JWT issuance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->