### PR TITLE
feat(contracts): ADR-0047 — a deny-all state for the MCP key set

### DIFF
--- a/contracts/mcp/mcp-key-set.schema.json
+++ b/contracts/mcp/mcp-key-set.schema.json
@@ -6,72 +6,100 @@
   "description": "The versioned hashed-key-set the Control plane renders for the MCP gateway to boot-load and validate presented sk-ocu- caller keys in-process (ADR-0027). Top-level `version` (const 1) + `records[]`; each record is one MCP API key as a salted SHA-256 hash plus its binding metadata, never the plaintext secret. Only active, non-expired records reach this set. The gateway resolves a presented bearer to a record here or refuses it (401); tenant and deployment scope are read from the resolved record, never from the opaque key.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["version", "records"],
-
+  "required": [
+    "version",
+    "records",
+    "state"
+  ],
   "$defs": {
     "KeyId": {
       "description": "Opaque public handle for the key: the value passed to `occ mcp-key revoke --id` and the correlation field on the audit record. A short random handle, structurally independent of the secret (never derived from it). Control mints it as the lowercase-hex encoding of 12 CSPRNG bytes (24 hex chars); the schema pins only that it is a non-empty opaque string, so a future id shape stays additive.",
       "type": "string",
       "minLength": 1,
       "maxLength": 256,
-      "examples": ["a1b2c3d4e5f6a7b8c9d0e1f2"]
+      "examples": [
+        "a1b2c3d4e5f6a7b8c9d0e1f2"
+      ]
     },
-
     "KeyHash": {
       "description": "Salted key digest: `sha256(salt || secret)`, lowercase-hex. Exactly 64 hex chars (256-bit SHA-256). The unsalted digest is rejected at construction (pass-the-hash floor, NFR-SEC-87). Lowercase-hex, NOT base64 (a raw []byte defaults to base64; the projection hex-encodes it to satisfy this pattern).",
       "type": "string",
       "pattern": "^[0-9a-f]{64}$",
-      "examples": ["0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"]
+      "examples": [
+        "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
+      ]
     },
-
     "Salt": {
       "description": "Per-key salt, lowercase-hex, an even number of hex chars, at least 16 (>= 64-bit). Control draws a fresh 32-byte crypto/rand salt per key, so the rendered value is 64 hex chars; the pattern floor of 16 keeps the entropy floor without pinning the exact width. Stored alongside the hash so the gateway can re-hash a presented bearer for comparison.",
       "type": "string",
       "pattern": "^([0-9a-f]{2}){8,}$",
-      "examples": ["2122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40"]
+      "examples": [
+        "2122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40"
+      ]
     },
-
     "Tenant": {
       "description": "The tenant the key is scoped to, read from THIS record at the gateway, never from a claim in the opaque key (an opaque key carries none). Operator-supplied at issuance (`occ mcp-key create --tenant <T>`).",
       "type": "string",
       "minLength": 1,
       "maxLength": 256,
-      "examples": ["tenant-a"]
+      "examples": [
+        "tenant-a"
+      ]
     },
-
     "Deployment": {
       "description": "The deployment the key is scoped to. A key whose deployment does not match this set's deployment fails to resolve and is refused with 401 (ADR-0027 absent-from-set refuse-path). Operator-supplied at issuance.",
       "type": "string",
       "minLength": 1,
       "maxLength": 256,
-      "examples": ["deploy-1"]
+      "examples": [
+        "deploy-1"
+      ]
     },
-
     "Status": {
       "description": "Lifecycle state as PUBLISHED on this wire: always `active`. Revoked/expired records are omitted before render (fail-closed), and the const makes a mis-render that leaks a revoked record schema-detectable by the vendored validator instead of silently usable. The at-rest record type also carries a `revoked` state; that state never reaches this artifact.",
       "type": "string",
       "const": "active"
     },
-
     "Timestamp": {
       "description": "An RFC 3339 date-time (UTC, e.g. 2026-03-01T12:00:00Z). Control formats the record's time from an injected monotonic Clock.",
       "type": "string",
       "format": "date-time",
-      "examples": ["2026-03-01T12:00:00Z"]
+      "examples": [
+        "2026-03-01T12:00:00Z"
+      ]
     },
-
     "HashedKeyRecord": {
       "description": "One MCP API key as a salted hash plus its binding metadata. NEVER the plaintext secret. Required: key_id, key_hash, salt, tenant, deployment, status, created_at. Optional: expires_at (absent => non-expiring, so the one-click path is not blocked). additionalProperties:false forbids any extra field smuggling a secret in.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["key_id", "key_hash", "salt", "tenant", "deployment", "status", "created_at"],
+      "required": [
+        "key_id",
+        "key_hash",
+        "salt",
+        "tenant",
+        "deployment",
+        "status",
+        "created_at"
+      ],
       "properties": {
-        "key_id": { "$ref": "#/$defs/KeyId" },
-        "key_hash": { "$ref": "#/$defs/KeyHash" },
-        "salt": { "$ref": "#/$defs/Salt" },
-        "tenant": { "$ref": "#/$defs/Tenant" },
-        "deployment": { "$ref": "#/$defs/Deployment" },
-        "status": { "$ref": "#/$defs/Status" },
+        "key_id": {
+          "$ref": "#/$defs/KeyId"
+        },
+        "key_hash": {
+          "$ref": "#/$defs/KeyHash"
+        },
+        "salt": {
+          "$ref": "#/$defs/Salt"
+        },
+        "tenant": {
+          "$ref": "#/$defs/Tenant"
+        },
+        "deployment": {
+          "$ref": "#/$defs/Deployment"
+        },
+        "status": {
+          "$ref": "#/$defs/Status"
+        },
         "expires_at": {
           "$ref": "#/$defs/Timestamp",
           "description": "Optional expiry. ABSENT means the key is non-expiring (ADR-0027). When present it is an RFC 3339 date-time; an expired record is omitted from this set before render, so a present expires_at here is always in the future relative to render time."
@@ -83,23 +111,37 @@
       }
     }
   },
-
   "properties": {
     "version": {
       "description": "Boot-set envelope format version. Pinned const 1; a format migration bumps it (NFR-IC-04, additive-only otherwise).",
       "const": 1
     },
     "records": {
-      "description": "The active, non-expired records the gateway boot-loads. minItems 1 pins the empty-set refusal schema-side: Control refuses to render an empty active set (fail-closed — an empty boot-set would make the gateway reject every presented key, masking a misconfiguration), so an empty artifact is invalid, not merely unexpected.",
+      "description": "The active, non-expired records the gateway boot-loads. Empty ONLY when state is deny-all: an empty list with state active is a mis-render (the set the gateway would boot-load rejects every key while looking healthy), and the allOf below makes that combination schema-invalid rather than merely unexpected. See ADR-0047.",
       "type": "array",
-      "minItems": 1,
-      "items": { "$ref": "#/$defs/HashedKeyRecord" }
+      "minItems": 0,
+      "items": {
+        "$ref": "#/$defs/HashedKeyRecord"
+      }
+    },
+    "state": {
+      "description": "Whether this document grants or refuses. deny-all is how a revoke of the LAST active key reaches a live gateway: the gateway swaps in the empty set instead of keeping its last-good one (ADR-0047). Emptiness alone cannot carry that intent \u2014 it is indistinguishable from a truncated write \u2014 so the state is explicit and the pairing is enforced.",
+      "type": "string",
+      "enum": [
+        "active",
+        "deny-all"
+      ]
     }
   },
-
   "examples": [
     {
       "version": 1,
+      "state": "deny-all",
+      "records": []
+    },
+    {
+      "version": 1,
+      "state": "active",
       "records": [
         {
           "key_id": "a1b2c3d4e5f6a7b8c9d0e1f2",
@@ -121,6 +163,46 @@
           "created_at": "2026-03-01T12:00:00Z"
         }
       ]
+    }
+  ],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "deny-all"
+          }
+        },
+        "required": [
+          "state"
+        ]
+      },
+      "then": {
+        "properties": {
+          "records": {
+            "maxItems": 0
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "active"
+          }
+        },
+        "required": [
+          "state"
+        ]
+      },
+      "then": {
+        "properties": {
+          "records": {
+            "minItems": 1
+          }
+        }
+      }
     }
   ]
 }

