### PR TITLE
test(image): exercise the data packages the image installs but never ran

### DIFF
--- a/tests/test-docker-image.sh
+++ b/tests/test-docker-image.sh
@@ -115,6 +115,24 @@ for pkg in docx pptx openpyxl; do
     RESULT=$(run_in_container "python3 -c \"import $pkg; print('OK')\"") || RESULT=""
     echo "$RESULT" | grep -q "OK" && pass "python import $pkg" || fail "python import $pkg"
 done
+
+# The data/imaging packages requirements.txt installs but nothing imported. A
+# major bump of any of these builds cleanly — pip resolves it, the image layer
+# is produced, "Build Sandbox Image" goes green — and then fails the first time
+# a skill touches it. Each line below EXERCISES the package rather than merely
+# importing it, because a broken major usually imports fine and moves an API.
+RESULT=$(run_in_container "python3 -c \"import pandas as pd; df=pd.DataFrame({'a':[1,2]}); assert df['a'].sum()==3; print('OK')\"") || RESULT=""
+echo "$RESULT" | grep -q "OK" && pass "python pandas (DataFrame + sum)" || fail "python pandas"
+RESULT=$(run_in_container "python3 -c \"import numpy as np; assert np.arange(3).sum()==3; print('OK')\"") || RESULT=""
+echo "$RESULT" | grep -q "OK" && pass "python numpy (arange + sum)" || fail "python numpy"
+RESULT=$(run_in_container "python3 -c \"import scipy.stats as st; assert round(st.norm.cdf(0),3)==0.5; print('OK')\"") || RESULT=""
+echo "$RESULT" | grep -q "OK" && pass "python scipy (stats.norm)" || fail "python scipy"
+RESULT=$(run_in_container "python3 -c \"import cv2, numpy as np; img=np.zeros((4,4,3),dtype=np.uint8); assert cv2.cvtColor(img, cv2.COLOR_BGR2GRAY).shape==(4,4); print('OK')\"") || RESULT=""
+echo "$RESULT" | grep -q "OK" && pass "python opencv (cvtColor)" || fail "python opencv"
+RESULT=$(run_in_container "python3 -c \"import imageio.v3 as iio, numpy as np, tempfile, os; p=os.path.join(tempfile.mkdtemp(),'t.png'); iio.imwrite(p, np.zeros((4,4,3),dtype=np.uint8)); assert iio.imread(p).shape==(4,4,3); print('OK')\"") || RESULT=""
+echo "$RESULT" | grep -q "OK" && pass "python imageio (write + read round-trip)" || fail "python imageio"
+RESULT=$(run_in_container "python3 -c \"from PIL import Image; im=Image.new('RGB',(4,4)); assert im.size==(4,4); print('OK')\"") || RESULT=""
+echo "$RESULT" | grep -q "OK" && pass "python pillow (Image.new)" || fail "python pillow"
 RESULT=$(run_in_container "python3 -c \"from playwright.sync_api import sync_playwright; print('OK')\"") || RESULT=""
 echo "$RESULT" | grep -q "OK" && pass "python playwright" || fail "python playwright"
 


### PR DESCRIPTION
Closes the coverage gap that has kept four major bumps unmergeable.

## The gap, measured

`requirements.txt` installs 20+ Python packages. The image test imported **four**: `docx`, `pptx`, `openpyxl`, `playwright`.

`pandas`, `numpy`, `scipy`, `opencv`, `imageio` and `pillow` were verified only by pip resolving them during the build. The image layer is produced, `Build Sandbox Image` goes green, and a skill is the first thing to discover a break.

That is the real reason the four majors in the queue (pandas 2→3, opencv 4→5, typescript 5→7, ubuntu 24.04→25.10) have been unmergeable — not that CI is thin in general, but that these exact packages are never executed.

## Exercised, not imported

Each new line performs an operation:

| package | what it does |
|---|---|
| pandas | build a DataFrame, sum a column |
| numpy | `arange(3).sum()` |
| scipy | `stats.norm.cdf(0) == 0.5` |
| opencv | `cvtColor` on a real array, check the output shape |
| imageio | write a PNG and read it back, check the shape |
| pillow | `Image.new`, check `.size` |

**Why that distinction is the whole point**, measured on pandas **3.0.5** — the version #367 proposes:

```
import pandas                -> OK
DataFrame.append(...)        -> raises (removed in 3.x)
```

A bare import waves the major through. An exercised call reds on it.

## Every payload was run before committing

Extracted the six `python3 -c` payloads back out of the script and executed them against real installed packages — pandas 3.0.5, numpy, scipy, opencv, imageio, pillow. All six pass, so none is a false red.

That run is also evidence about #367 specifically: on pandas 3.0.5 these operations still work, so the major does not break what this now checks. It does not clear the major on its own — the skills themselves remain unexercised — but it moves the line from "nothing runs these" to "these run".