### PR TITLE
fix(fleet): take the unauthenticated exec surface off the shared frontend bridge

### DIFF
--- a/deploy/fleet/docker-compose.fleet.yml
+++ b/deploy/fleet/docker-compose.fleet.yml
@@ -28,6 +28,12 @@ name: ocu-fleet
 networks:
   ocu-frontend:
     driver: bridge
+  # g7-visualizer serves an UNAUTHENTICATED /api/* that drives real
+  # create/exec/destroy through its gateway mTLS cert. It must not share
+  # a bridge with the web tier, which processes untrusted input: a
+  # loopback `ports:` publish does not restrict in-network callers.
+  ocu-g7:
+    driver: bridge
   ocu-north:
     driver: bridge
   ocu-mount-facing:
@@ -820,6 +826,9 @@ services:
     networks:
       - ocu-frontend
       - ocu-state
+      # Reachable from the g7 visualiser, which no longer shares the frontend
+      # bridge with the web tier.
+      - ocu-g7
     user: "65532:65532"
     # Control runs as uid 65532 with a read-only rootfs, so it must JOIN the
     # group that owns the Docker socket to read it for the per-session container
@@ -1181,7 +1190,7 @@ services:
     ports:
       - "127.0.0.1:8099:8099"
     networks:
-      - ocu-frontend
+      - ocu-g7
     read_only: true
     cap_drop: [ALL]
     security_opt:

--- a/deploy/fleet/g7-visualizer/proxy.go
+++ b/deploy/fleet/g7-visualizer/proxy.go
@@ -233,19 +233,22 @@ func main() {
 
 	addr := envOr("LISTEN", ":8099")
 	log.Printf("g7-proxy: listening on %s → %s", addr, base)
-	// Plain HTTP is deliberate here and only here. The compose service
-	// publishes this port as `127.0.0.1:8099:8099`, so the listener is
-	// reachable from the host loopback alone — never from the fleet network
-	// and never off-box — and terminating TLS on a loopback port means
-	// shipping a cert nobody can validate.
+	// Plain HTTP on this listener, and what actually contains it.
 	//
-	// Read this together with what sits behind it: the handler forwards to
-	// the gateway over mTLS (TLS 1.3, client cert from /pki), so this port is
-	// an UNAUTHENTICATED front to an authenticated channel. That is tolerable
-	// only while the bind stays on loopback, where reaching it already means
-	// host access. Two things invalidate the waiver: the published port
-	// losing its 127.0.0.1 prefix, and any route here that is not safe for
-	// whoever holds a shell on the host.
+	// Do not read this as "it is only a visualiser": `/api/create`, `/api/exec`,
+	// `/api/tool` and `/api/destroy` take no inbound credential and drive the
+	// real chain through the gateway mTLS client cert this process holds. Anything
+	// that can open a socket here acts with that cert and none of its own.
+	//
+	// Two compose properties contain it, and `deploy/tests/test_fleet_g7_isolation.py`
+	// reds if either is lost:
+	//   - the port publishes as `127.0.0.1:8099:8099`, so it is not offered off-box;
+	//   - the service shares a bridge with control ALONE. A `ports:` publish does
+	//     not restrict in-network callers, so sharing the frontend bridge would
+	//     hand these routes to the web tier, which processes untrusted input.
+	//
+	// TLS on this hop would encrypt a channel whose real exposure is authorisation,
+	// not eavesdropping; the containment above is what the rule cannot see.
 	// nosemgrep: go.lang.security.audit.net.use-tls.use-tls
 	log.Fatal(http.ListenAndServe(addr, mux))
 }

--- a/deploy/tests/test_fleet_g7_isolation.py
+++ b/deploy/tests/test_fleet_g7_isolation.py
@@ -28,9 +28,11 @@ _COMPOSE = (
     Path(__file__).resolve().parents[1] / "fleet" / "docker-compose.fleet.yml"
 )
 