--- a/docs/architecture/adr/0047-config-plane-deny-all-tombstone.md
+++ b/docs/architecture/adr/0047-config-plane-deny-all-tombstone.md
@@ -58,9 +58,16 @@ explicit `state` makes the deny deliberate and a torn document invalid.
   Deny-all is expressible; it is not the failure mode.
 - The frozen schema changes, so every vendored copy must move in lockstep and
   the parity gate must pass on the same commit.
-- The gateway's loader gains one branch. An old gateway reading a deny-all
-  document rejects it as schema-invalid and keeps last-good — so the gateway
-  must ship before Control emits the state.
+- `state` is required in both directions, so the change is breaking rather than
+  additive: a document without it is schema-invalid, and Control's current
+  renderer emits none. Producer, consumer, and both vendored copies therefore
+  land in one wave. Making `state` optional with an implied `active` default was
+  rejected for the reason this ADR exists — an absent field carrying intent is
+  the same ambiguity as an empty list carrying it. Bumping `version` to 2 was
+  rejected as a format barrier disproportionate to one added field (NFR-IC-04
+  prefers additive evolution, and a coordinated wave preserves it here).
+- The gateway's loader gains one branch: on a deny-all document it swaps in the
+  empty set rather than keeping last-good.
 
 ## Alternatives
 

