### PR TITLE
ci(docs): turn off MD060 on main, matching next/v1

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -49,3 +49,11 @@ MD046:
 # MD059 — link text should be descriptive. Allow "here" / "this" because we
 # use them in legitimate context-sentence patterns.
 MD059: false
+
+# MD060 — table-column-style. Introduced in markdownlint-cli2 19; it requires
+# each delimiter cell to match the width of its header cell. The compact
+# `|---|---|` form renders identically and is what every table in
+# docs/architecture/ uses, so enforcing it would rewrite 500 delimiter rows
+# across the canon for no reader-visible change — history noise that buries
+# real diffs. Column ALIGNMENT (the colons) is unaffected and still linted.
+MD060: false


### PR DESCRIPTION
Unblocks #418 (markdownlint-cli2 18 → 19), which targets `main`.

## Same rule, other branch

v19 introduces `MD060/table-column-style`, which requires each delimiter cell to be padded to its header cell's width:

```
| # | Zone | One-line role |
|---|---|---|                    <- what these docs use
|---|------|---------------|     <- what MD060 wants
```

Identical rendering. The rule did not exist when the documents were written.

The exclusion landed on `next/v1` as #419. `main` carries the same 41 architecture documents and the same `.markdownlint.yaml`, and **#418 targets `main`**, so the fix has to exist on both branches or the bump stays red here.

## Checks

- diffed against `main` to confirm **only** `MD060: false` is added — nothing else rode along from the `next/v1` copy of the file
- with it off, the 41 architecture files lint clean under v19
- a planted bare URL still reds (`MD034`), so the rule is off and the linter is not