### PR TITLE
ci(docs): turn off MD060, which markdownlint-cli2 19 adds

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -49,3 +49,11 @@ MD046:
 # MD059 — link text should be descriptive. Allow "here" / "this" because we
 # use them in legitimate context-sentence patterns.
 MD059: false
+
+# MD060 — table-column-style. Introduced in markdownlint-cli2 19; it requires
+# each delimiter cell to match the width of its header cell. The compact
+# `|---|---|` form renders identically and is what every table in
+# docs/architecture/ uses, so enforcing it would rewrite 500 delimiter rows
+# across the canon for no reader-visible change — history noise that buries
+# real diffs. Column ALIGNMENT (the colons) is unaffected and still linted.
+MD060: false


### PR DESCRIPTION
Unblocks #418 (the markdownlint-cli2 18 → 19 bump), which is red on 500 findings.

## What is red, and why it is neither the bump nor the docs

All 500 are one rule the new version **introduces**: `MD060/table-column-style`, which requires each delimiter cell to be padded to the width of its header cell.

```
| # | Zone | One-line role | §02 anchor |
|---|---|---|---|          <- what every canon table does
|---|------|---------------|------------|   <- what MD060 wants
```

The two render identically. The rule did not exist when these documents were written, so this is a new opinion applied retroactively to 72 files, not a defect anyone introduced.

## The call

Enforcing it would rewrite ~500 delimiter rows across `docs/architecture/` for no reader-visible change, and a diff that size buries the ones that matter. Turned off, with the reason recorded in `.markdownlint.yaml` beside the seven exclusions already there.

Column **alignment** — the colons, which genuinely change how a table renders — is a separate concern and remains linted.

## Probed both directions

A green from a rule you just disabled is worth checking twice:

| state | result |
|---|---|
| MD060 off, 72 architecture files under v19 | 0 errors |
| planted bare URL | **MD034 fires** — the linter still works |
| MD060 re-enabled, single file | **90 hits** — the rule is what was silenced |

So the rule is off and nothing else is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Markdown linting configuration to allow compact table-column delimiter styles.
  * Preserved validation for table-column alignment and documented the configuration choice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->