### PR TITLE
feat(contracts): freeze the F5 exec-reply envelope

### DIFF
--- a/contracts/exec/exec-reply.schema.json
+++ b/contracts/exec/exec-reply.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.open-computer-use.dev/exec/exec-reply.schema.json",
+  "$comment": "SPDX-License-Identifier: FSL-1.1-Apache-2.0. Copyright (c) 2025 Open Computer Use Contributors. STATUS frozen. The F5 HTTP exec-reply envelope Control returns to the MCP gateway for a guest exec. Field names are frozen de-facto: they are already on the wire between ocu-control (internal/ingress/gateway) and ocu-mcp-gateway (internal/forward), so a rename is a breaking change to a live surface, not an edit. SIZING INVARIANT, which is the reason this file exists rather than living only as two Go structs: gateway.maxReplyBytes >= 2*ceil(control.replyCeiling*4/3) + envelope, and gateway.boundContent >= control.replyCeiling. The two caps are set in different repositories, and when they diverged (64 KiB gateway read against an 8 MiB control capture) a large output was read to the limit, the JSON truncated mid-string, and the whole result was dropped as a 502 rather than as a truncated success. The maxLength below pins the first half of that invariant in the contract: 87384 is the base64 length of the 65536-byte per-stream ceiling, so two of them plus the envelope must fit under the reader's bound. JSON Schema 2020-12 (json-schema.org).",
+
+  "title": "ExecReply",
+  "description": "One completed guest exec: the child's exit code, each captured output stream as base64, and a per-stream flag saying whether that stream was cut at the capture ceiling. Truncation is reported, never silent — a caller that sees stdout_truncated knows the bytes it holds are a prefix, not the whole output.",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "exit_code",
+    "stdout_b64",
+    "stderr_b64",
+    "stdout_truncated",
+    "stderr_truncated"
+  ],
+
+  "$defs": {
+    "Base64Stream": {
+      "description": "One captured output stream, base64 (RFC 4648 standard alphabet, padded). Base64 rather than a JSON string because the bytes are arbitrary: guest output is not required to be valid UTF-8, and a raw string field would force lossy replacement or a parse failure. An empty stream is the empty string, never null. maxLength 87384 is base64(65536) — the encoded size of one stream at the capture ceiling; see the sizing invariant in $comment.",
+      "type": "string",
+      "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+      "maxLength": 87384
+    }
+  },
+
+  "properties": {
+    "exit_code": {
+      "description": "The guest child's exit status, 0-255. A non-zero exit is a completed exec whose command failed — it is carried here, not raised as a transport error, so the caller can distinguish 'the command ran and returned 3' from 'the exec did not happen'.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "stdout_b64": {
+      "$ref": "#/$defs/Base64Stream"
+    },
+    "stderr_b64": {
+      "$ref": "#/$defs/Base64Stream"
+    },
+    "stdout_truncated": {
+      "description": "True when stdout exceeded the capture ceiling and the bytes in stdout_b64 are a prefix. The flag is required, so a reply can never leave the caller unable to tell a complete stream from a cut one.",
+      "type": "boolean"
+    },
+    "stderr_truncated": {
+      "description": "True when stderr exceeded the capture ceiling and the bytes in stderr_b64 are a prefix.",
+      "type": "boolean"
+    }
+  },
+
+  "examples": [
+    {
+      "exit_code": 0,
+      "stdout_b64": "aGVsbG8K",
+      "stderr_b64": "",
+      "stdout_truncated": false,
+      "stderr_truncated": false
+    },
+    {
+      "exit_code": 2,
+      "stdout_b64": "",
+      "stderr_b64": "Y2F0OiAvbm9wZTogTm8gc3VjaCBmaWxlIG9yIGRpcmVjdG9yeQo=",
+      "stdout_truncated": false,
+      "stderr_truncated": false
+    },
+    {
+      "exit_code": 0,
+      "stdout_b64": "bG9uZyBvdXRwdXQu",
+      "stderr_b64": "",
+      "stdout_truncated": true,
+      "stderr_truncated": false
+    }
+  ]
+}


### PR DESCRIPTION
Closes #344.

## Why a file, when the wire already works

The exec-reply envelope lived only as two Go structs — `ocu-control` `internal/ingress/gateway` and `ocu-mcp-gateway` `internal/forward` — in two repositories with no shared artifact. That is the mechanism behind the large-output-502 class: the gateway bounded its read at 64 KiB while control captured up to 8 MiB, so a large reply was read to the limit, the JSON truncated mid-string, and the whole result was dropped as a **502** rather than delivered as a truncated success.

#127/#128/#131 fixed the values. Nothing stopped them drifting apart again, because the constraint that ties them lives in neither struct.

## The invariant, in the contract

`gateway.maxReplyBytes >= 2*ceil(control.replyCeiling*4/3) + envelope`, and `boundContent >= ceiling`.

`maxLength: 87384` pins the first half: it is base64(65536) — the encoded width of one stream at the capture ceiling — so any reader's bound must clear two of them plus the envelope.

Checked against the live constants rather than the issue text (the caps moved across three PRs):

| | value | source |
|---|---|---|
| control `defaultStdioCap` | 65536 | `internal/guestexec/driver.go` |
| base64 of one stream | 87384 | computed |
| two streams | 174768 | |
| gateway `maxReplyBytes` | 262144 | `internal/forward/http.go` |
| envelope headroom | 87376 | |

Field names are frozen as they already are on the wire — this describes the surface, it does not change it.

## Verification

Compiles under the CI invocation (`ajv-cli@5.0.0 --spec=draft2020 --strict=false`), and all three `examples` validate against it.

Twelve instance vectors, each measured:

| vector | verdict |
|---|---|
| minimal reply | VALID |
| `exit_code: 255` | VALID |
| stream exactly at the ceiling | VALID |
| `exit_code: 256` / `-1` / `1.5` | INVALID |
| missing `stdout_truncated` | INVALID |
| `stderr_b64: null` | INVALID |
| extra top-level field | INVALID |
| non-base64 alphabet | INVALID |
| stream past the ceiling | INVALID |
| `stdout_truncated: "true"` | INVALID |

The boundary pair is the point: at the ceiling validates, past it does not.

One probe was initially wrong and is worth recording — a payload of 65537 bytes was expected to exceed `maxLength` and did not. Base64 encodes 3 bytes to 4 characters, so 65536, 65537, and 65538 all encode to exactly 87384 characters; 65539 is the first size that actually overflows. The probe was rebuilt rather than the constraint loosened.

Each constraint is mutation-checked — dropping `maxLength`, the base64 `pattern`, the `exit_code` `maximum`, `additionalProperties: false`, or a required truncation flag each admits a document the schema otherwise refuses. None is decorative.

## Follow-up

Vendoring byte-identical into control and gateway is deliberately **not** in this PR: both repositories' contract-identity gates are mid-flight on the ADR-0047 deny-all wave (ocu-control#135, ocu-mcp-gateway#81), and their canon pins move with it. Canon lands first, then the vendoring follows against a settled pin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a schema for completed guest command execution responses.
  * Responses now include the exit code, encoded standard output and error output, and truncation indicators.
  * Added validation for exit-code ranges, encoded output formats, output size limits, and supported execution examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->