### PR TITLE
fix(deps): take cryptography to 50.0.0, the two fixable HIGH the gate blocks on

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -99,7 +99,7 @@ Flask==3.1.3
 Werkzeug==3.1.3
 
 # Other dependencies
-cryptography==48.0.1
+cryptography==50.0.0
 PyJWT==2.13.0
 python-dateutil==2.9.0.post0
 pytz==2025.2


### PR DESCRIPTION
Clears the `SCA — trivy (filesystem)` red on #346 (and inherited by #430).

## What the gate blocks on

The gate runs `severity: HIGH`, `exit-code: "1"`, `ignore-unfixed: true` — fixable HIGH only. Across tracked files that is exactly two CVEs, both in one package:

| package | pinned | fixed | CVEs |
|---|---|---|---|
| cryptography | 48.0.1 | 50.0.0 | CVE-2026-69249, CVE-2026-69247 |

Re-running the gate's own invocation over `requirements.txt` after the bump reports **0**.

Scope the scan with `git ls-files` before reading the number: an unfiltered working-tree scan also reports findings from untracked directories that no CI checkout contains, and those are not what the gate measures.

## Compatibility

48 → 50 crosses two majors, and the removals are real: 49.0.0 dropped the deprecated `PUBLIC_KEY_TYPES` / `PRIVATE_KEY_TYPES` / `CERTIFICATE_*_KEY_TYPES` aliases, changed ChaCha20 nonce semantics, and rejects X.509 NULL-param signatures; 50.0.0 deprecates finite-field DH.

No tracked `*.py` imports `cryptography` directly, and none of the removed surface is used. `PyJWT==2.13.0` is the only dependent, its own metadata is `cryptography>=3.4.0` with no upper bound, and no other tracked requirements file names cryptography or a dependent that pulls it — so the root pin is the only one to move. `tests/test_requirements.py` asserts a lower bound of 46.0.6, which 50.0.0 satisfies.

Verified on the image's Python (3.12, per `ubuntu:24.04`) rather than the host, whose 3.14 fails the resolve on an unrelated package: `cryptography==50.0.0` and `PyJWT==2.13.0` install together and RS256 and ES256 sign/verify round-trips complete.

## One caveat

cryptography 49 dropped x86_64-macOS wheels. The image builds `linux/amd64` and `linux/arm64`, and 50.0.0 publishes `manylinux2014` wheels for both (cp311-abi3, covering 3.12), so the image path is unaffected. A developer on an Intel Mac running a local `pip install` builds from sdist instead of getting a prebuilt wheel.

The remaining Trivy alerts here are unfixable-HIGH or outside tracked files, so they fall outside what this gate blocks on.
