### PR TITLE
ci(security): move every codeql-action subpath to one SHA, and gate it

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
-      - uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3.36.2
+      - uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43  # v4.37.5
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
-      - uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3.36.2
+      - uses: github/codeql-action/autobuild@d1ba80a13dd99fba24a470575428917156a28b43  # v4.37.5
 
-      - uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3.36.2
+      - uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43  # v4.37.5

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -278,7 +278,7 @@ jobs:
           limit-severities-for-sarif: true
       - name: Upload SARIF (CRITICAL)
         if: always()
-        uses: github/codeql-action/upload-sarif@fee9466b8957867761f2d78f922ab084e3e2dd17  # v3
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43  # v4.37.5
         with:
           sarif_file: trivy-fs.sarif
           category: trivy-fs
@@ -307,7 +307,7 @@ jobs:
           limit-severities-for-sarif: true
       - name: Upload SARIF (HIGH)
         if: always()
-        uses: github/codeql-action/upload-sarif@fee9466b8957867761f2d78f922ab084e3e2dd17  # v3
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43  # v4.37.5
         with:
           sarif_file: trivy-fs-high.sarif
           category: trivy-fs-high
@@ -499,6 +499,19 @@ jobs:
 
       - name: Self-test the exception-ledger checker
         run: python3 tests/security/check_security_exceptions.py --self-test
+
+      # Subpaths of one action repository share runtime state — CodeQL refuses
+      # to analyze when init and analyze disagree ("Loaded a configuration file
+      # for version X, but running version Y"). Dependabot opens one PR per
+      # SUBPATH, so a package used through four paths arrives as four PRs that
+      # each break the set in isolation, and the failure names a version
+      # mismatch rather than the split bump behind it. zizmor proves each ref IS
+      # a SHA; nothing proved sibling subpaths share one.
+      - name: Self-test the action-pin checker
+        run: python3 scripts/check-action-pin-consistency.py --self-test
+
+      - name: Action subpaths of one repository share a SHA
+        run: python3 scripts/check-action-pin-consistency.py
 
       - name: Enforce the HIGH-exception ledger
         # The ledger carried a schema with `since`, `expires`, an owner and a