--- a/docs/architecture/adr/0047-config-plane-deny-all-tombstone.md
+++ b/docs/architecture/adr/0047-config-plane-deny-all-tombstone.md
@@ -1,0 +1,77 @@
+---
+status: proposed
+last-reviewed: 2026-08-09
+owner: architecture
+applies-to: contracts/mcp/mcp-key-set.schema.json, component-01, component-02
+---
+
+Gives the config plane a way to say "authenticate nobody", so revoking the last
+active key reaches a live gateway. Audience: anyone touching the key-set wire or
+the gateway's refresh path.
+
+## Context
+
+Revoking the **last** active mcp-key leaves that key valid on a running gateway
+until it restarts. NFR-SEC-04 requires revocation to land within five minutes.
+
+Both halves are individually correct:
+
+- The frozen key-set schema pins `records.minItems: 1`. Control refuses to
+  render an empty active set, because an empty set was only ever reachable as a
+  mis-render, and one would make the gateway reject every key while looking
+  healthy.
+- The gateway's `Refresh()` keeps the last-good set on a loader error or a
+  missing file, so a transient filesystem hiccup does not blank all auth. Its
+  own doc says revocation "converges on the next **successful** refresh".
+
+Together they deadlock. Control writes nothing for the empty case, so no
+successful refresh ever happens; deleting the artifact does not help, because a
+missing file also keeps last-good. **Empty and unreadable are the same state on
+this wire, and neither means deny.**
+
+## Decision
+
+We add an explicit deny-all state to the key set, and the gateway treats it as
+authenticate-nothing rather than as an error.
+
+- `records.minItems` relaxes to 0.
+- A new required top-level `state` carries `"active"` or `"deny-all"`.
+- `state: "deny-all"` requires `records: []`; `state: "active"` keeps
+  `minItems: 1`.
+- `Refresh()` swaps in the empty set when it loads a deny-all document. It keeps
+  last-good only for a load FAILURE, which is unchanged.
+
+Deny-all is a value on the existing artifact, not a second file. A separate
+marker would make authentication state depend on the read order of two files,
+and that ordering becomes an invariant nobody declared.
+
+The distinction the schema must carry is intent, not emptiness. `records: []`
+alone would still be ambiguous with a truncated write; pairing it with an
+explicit `state` makes the deny deliberate and a torn document invalid.
+
+## Consequences
+
+- Revoking the last key produces a document Control can render and the gateway
+  can load, so revocation converges within the NFR-SEC-04 window without a
+  restart.
+- A truncated or corrupt artifact still fails to load and still keeps last-good.
+  Deny-all is expressible; it is not the failure mode.
+- The frozen schema changes, so every vendored copy must move in lockstep and
+  the parity gate must pass on the same commit.
+- The gateway's loader gains one branch. An old gateway reading a deny-all
+  document rejects it as schema-invalid and keeps last-good — so the gateway
+  must ship before Control emits the state.
+
+## Alternatives
+
+**A separate deny-all marker file.** Rejected: two files, one answer. The
+gateway would have to read them in a fixed order, and that order is an
+undeclared invariant that a future refactor can silently invert.
+
+**A tombstone record with `status: "deny-all"`.** Rejected: it puts a non-key in
+the key list, so every consumer that iterates records must learn to skip it, and
+one that forgets treats deny-all as a credential.
+
+**Leave it to operators (delete the artifact, restart the gateway).** Rejected:
+a restart is not a five-minute guarantee, and it makes revocation depend on an
+operator noticing.