-# Services that handle untrusted input and must never share a bridge with the
-# unauthenticated exec surface.
-_WEB_TIER = {"open-webui", "webui", "embed-portal", "admin", "mcp-gateway"}
+# The ONLY service allowed to share a bridge with the unauthenticated exec
+# surface. An allowlist rather than a denylist of web-tier names: a denylist
+# passes silently the moment a service is renamed or a new one is added, which
+# is exactly how this containment would be lost.
+_ALLOWED_CO_TENANTS = {"control"}
 
 
 def _doc() -> dict:
@@ -48,22 +50,23 @@ def test_the_visualiser_publishes_on_loopback_only() -> None:
         )
 
 
-def test_the_visualiser_shares_no_bridge_with_the_web_tier() -> None:
+def test_the_visualiser_shares_a_bridge_with_control_alone() -> None:
     doc = _doc()
     g7 = set(doc["services"]["g7-visualizer"].get("networks") or [])
     assert g7, "g7-visualizer declares no network; this guard would be vacuous"
 
-    for name in sorted(_WEB_TIER):
-        svc = doc["services"].get(name)
-        if svc is None:
-            continue
-        shared = g7 & set(svc.get("networks") or [])
-        assert not shared, (
-            f"g7-visualizer and {name} share {sorted(shared)}. The loopback "
-            "publish does not restrict in-network callers, so {name} could "
-            "POST /api/exec in cleartext and execute in a live guest using the "
-            "proxy's mTLS cert, with no credential of its own."
-        )
+    co_tenants = {
+        name
+        for name, svc in doc["services"].items()
+        if name != "g7-visualizer" and g7 & set(svc.get("networks") or [])
+    }
+    unexpected = co_tenants - _ALLOWED_CO_TENANTS
+    assert not unexpected, (
+        f"{sorted(unexpected)} share a bridge with g7-visualizer. The loopback "
+        "publish does not restrict in-network callers, so each of these could "
+        "POST /api/exec in cleartext and run an arbitrary argv in a live guest "
+        "under the proxy's mTLS cert, holding no credential of its own."
+    )
 
 
 def test_the_visualiser_still_reaches_control() -> None:

--- a/deploy/tests/test_fleet_g7_isolation.py
+++ b/deploy/tests/test_fleet_g7_isolation.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+"""g7-visualizer network-isolation guard.
+
+The visualiser serves `/api/create`, `/api/exec`, `/api/tool` and
+`/api/destroy` over plain HTTP with NO inbound authentication, and it holds the
+gateway mTLS client credential, so every one of those routes drives a real
+create/exec/destroy in a live guest using the proxy's cert. Anything that can
+open a TCP connection to it is a confused deputy.
+
+Two properties keep that contained, and neither is self-evident from reading
+the service:
+
+- the published port keeps its `127.0.0.1:` prefix, so the host does not offer
+  it off-box;
+- the service shares a bridge with control ALONE. A `ports:` publish says
+  nothing about in-network callers, so putting it back on the frontend bridge
+  would hand `/api/exec` to the web tier, which processes untrusted input.
+
+These are asserted here because a compose edit is exactly how they get lost.
+"""
+
+from pathlib import Path
+
+import yaml
+
+_COMPOSE = (
+    Path(__file__).resolve().parents[1] / "fleet" / "docker-compose.fleet.yml"
+)
+
+# Services that handle untrusted input and must never share a bridge with the
+# unauthenticated exec surface.
+_WEB_TIER = {"open-webui", "webui", "embed-portal", "admin", "mcp-gateway"}
+
+
+def _doc() -> dict:
+    return yaml.safe_load(_COMPOSE.read_text(encoding="utf-8"))
+
+
+def test_the_visualiser_publishes_on_loopback_only() -> None:
+    ports = _doc()["services"]["g7-visualizer"].get("ports", [])
+    assert ports, "g7-visualizer publishes no port; this guard would be vacuous"
+    for entry in ports:
+        assert str(entry).startswith("127.0.0.1:"), (
+            f"g7-visualizer publishes {entry!r} without a 127.0.0.1 prefix, so "
+            "an unauthenticated /api/exec that runs arbitrary argv in a live "
+            "guest is offered on every host interface"
+        )
+
+
+def test_the_visualiser_shares_no_bridge_with_the_web_tier() -> None:
+    doc = _doc()
+    g7 = set(doc["services"]["g7-visualizer"].get("networks") or [])
+    assert g7, "g7-visualizer declares no network; this guard would be vacuous"
+
+    for name in sorted(_WEB_TIER):
+        svc = doc["services"].get(name)
+        if svc is None:
+            continue
+        shared = g7 & set(svc.get("networks") or [])
+        assert not shared, (
+            f"g7-visualizer and {name} share {sorted(shared)}. The loopback "
+            "publish does not restrict in-network callers, so {name} could "
+            "POST /api/exec in cleartext and execute in a live guest using the "
+            "proxy's mTLS cert, with no credential of its own."
+        )
+
+
+def test_the_visualiser_still_reaches_control() -> None:
+    # The isolation is only correct if it does not also break the one hop the
+    # service needs; otherwise a green suite would hide a dead visualiser.
+    doc = _doc()
+    g7 = set(doc["services"]["g7-visualizer"].get("networks") or [])
+    control = set(doc["services"]["control"].get("networks") or [])
+    assert g7 & control, (
+        "g7-visualizer shares no network with control, so it cannot reach the "
+        f"gateway it proxies to (g7={sorted(g7)}, control={sorted(control)})"
+    )


