### PR TITLE
fix(fleet): waive the visualiser's plain-HTTP listener, which is loopback-only

### DIFF
--- a/deploy/fleet/g7-visualizer/proxy.go
+++ b/deploy/fleet/g7-visualizer/proxy.go
@@ -236,10 +236,16 @@ func main() {
 	// Plain HTTP is deliberate here and only here. The compose service
 	// publishes this port as `127.0.0.1:8099:8099`, so the listener is
 	// reachable from the host loopback alone — never from the fleet network
-	// and never off-box. It serves a read-only visualiser over data the
-	// operator already has locally, and terminating TLS on a loopback port
-	// would mean shipping a cert nobody can validate. Would NOT hold the
-	// moment the published port drops its 127.0.0.1 prefix.
+	// and never off-box — and terminating TLS on a loopback port means
+	// shipping a cert nobody can validate.
+	//
+	// Read this together with what sits behind it: the handler forwards to
+	// the gateway over mTLS (TLS 1.3, client cert from /pki), so this port is
+	// an UNAUTHENTICATED front to an authenticated channel. That is tolerable
+	// only while the bind stays on loopback, where reaching it already means
+	// host access. Two things invalidate the waiver: the published port
+	// losing its 127.0.0.1 prefix, and any route here that is not safe for
+	// whoever holds a shell on the host.
 	// nosemgrep: go.lang.security.audit.net.use-tls.use-tls
 	log.Fatal(http.ListenAndServe(addr, mux))
 }

--- a/deploy/fleet/g7-visualizer/proxy.go
+++ b/deploy/fleet/g7-visualizer/proxy.go
@@ -233,6 +233,14 @@ func main() {
 
 	addr := envOr("LISTEN", ":8099")
 	log.Printf("g7-proxy: listening on %s → %s", addr, base)
+	// Plain HTTP is deliberate here and only here. The compose service
+	// publishes this port as `127.0.0.1:8099:8099`, so the listener is
+	// reachable from the host loopback alone — never from the fleet network
+	// and never off-box. It serves a read-only visualiser over data the
+	// operator already has locally, and terminating TLS on a loopback port
+	// would mean shipping a cert nobody can validate. Would NOT hold the
+	// moment the published port drops its 127.0.0.1 prefix.
+	// nosemgrep: go.lang.security.audit.net.use-tls.use-tls
 	log.Fatal(http.ListenAndServe(addr, mux))
 }
 


### PR DESCRIPTION
Clears the last red gate on #346.

## The finding

`SAST — semgrep` blocks on exactly one: `go.lang.security.audit.net.use-tls` against `http.ListenAndServe` in `deploy/fleet/g7-visualizer/proxy.go:236`.

## Why a waiver and not a fix

The rule cannot see the deployment, and the deployment is what makes it safe. The compose service publishes the port as:

```yaml
ports:
  - "127.0.0.1:8099:8099"
```

Loopback only — never the fleet network, never off-box. That is the sole exposure: no second compose file or override, no nginx or ingress forwarding to it, no k8s manifest, no Helm value, no `docker run` in a stand script. Terminating TLS on a loopback port means shipping a certificate nobody can validate.

## What sits behind the port

Worth stating plainly, because the first version of this waiver got it wrong. The service is **not** a read-only visualiser: the handler POSTs to the gateway over mTLS (TLS 1.3, client cert from `/pki`), so this plain-HTTP port is an **unauthenticated front to an authenticated channel**.

That does not make the waiver false — reaching a loopback port already means host access — but it is the fact a reviewer needs, so the comment states it rather than the softer claim. Two conditions invalidate the waiver, and both are written at the line: the published port losing its `127.0.0.1` prefix, and any route here that is not safe for whoever holds a shell on the host.

## Per-line, not a rule disable

A second plain-HTTP listener added later fires fresh instead of being silently pre-exempted. Verified: the finding goes **1 → 0** with the waiver and returns to **1** when it is removed.

One note: `gofmt` reports this file as unformatted, from a stray blank line at 294 that predates this change. Left alone — it is not this diff's line.