### PR DESCRIPTION
Closes #332.

## The deadlock

Revoking the last active key produced no document any peer would accept:

- `contracts/mcp/mcp-key-set.schema.json` pinned `records.minItems: 1`, with a comment stating an empty artifact "is invalid, not merely unexpected" — so Control could render nothing for the empty case.
- The gateway's `Refresh()` returns `"boot: refresh failed, keeping the last-good key set: %w"` on **any** load error.

Composed: nothing is written, no successful refresh occurs, and the gateway keeps serving the revoked key until it restarts — outside the NFR-SEC-04 five-minute revocation window.

## The decision

`records` relaxes to `minItems: 0`; a required top-level `state` carries `active` or `deny-all`. The pairing is enforced in both directions, so an empty *active* set stays schema-invalid rather than quietly becoming the second spelling of deny-all.

Emptiness alone cannot carry the intent — it is indistinguishable from a truncated write, which is precisely the case that must keep last-good.

## Breaking, deliberately

`state` is required both ways, and Control's renderer emits no such field today. The additive spellings were considered and refused in the ADR:

- **optional `state`, absent ⇒ active** — reintroduces the implied-intent ambiguity this decision exists to remove;
- **bump `version` to 2** — a format barrier disproportionate to one added field, where NFR-IC-04 prefers additive evolution.

Producer, consumer, and both vendored copies (`ocu-control`, `ocu-mcp-gateway`) land in one wave instead. Control's `mcp-key-set.golden.json` is currently `{version, records}` and is confirmed schema-invalid under this commit — that migration is the wave's other half.

## Verification

Six instance vectors through the CI ajv invocation (`ajv-cli@5.0.0 --spec=draft2020 --strict=false`), each measured rather than assumed:

| document | verdict |
|---|---|
| `deny-all` + `records: []` | VALID |
| `active` + one record | VALID |
| `deny-all` + a record | INVALID |
| `active` + `records: []` | INVALID |
| no `state` | INVALID |
| `state: "off"` | INVALID |

Both directions of each `allOf` branch discriminate, so neither is vacuous. The schema compiles, and both `examples` (a deny-all and an active document) validate against it — the pre-existing example carried no `state` and was invalid under the edit until fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for explicit `active` and `deny-all` key-set states.
  * `deny-all` configurations can now represent an intentionally empty key set.
  * `active` configurations require at least one key record.

* **Documentation**
  * Added architecture guidance covering deny-all behavior, compatibility, refresh handling, and failure scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->