### PR TITLE
chore(image-test): collapse the double blank line left by the revert

### DIFF
--- a/tests/test-docker-image.sh
+++ b/tests/test-docker-image.sh
@@ -78,7 +78,6 @@ echo "$RESULT" | grep -q "OK" && pass "tsc compiles a strict file" || fail "tsc 
 RESULT=$(run_in_container "d=\$(mktemp -d); printf 'const n: number = \\"nope\\";\\n' > \$d/b.ts; tsc --noEmit --strict \$d/b.ts >/dev/null 2>&1 && echo FAIL || echo OK") || RESULT=""
 echo "$RESULT" | grep -q "OK" && pass "tsc rejects an ill-typed file" || fail "tsc did not reject bad types"
 
-
 # 3. ES Modules import
 echo ""
 echo "[3/14] ES Modules import"


### PR DESCRIPTION
One line. Pulling the tsx check out of #425 left two consecutive blank lines where the file uses one. Noted in review of #425; fixing it here rather than letting it accumulate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * No user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->