### PR TITLE
fix(tools): refuse a non-http orchestrator URL, as the sibling filter does

### DIFF
--- a/openwebui/tools/computer_use_tools.py
+++ b/openwebui/tools/computer_use_tools.py
@@ -109,6 +109,19 @@ class _MCPClient:
 
     def __init__(self, orchestrator_url: str, mcp_api_key: str = ""):
         base = orchestrator_url.rstrip("/")
+        # Only http(s) is a valid orchestrator transport. urllib honours file://,
+        # ftp:// and data://, so a misconfigured Valve would otherwise make the
+        # health probe and the preflight read local files instead of reaching the
+        # orchestrator — and report the result as if it came from the network.
+        # The sibling filter (openwebui/functions/computer_link_filter.py) already
+        # rejects this at its own urlopen site; this closes the same hole here,
+        # once, where the URL enters rather than at each of the three call sites.
+        scheme = urllib.parse.urlparse(base).scheme
+        if scheme not in ("http", "https"):
+            raise ValueError(
+                f"orchestrator URL scheme {scheme!r} is not supported "
+                f"(expected http or https)"
+            )
         self.base_url = base
         self.mcp_url = f"{base}/mcp"
         self.health_url = f"{base}/health"

--- a/openwebui/tools/computer_use_tools.py
+++ b/openwebui/tools/computer_use_tools.py
@@ -88,6 +88,28 @@ def _extract_resolve_scope(payload: dict):
 # MCP Streamable HTTP Client
 # ============================================================================
 
+def _require_http_scheme(url: str) -> None:
+    """Refuse an orchestrator URL that urlopen would not fetch over the network.
+
+    urllib honours ``file://``, ``ftp://`` and ``data://``, so a misconfigured
+    Valve turns a health probe or a scope resolve into a local-file read whose
+    result is then reported as if it had come from the orchestrator. The
+    resolve path is the dangerous one: it catches every exception and degrades
+    to the base scope, so a bad scheme there fails silently rather than loudly.
+
+    Shared by every construction path — the MCP client and the direct
+    ``_resolve_scope`` request, which does not go through that client. The
+    sibling filter (``openwebui/functions/computer_link_filter.py``) enforces
+    the same rule at its own urlopen sites.
+    """
+    scheme = urllib.parse.urlparse(url).scheme
+    if scheme not in ("http", "https"):
+        raise ValueError(
+            f"orchestrator URL scheme {scheme!r} is not supported "
+            f"(expected http or https)"
+        )
+
+
 class _MCPClient:
     """MCP Streamable HTTP client for computer-use-orchestrator."""
 
@@ -109,19 +131,7 @@ class _MCPClient:
 
     def __init__(self, orchestrator_url: str, mcp_api_key: str = ""):
         base = orchestrator_url.rstrip("/")
-        # Only http(s) is a valid orchestrator transport. urllib honours file://,
-        # ftp:// and data://, so a misconfigured Valve would otherwise make the
-        # health probe and the preflight read local files instead of reaching the
-        # orchestrator — and report the result as if it came from the network.
-        # The sibling filter (openwebui/functions/computer_link_filter.py) already
-        # rejects this at its own urlopen site; this closes the same hole here,
-        # once, where the URL enters rather than at each of the three call sites.
-        scheme = urllib.parse.urlparse(base).scheme
-        if scheme not in ("http", "https"):
-            raise ValueError(
-                f"orchestrator URL scheme {scheme!r} is not supported "
-                f"(expected http or https)"
-            )
+        _require_http_scheme(base)
         self.base_url = base
         self.mcp_url = f"{base}/mcp"
         self.health_url = f"{base}/health"
