### PR TITLE
chore(deps): drop ts-node, which TypeScript 7 breaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,9 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-icons": "^5.5.0",
-"remark-cli": "^12.0.1",
+    "remark-cli": "^12.0.1",
     "remark-preset-lint-recommended": "^7.0.1",
     "sharp": "^0.35.2",
-    "ts-node": "^10.9.2",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3"
   }

--- a/tests/test-docker-image.sh
+++ b/tests/test-docker-image.sh
@@ -84,8 +84,13 @@ echo "$RESULT" | grep -q "OK" && pass "tsc rejects an ill-typed file" || fail "t
 # is esbuild-based and does not touch that API, so it survives the 7.x line.
 # Verifying the replacement matters more than verifying the removal: without
 # this, dropping ts-node would be a claim rather than a checked fact.
-RESULT=$(run_in_container "d=\$(mktemp -d); printf 'const x: number = 2; console.log(\\"tsx-ok\\", x*2);\\n' > \$d/r.ts; tsx \$d/r.ts 2>/dev/null | grep -q 'tsx-ok 4' && echo OK || echo FAIL") || RESULT=""
-echo "$RESULT" | grep -q "OK" && pass "tsx executes a .ts file" || fail "tsx execution"
+#
+# stderr is NOT suppressed and the failure path echoes it. The first version of
+# this check sent stderr to /dev/null, so when it failed in the image the log
+# said only "FAIL: tsx execution" and the cause was invisible — a check that
+# hides why it failed costs more than it saves.
+RESULT=$(run_in_container "d=\$(mktemp -d); printf 'const x: number = 2; console.log(\\"tsx-ok\\", x*2);\\n' > \$d/r.ts; tsx \$d/r.ts 2>&1 | grep -q 'tsx-ok 4' && echo OK || { echo FAIL; tsx \$d/r.ts 2>&1 | head -3; }") || RESULT=""
+echo "$RESULT" | grep -q "OK" && pass "tsx executes a .ts file" || fail "tsx execution: $RESULT"
 
 # 3. ES Modules import
 echo ""

--- a/tests/test-docker-image.sh
+++ b/tests/test-docker-image.sh
@@ -78,6 +78,15 @@ echo "$RESULT" | grep -q "OK" && pass "tsc compiles a strict file" || fail "tsc 
 RESULT=$(run_in_container "d=\$(mktemp -d); printf 'const n: number = \\"nope\\";\\n' > \$d/b.ts; tsc --noEmit --strict \$d/b.ts >/dev/null 2>&1 && echo FAIL || echo OK") || RESULT=""
 echo "$RESULT" | grep -q "OK" && pass "tsc rejects an ill-typed file" || fail "tsc did not reject bad types"
 
+# tsx EXECUTES TypeScript. ts-node used to be the runner shipped here; it was
+# dropped because it consumes typescript's JS API, which TypeScript 7 removes
+# (require('typescript') returns only {version, versionMajorMinor} there). tsx
+# is esbuild-based and does not touch that API, so it survives the 7.x line.
+# Verifying the replacement matters more than verifying the removal: without
+# this, dropping ts-node would be a claim rather than a checked fact.
+RESULT=$(run_in_container "d=\$(mktemp -d); printf 'const x: number = 2; console.log(\\"tsx-ok\\", x*2);\\n' > \$d/r.ts; tsx \$d/r.ts 2>/dev/null | grep -q 'tsx-ok 4' && echo OK || echo FAIL") || RESULT=""
+echo "$RESULT" | grep -q "OK" && pass "tsx executes a .ts file" || fail "tsx execution"
+
 # 3. ES Modules import
 echo ""
 echo "[3/14] ES Modules import"

--- a/tests/test-docker-image.sh
+++ b/tests/test-docker-image.sh
@@ -78,19 +78,6 @@ echo "$RESULT" | grep -q "OK" && pass "tsc compiles a strict file" || fail "tsc 
 RESULT=$(run_in_container "d=\$(mktemp -d); printf 'const n: number = \\"nope\\";\\n' > \$d/b.ts; tsc --noEmit --strict \$d/b.ts >/dev/null 2>&1 && echo FAIL || echo OK") || RESULT=""
 echo "$RESULT" | grep -q "OK" && pass "tsc rejects an ill-typed file" || fail "tsc did not reject bad types"
 
-# tsx EXECUTES TypeScript. ts-node used to be the runner shipped here; it was
-# dropped because it consumes typescript's JS API, which TypeScript 7 removes
-# (require('typescript') returns only {version, versionMajorMinor} there). tsx
-# is esbuild-based and does not touch that API, so it survives the 7.x line.
-# Verifying the replacement matters more than verifying the removal: without
-# this, dropping ts-node would be a claim rather than a checked fact.
-#
-# stderr is NOT suppressed and the failure path echoes it. The first version of
-# this check sent stderr to /dev/null, so when it failed in the image the log
-# said only "FAIL: tsx execution" and the cause was invisible — a check that
-# hides why it failed costs more than it saves.
-RESULT=$(run_in_container "d=\$(mktemp -d); printf 'const x: number = 2; console.log(\\"tsx-ok\\", x*2);\\n' > \$d/r.ts; tsx \$d/r.ts 2>&1 | grep -q 'tsx-ok 4' && echo OK || { echo FAIL; tsx \$d/r.ts 2>&1 | head -3; }") || RESULT=""
-echo "$RESULT" | grep -q "OK" && pass "tsx executes a .ts file" || fail "tsx execution: $RESULT"
 
 # 3. ES Modules import
 echo ""


### PR DESCRIPTION
Unblocks #352 (typescript 5→7) by removing the package that makes it unmergeable.

## The blocker

TypeScript 7 is the native compiler and removes the JavaScript API:

```
$ npm i typescript@7.0.2
$ node -e "const ts=require('typescript'); console.log(Object.keys(ts), typeof ts.createProgram)"
[ 'version', 'versionMajorMinor' ] undefined
```

`ts-node@10` consumes that API. Reproduced with a real `.ts` file:

| typescript | ts-node |
|---|---|
| 7.0.2 | dies at `ts.sys.fileExists` in its own `configuration.js` |
| 5.9.3 (control) | runs |

## Why removal is the answer rather than a pin

`ts-node` is dead weight here:

- nothing in `skills/`, `computer-use-server/` or `openwebui/` invokes it
- the Dockerfile's comment lists the shipped CLI tools as `mmdc, tsc, tsx` — it is not among them
- it reaches the image only because `package.json` declares it, and the global install is driven straight off that file

`tsx` remains as the TypeScript runner: esbuild-based, no dependency on typescript's JS API, so it survives the 7.x line.

## Scope note — what this PR does NOT do

An earlier revision added an image check that **executed** a `.ts` file through `tsx`, to verify the replacement rather than assert it. It failed in the image twice and my diagnostics could not reach the cause from outside the container — the invocation produced no output at all, while the identical payload runs on the host with `rc=0`.

I pulled it out rather than ship a gate I do not understand, and filed **#426** with the reproduction steps and the candidate causes. So this PR is the removal on its own evidence; the `tsx` coverage is separate work for someone who can enter the image.

That leaves `tsx` verified only as present-in-PATH, which is the same state it was in before this PR — not a regression, but a gap now worth naming, since removing `ts-node` makes `tsx` the only runner.