--- a/scripts/check-action-pin-consistency.py
+++ b/scripts/check-action-pin-consistency.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# Actions used through SEVERAL SUBPATHS of one repository must share a SHA.
+#
+# github/codeql-action ships init, autobuild, and analyze as three paths in ONE
+# repository, and CodeQL refuses to run when they disagree: "Loaded a
+# configuration file for version '4.36.2', but running version '4.37.5'". The
+# same holds for any multi-path action.
+#
+# Dependabot opens one PR per PATH, so a package with three used paths arrives
+# as three PRs that each break the trio in isolation. Merging any one of them
+# reds CodeQL on every subsequent PR, and the failure names a version mismatch
+# rather than the split bump that produced it.
+#
+# The rule is scoped to multi-subpath packages on purpose. A single-path action
+# like actions/checkout is a fresh, independent invocation each time, so two
+# workflows may sit on different versions without interacting; demanding one SHA
+# there would be a house-style opinion, not a correctness gate. What breaks is
+# subpaths of one package that share runtime state.
+#
+# zizmor's unpinned-uses rule checks that each ref IS a SHA. It does not check
+# that sibling subpaths share one, which is the failure this catches.
+#
+# --self-test plants a divergent pin and asserts the check goes RED, then
+# asserts the shipped tree passes.
+import os
+import re
+import sys
+from collections import defaultdict
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WORKFLOWS = os.path.join(ROOT, ".github", "workflows")
+
+# owner/repo[/subpath]@sha — the SHA is what must agree across subpaths.
+USES_RE = re.compile(r"uses:\s*([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)(/[A-Za-z0-9._/-]+)?@([0-9a-f]{40})")
+
+
+def scan(workflows=WORKFLOWS):
+    """Return {package: {sha: [locations]}} for SHA-pinned actions, and the set
+    of subpaths seen per package."""
+    seen = defaultdict(lambda: defaultdict(list))
+    subpaths = defaultdict(set)
+    if not os.path.isdir(workflows):
+        return seen
+    for name in sorted(os.listdir(workflows)):
+        if not name.endswith((".yml", ".yaml")):
+            continue
+        path = os.path.join(workflows, name)
+        with open(path, encoding="utf-8") as f:
+            for lineno, line in enumerate(f, 1):
+                m = USES_RE.search(line)
+                if m:
+                    pkg, sub, sha = m.group(1), m.group(2) or "", m.group(3)
+                    seen[pkg][sha].append(f"{name}:{lineno}{sub}")
+                    subpaths[pkg].add(sub)
+    return seen, subpaths
+
+
+def check(workflows=WORKFLOWS, quiet=False):
+    """Return a list of failure strings; empty means every package agrees."""
+    seen, subpaths = scan(workflows)
+    if not seen:
+        return ["no SHA-pinned actions found; this gate would be vacuous"]
+    multi = {p for p, subs in subpaths.items() if len(subs) > 1}
+    if not multi:
+        return ["no action is used through more than one subpath; this gate would be vacuous"]
+    problems = []
+    for pkg, by_sha in sorted(seen.items()):
+        if pkg in multi and len(by_sha) > 1:
+            detail = "; ".join(f"{sha[:8]} at {', '.join(locs)}" for sha, locs in sorted(by_sha.items()))
+            problems.append(
+                f"{pkg} is pinned to {len(by_sha)} different SHAs — {detail}. "
+                f"Paths of one action repository must share a SHA (a split dependabot bump does this)."
+            )
+    if not quiet:
+        print(f"action-pin-consistency: {len(multi)} multi-subpath package(s) checked, each pinned to one SHA")
+    return problems
+
+
+def self_test():
+    import shutil
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        work = os.path.join(tmp, "workflows")
+        shutil.copytree(WORKFLOWS, work)
+        if check(work, quiet=True):
+            print("::error::action-pin-consistency: the shipped tree already fails; the mutation below would prove nothing", file=sys.stderr)
+            sys.exit(1)
+
+        # Find a package used at two or more locations and split it.
+        target = None
+        seen_w, subs_w = scan(work)
+        for pkg, by_sha in seen_w.items():
+            if len(subs_w[pkg]) < 2:
+                continue
+            locs = next(iter(by_sha.values()))
+            if len(locs) >= 2:
+                target = (pkg, next(iter(by_sha)), locs[0].split(":")[0])
+                break
+        if target is None:
+            print("::error::action-pin-consistency: no multi-subpath action to mutate; the self-test cannot prove anything", file=sys.stderr)
+            sys.exit(1)
+
+        pkg, sha, fname = target
+        path = os.path.join(work, fname)
+        with open(path, encoding="utf-8") as f:
+            body = f.read()
+        # Diverge exactly one occurrence.
+        body = body.replace("@" + sha, "@" + "0" * 40, 1)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(body)
+
+        if not check(work, quiet=True):
+            print(f"::error::action-pin-consistency: a divergent pin on {pkg} was NOT caught", file=sys.stderr)
+            sys.exit(1)
+
+    print("action-pin-consistency self-test: a divergent pin reds the gate; the shipped tree passes")
+
+
+def main(argv):
+    if "--self-test" in argv:
+        self_test()
+        return 0
+    problems = check()
+    for p in problems:
+        print(f"::error::action-pin-consistency: {p}", file=sys.stderr)
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Supersedes #413 and #417, which cannot succeed separately.

## Why those two PRs are red

`github/codeql-action` ships `init`, `autobuild`, `analyze` and `upload-sarif` as four paths in **one** repository, and they share runtime state. Dependabot opens one PR per **subpath**, so each one breaks the set in isolation:

```
##[error]Loaded a configuration file for version '4.36.2',
         but running version '4.37.5'
```

That message names the mismatch, not the split bump behind it — which is why both PRs look like a CodeQL problem rather than a packaging one. Merging either would red CodeQL on every subsequent PR.

All four move to `d1ba80a` (v4.37.5) together. That is what #413 and #417 were each asking for and could not achieve alone.

## The gate that would have caught this did not exist

zizmor's `unpinned-uses` proves each ref **is** a SHA. Nothing proved that sibling subpaths share **one**. `scripts/check-action-pin-consistency.py` does.

Writing it surfaced a second defect I was not looking for: **`upload-sarif` sat on `fee9466b` tagged `# v3`** while the other three had already moved to v3.36.2 — three minor lines behind, in the step that publishes SARIF to the security tab.

## Scoped deliberately

Only packages used through **more than one subpath** are checked. `actions/checkout` is pinned to both v4 (24 call sites) and v6 (13) across these workflows, and that is fine — it has no subpaths, each call is an independent invocation, and demanding one SHA there would be house style rather than correctness. The gate reports one package today, and says so in its output rather than implying broader coverage.

## Verification

| check | result |
|---|---|
| gate on this tree | pass — 1 multi-subpath package, one SHA |
| `--self-test` (plant a divergent pin) | reds, after asserting the shipped tree passes first |
| every workflow still parses as YAML | yes |
| `upload-sarif/action.yml` exists at `d1ba80a` | HTTP 200 |

The self-test asserts the clean tree passes **before** mutating, so a checker that failed on everything could not satisfy it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated security scanning workflows to use newer, commit-pinned analysis actions.
  * Added automated validation to ensure related workflow actions use consistent security pins.
  * Added self-checking to verify that inconsistent action pins are detected.
* **Chores**
  * Improved workflow diagnostics and failure reporting for security configuration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->