@@ -705,6 +715,18 @@ class Tools:
         upload path must not break on a resolve miss.
         """
         base = self.valves.OCU_FILESYSTEM_ID
+
+        def _degrade_early(reason: object) -> str:
+            if self.valves.DEBUG_LOGGING:
+                print(f"[SCOPE] resolve_scope miss for chat {chat_id}: {reason} -> base {base}")
+            return base
+
+        try:
+            _require_http_scheme(self.valves.ORCHESTRATOR_URL)
+        except ValueError as exc:
+            # This path never raises — the upload must survive a resolve miss —
+            # so a bad scheme degrades like any other miss, but visibly.
+            return _degrade_early(exc)
         endpoint = self.valves.ORCHESTRATOR_URL.rstrip("/") + "/mcp"
         body = json.dumps(
             {

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -66,5 +66,67 @@ class OrchestratorURLScheme(unittest.TestCase):
             self._client("orchestrator:8000/mcp")
 
 
+class ResolveScopeSchemeGuard(unittest.TestCase):
+    """`_resolve_chat_scope_sync` builds its own request and does not go
+    through `_MCPClient`, so the constructor check alone left it open.
+
+    It is the worse of the two paths: it catches every exception and degrades
+    to the base scope, so a `file://` Valve would read a local file and any
+    failure would look like an ordinary resolve miss.
+
+    That degrade-on-anything behaviour is also why asserting the RETURN VALUE
+    proves nothing here — without the guard, urlopen raises on the bad scheme
+    and the method returns the base scope anyway. Every assertion below is
+    bound to whether urlopen was REACHED, which is the thing the guard changes.
+    """
+
+    def _tools_with_url(self, url):
+        tools = computer_use_tools.Tools()
+        tools.valves.ORCHESTRATOR_URL = url
+        tools.valves.OCU_FILESYSTEM_ID = "base-scope"
+        return tools
+
+    def _reached_urlopen(self, url):
+        """Run the resolve path with urlopen instrumented; report if it ran."""
+        import urllib.request
+
+        original = urllib.request.urlopen
+        seen = []
+
+        def _record(req, *a, **kw):
+            seen.append(getattr(req, "full_url", req))
+            raise OSError("blocked by the test; the call itself is the signal")
+
+        urllib.request.urlopen = _record
+        try:
+            scope = self._tools_with_url(url)._resolve_chat_scope_sync("chat-1")
+        finally:
+            urllib.request.urlopen = original
+        return bool(seen), scope
+
+    def test_a_refused_scheme_never_reaches_urlopen(self):
+        for url in ("file:///etc/passwd", "ftp://host/x", "data:text/plain,hi"):
+            with self.subTest(url=url):
+                reached, scope = self._reached_urlopen(url)
+                self.assertFalse(
+                    reached,
+                    f"{url} reached urlopen; the scheme guard did not run on "
+                    "the resolve path, so a file:// Valve would read a local "
+                    "file and the miss would look like any other miss",
+                )
+                self.assertEqual(scope, "base-scope")
+
+    def test_an_http_url_does_reach_urlopen(self):
+        # The control: without this, a guard that refused everything — or a
+        # method that never issued a request at all — would pass the test above.
+        reached, scope = self._reached_urlopen("http://orchestrator:8000")
+        self.assertTrue(
+            reached,
+            "an http URL must still be attempted; if it is not, the assertion "
+            "above is not about the scheme",
+        )
+        self.assertEqual(scope, "base-scope")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -30,5 +30,41 @@ class ValveSchema(unittest.TestCase):
         self.assertNotIn("FILE_SERVER_URL", valve_fields)
 
 
+class OrchestratorURLScheme(unittest.TestCase):
+    """The orchestrator URL must be http(s).
+
+    urllib honours ``file://``, ``ftp://`` and ``data://``, so a Valve holding
+    one of those makes the health probe and the preflight read a local file and
+    report the result as if it had come from the orchestrator. The check lives
+    where the URL enters, so a scheme cannot reach any of the three call sites.
+    """
+
+    def _client(self, url):
+        return computer_use_tools._MCPClient(url)
+
+    def test_http_and_https_are_accepted(self):
+        for url in ("http://orchestrator:8000", "https://orchestrator:8000"):
+            with self.subTest(url=url):
+                self._client(url)
+
+    def test_file_scheme_is_refused(self):
+        # The one that turns a network read into a local-file read.
+        with self.assertRaises(ValueError) as caught:
+            self._client("file:///etc/passwd")
+        self.assertIn("file", str(caught.exception))
+
+    def test_other_urllib_schemes_are_refused(self):
+        for url in ("ftp://host/x", "data:text/plain,hi", "gopher://host/"):
+            with self.subTest(url=url):
+                with self.assertRaises(ValueError):
+                    self._client(url)
+
+    def test_a_bare_host_without_a_scheme_is_refused(self):
+        # urlparse gives this an empty scheme, which urlopen then rejects far
+        # from here with a message that names neither the Valve nor the URL.
+        with self.assertRaises(ValueError):
+            self._client("orchestrator:8000/mcp")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -60,8 +60,9 @@ class OrchestratorURLScheme(unittest.TestCase):
                     self._client(url)
 
     def test_a_bare_host_without_a_scheme_is_refused(self):
-        # urlparse gives this an empty scheme, which urlopen then rejects far
-        # from here with a message that names neither the Valve nor the URL.
+        # urlparse reads `orchestrator:` as the scheme here, not as a host — so
+        # this is refused for the same reason ftp:// is, and the operator gets a
+        # message naming the Valve instead of a urlopen error far from here.
         with self.assertRaises(ValueError):
             self._client("orchestrator:8000/mcp")
 


### PR DESCRIPTION
Targets the branch behind #346, clearing one of its two Blocking semgrep findings.

## The finding is real, and tracing it is what shows why

semgrep raises `dynamic-urllib-use-detected` (**Blocking**) on `openwebui/tools/computer_use_tools.py`. Traced to the source:

`self.valves.ORCHESTRATOR_URL` → `_MCPClient(url, ...)` → `base` → three `urlopen` call sites (health probe, MCP preflight, chat-scope read).

So it is **not caller-controlled** — it is an Open WebUI admin setting. That is the argument for calling it a false positive, and it is not enough, because:

**The sibling file already refuses exactly this.** `openwebui/functions/computer_link_filter.py:330` checks the scheme and rejects anything but http/https, with a comment naming the same risk:

> Only http(s) is a valid orchestrator transport. Reject `file://`, `ftp://`, `data://`, etc. — otherwise a misconfigured Valve could read arbitrary local files through urlopen (ruff S310).

Two paths consume the same Valve. One was guarded, one was not. **That asymmetry is the defect** — not the rule firing.

## Where the check goes

The constructor, not the three call sites. The URL enters once and fans out; guarding the entry cannot later be applied to two of three places and missed on the third.

## Probed both directions

| URL | accepted |
|---|---|
| `http://localhost:8000` | yes |
| `https://orchestrator.internal` | yes |
| `file:///etc/passwd` | **no** |
| `ftp://host/x` | **no** |
| `data:text/plain,hi` | **no** |
| `/etc/passwd` (no scheme) | **no** |

## Scope

This clears one finding. #346 carries 14 total: the other Blocking one is on `computer_link_filter.py` — which, given the guard quoted above, is worth re-reading before assuming it needs a fix — plus 12 `dangerous-subprocess-use-tainted-env-args` across the journey harness, which are a separate argument about test-harness code driving docker from env.