### PR DESCRIPTION
Corrects #433, which I merged on a false premise.

## What was wrong

That waiver said the visualiser is "reachable from the host loopback alone — never from the fleet network". The first clause is true; **the second was false**. The `ports:` publish is `127.0.0.1:8099:8099`, but the service sat on `ocu-frontend` — a plain bridge (`driver: bridge`, no `internal: true`) shared with `open-webui`, `webui`, `embed-portal`, `admin` and `mcp-gateway`. A published port governs host exposure, not in-network reachability, so every co-tenant could reach it.

## Why that mattered

| route | takes a credential? | what it does |
|---|---|---|
| `/api/create` | no | creates a real gVisor session |
| `/api/exec` | no | runs an arbitrary argv in the live guest |
| `/api/tool` | no | bash / create_file / str_replace in the guest |
| `/api/destroy` | no | destroys sessions |

There is no `Authorization` check, no token, no header check anywhere on the inbound side — I grepped for all of them. The process holds the gateway mTLS client cert (`/pki/client.pem`), so any co-tenant could POST an arbitrary argv in cleartext and have it executed under that cert with no credential of its own. `open-webui` processes untrusted agent and user input and was one of those co-tenants.

## The fix

g7 moves to a dedicated `ocu-g7` bridge shared with `control` alone — the only hop it needs (`GATEWAY_URL` defaults to `https://control:9466`). The web tier can no longer address it at all.

The `use-tls` waiver stays, because the rule still cannot see a deployment, but its stated reason is replaced: the containment is the network isolation, and the exposure on this hop is **authorisation, not eavesdropping**. TLS here would encrypt a channel whose problem was never confidentiality.

## Enforced, not asserted

`deploy/tests/test_fleet_g7_isolation.py` makes all three properties mechanical, which is what #433 was missing — it asserted a precondition nothing checked:

- the published port keeps its `127.0.0.1:` prefix
- g7 shares no bridge with any web-tier service
- g7 still shares a network with control — so the isolation cannot pass by breaking the service

Mutation-checked: each reds on its own violation (put g7 back on `ocu-frontend`; drop the loopback prefix; remove control from `ocu-g7`).

## Not addressed here

The `/api/*` surface is still unauthenticated. Network isolation contains it for this deployment; it is not a substitute for an inbound credential. That is a larger change than this correction, and it belongs to whoever owns the demo surface.