### PR TITLE
test(journeys): a walrus binds to its nearest scope, not to the whole subtree

### DIFF
--- a/deploy/tests/journeys/test_z_meta_guard.py
+++ b/deploy/tests/journeys/test_z_meta_guard.py
@@ -296,11 +296,24 @@ def _shell_hazard_sites(path: Path) -> list[tuple[int, str]]:
                         # A walrus in a comprehension binds outward (PEP 572),
                         # so its assignment belongs to THIS scope even though
                         # the comprehension owns its other names.
-                        for sub in ast.walk(child):
-                            if isinstance(sub, ast.NamedExpr) and isinstance(sub.target, ast.Name):
-                                built = _built_string(sub.value)
-                                if built is not None:
-                                    found[sub.target.id] = built
+                        def _walrus(node: ast.AST) -> None:
+                            for sub in ast.iter_child_nodes(node):
+                                # A walrus binds outward only as far as the
+                                # nearest scope: one written inside a nested
+                                # lambda or comprehension belongs to THAT
+                                # scope, so stop instead of sweeping the
+                                # whole subtree.
+                                if isinstance(sub, _SCOPES):
+                                    continue
+                                if isinstance(sub, ast.NamedExpr) and isinstance(
+                                    sub.target, ast.Name
+                                ):
+                                    built = _built_string(sub.value)
+                                    if built is not None:
+                                        found[sub.target.id] = built
+                                _walrus(sub)
+
+                        _walrus(child)
                     continue
                 if isinstance(child, ast.Assign):
                     built = _built_string(child.value)
@@ -663,6 +676,30 @@ def test_shell_hazard_guard_reds_on_planted_violations() -> None:
     assert sorted(ln for ln, _ in lambda_hits) == [8], (
         f"only line 8 reads the module's built string; every lambda above binds "
         f"`cmd` itself and passes its own argument. Got {lambda_hits!r}."
+    )
+
+    # A walrus binds outward only as far as the nearest scope. Sweeping the
+    # whole comprehension subtree collected one written inside a NESTED lambda
+    # and attributed it to the enclosing function, reding that function's clean
+    # list argv — the same over-collection as the nested-def leak.
+    walrus_scope = (
+        "import subprocess\n"
+        "def f(x):\n"
+        '    cmd = ["docker", "ps"]\n'
+        '    fns = [lambda: (cmd := f"rm {x}") for _ in range(1)]\n'
+        "    subprocess.run(cmd)\n"
+        "def g(x):\n"
+        '    data = [(cmd := f"rm {x}") for _ in range(1)]\n'
+        "    subprocess.run(cmd)\n"
+    )
+    with tempfile.TemporaryDirectory() as td:
+        f = Path(td) / "walrus_scope.py"
+        f.write_text(walrus_scope, encoding="utf-8")
+        walrus_hits = _shell_hazard_sites(f)
+    assert sorted(ln for ln, _ in walrus_hits) == [8], (
+        f"line 5 passes a list argv — the walrus on line 4 binds inside the "
+        f"lambda, not in `f` — while line 8 uses a name the comprehension's own "
+        f"walrus bound in `g`. Got {walrus_hits!r}."
     )
 
     clean = (


### PR DESCRIPTION
Follow-up to #430, from a review pass on the merged guard.

## The defect

The walrus collector swept the entire comprehension with `ast.walk`, so a `:=` written inside a **nested lambda** was attributed to the enclosing function and reddened that function's clean list argv:

```python
def f(x):
    cmd = ["docker", "ps"]
    fns = [lambda: (cmd := f"rm {x}") for _ in range(1)]
    subprocess.run(cmd)          # flagged, and clean
```

PEP 572 binds a walrus in the scope that contains it — inside a lambda that is the lambda, not the function. At runtime `cmd` is still `["docker", "ps"]`.

## The fix

The collector recurses through direct children and stops at every nested scope, the same pruning the nested-`def` fix applied. A walrus written in the comprehension itself still binds outward and is still caught, in both list and generator forms.

## Status

**Latent, not live.** The harness contains no walrus expression today, so the tree was 0-hit either way. It is worth closing because it is the same reds-on-the-safe-form failure the earlier scoping work drove out, and a guard that reds on the safe form forces the per-site waivers off instead of keeping them honest.

## Measured

- walrus inside a lambda: clean; walrus in the comprehension: caught; genexp form: caught; plain `if (cmd := ...)`: caught
- harness 32 passed / 1 skipped, semgrep tree 0
- mutation: restoring the subtree walk reds 14 cases

One note on method: my first mutation probe of this **failed to parse**, so its green measured a build error rather than the guard. Redone with the indentation preserved before the result was read.