### PR TITLE
feat(sandbox): address sandbox services by published port, not container IP

### DIFF
--- a/computer-use-server/app.py
+++ b/computer-use-server/app.py
@@ -32,7 +32,9 @@ from pydantic import BaseModel, Field
 
 from system_prompt import SYSTEM_PROMPT_TEMPLATE, build_system_prompt, render_system_prompt
 from docker_manager import (
-    get_container_cdp_address,
+    get_container_service_address,
+    CDP_PORT,
+    TTYD_PORT,
     PUBLIC_BASE_URL,
     warn_if_public_base_url_is_default,
     warn_if_mcp_api_key_missing,
@@ -634,14 +636,14 @@ async def browser_status(chat_id: str, response: Response):
     """Check if browser (Chromium CDP) is running in the chat's container."""
     chat_id = sanitize_chat_id(chat_id)
     response.headers["Cache-Control"] = "no-cache, no-store"
-    container_ip = get_container_cdp_address(chat_id)
-    if not container_ip:
+    container_addr = get_container_service_address(chat_id, CDP_PORT)
+    if not container_addr:
         return {"active": False, "pages": []}
 
     try:
         async with aiohttp.ClientSession() as session:
             async with session.get(
-                f"http://{container_ip}:9222/json",
+                f"http://{container_addr}/json",
                 timeout=aiohttp.ClientTimeout(total=2)
             ) as resp:
                 pages = await resp.json()
@@ -661,14 +663,14 @@ async def browser_status(chat_id: str, response: Response):
 async def browser_cdp_json(chat_id: str):
     """Proxy CDP /json endpoint from container."""
     chat_id = sanitize_chat_id(chat_id)
-    container_ip = get_container_cdp_address(chat_id)
-    if not container_ip:
+    container_addr = get_container_service_address(chat_id, CDP_PORT)
+    if not container_addr:
         raise HTTPException(404, "Container not found or not running")
 
     try:
         async with aiohttp.ClientSession() as session:
             async with session.get(
-                f"http://{container_ip}:9222/json",
+                f"http://{container_addr}/json",
                 timeout=aiohttp.ClientTimeout(total=3)
             ) as resp:
                 return await resp.json()
@@ -680,14 +682,14 @@ async def browser_cdp_json(chat_id: str):
 async def browser_cdp_json_version(chat_id: str):
     """Proxy CDP /json/version endpoint from container."""
     chat_id = sanitize_chat_id(chat_id)
-    container_ip = get_container_cdp_address(chat_id)
-    if not container_ip:
+    container_addr = get_container_service_address(chat_id, CDP_PORT)
+    if not container_addr:
         raise HTTPException(404, "Container not found or not running")
 
     try:
         async with aiohttp.ClientSession() as session:
             async with session.get(
-                f"http://{container_ip}:9222/json/version",
+                f"http://{container_addr}/json/version",
                 timeout=aiohttp.ClientTimeout(total=3)
             ) as resp:
                 return await resp.json()
@@ -699,14 +701,14 @@ async def browser_cdp_json_version(chat_id: str):
 async def browser_ws_proxy(websocket: WebSocket, chat_id: str, page_id: str):
     """Bidirectional WebSocket proxy for CDP — connects browser viewer to container's Chromium."""
     chat_id = sanitize_chat_id(chat_id)
-    container_ip = get_container_cdp_address(chat_id)
-    if not container_ip:
+    container_addr = get_container_service_address(chat_id, CDP_PORT)
+    if not container_addr:
         await websocket.close(code=1008, reason="Container not found")
         return
 
     await websocket.accept()
 
-    backend_url = f"ws://{container_ip}:9222/devtools/page/{page_id}"
+    backend_url = f"ws://{container_addr}/devtools/page/{page_id}"
 
     try:
         async with aiohttp.ClientSession() as session:
@@ -798,8 +800,8 @@ async def terminal_status(chat_id: str, response: Response):
     """Check if ttyd terminal is available in the chat's container."""
     chat_id = sanitize_chat_id(chat_id)
     response.headers["Cache-Control"] = "no-cache, no-store"
-    container_ip = get_container_cdp_address(chat_id)
-    if not container_ip:
+    container_addr = get_container_service_address(chat_id, TTYD_PORT)
+    if not container_addr:
         # Check if container exists but is stopped
         container = _get_container_stopped(chat_id)
         if container:
@@ -812,7 +814,7 @@ async def terminal_status(chat_id: str, response: Response):
     try:
         async with aiohttp.ClientSession() as session:
             async with session.get(
-                f"http://{container_ip}:7681/",
+                f"http://{container_addr}/",
                 timeout=aiohttp.ClientTimeout(total=2)
             ) as resp:
                 return {"active": resp.status == 200}
@@ -1069,14 +1071,14 @@ async def terminal_heartbeat(chat_id: str):
 async def terminal_ws_proxy(websocket: WebSocket, chat_id: str):
     """Bidirectional WebSocket proxy — connects xterm.js to container's ttyd."""
     chat_id = sanitize_chat_id(chat_id)
-    container_ip = get_container_cdp_address(chat_id)
-    if not container_ip:
+    container_addr = get_container_service_address(chat_id, TTYD_PORT)
+    if not container_addr:
         await websocket.close(code=1008, reason="Container not found")
         return
 
     await websocket.accept(subprotocol="tty")
 
-    backend_url = f"ws://{container_ip}:7681/ws"
+    backend_url = f"ws://{container_addr}/ws"
 
     try:
         async with aiohttp.ClientSession() as session:

--- a/computer-use-server/docker_manager.py
+++ b/computer-use-server/docker_manager.py
@@ -62,6 +62,11 @@ PUBLIC_BASE_URL = (os.getenv("PUBLIC_BASE_URL") or PUBLIC_BASE_URL_DEFAULT).rstr
 CONTAINER_IDLE_TIMEOUT = int(os.getenv("CONTAINER_IDLE_TIMEOUT", "600"))
 DEBUG_LOGGING = os.getenv("DEBUG_LOGGING", "false").lower() == "true"
 ORCHESTRATOR_CONTAINER_NAME = os.getenv("ORCHESTRATOR_CONTAINER_NAME", "computer-use-server")
+# Service ports INSIDE the sandbox. Fixed by the workspace image; only the host side of each
+# mapping varies, and the container engine assigns that.
+CDP_PORT = int(os.getenv("CDP_PORT", "9222"))    # Chrome DevTools
+TTYD_PORT = int(os.getenv("TTYD_PORT", "7681"))  # web terminal
+SANDBOX_PUBLISHED_PORTS = (CDP_PORT, TTYD_PORT)
 BASE_DATA_DIR = Path(os.getenv("BASE_DATA_DIR", "/data"))
 
 # MCP Tokens Wrapper for GitLab token fetching
@@ -418,8 +423,40 @@ def _get_compose_network_name(force_refresh: bool = False) -> Optional[str]:
     return None
 
 
-def get_container_cdp_address(chat_id: str) -> Optional[str]:
-    """Get the IP address of a chat's container on the compose network (for CDP proxy).
+def _published_address(container, container_port: int) -> Optional[str]:
+    """Host-side address of a published container port, if it has one.
+
+    Works identically on Docker and Podman: both report the mapping under
+    NetworkSettings.Ports as {"9222/tcp": [{"HostIp": ..., "HostPort": ...}]}. Returns None when
+    the port is not published, which is the case for containers created before this was introduced.
+
+    An empty or 0.0.0.0 HostIp is normalised to 127.0.0.1 — the orchestrator shares a network
+    namespace with the engine, so loopback is both correct and the narrower target.
+    """
+    ports = (container.attrs.get("NetworkSettings") or {}).get("Ports") or {}
+    for binding in ports.get(f"{container_port}/tcp") or []:
+        host_port = binding.get("HostPort")
+        if not host_port:
+            continue
+        host_ip = binding.get("HostIp") or "127.0.0.1"
+        if host_ip in ("0.0.0.0", "::", ""):
+            host_ip = "127.0.0.1"
+        return f"{host_ip}:{host_port}"
+    return None
+
+
+def get_container_service_address(chat_id: str, container_port: int) -> Optional[str]:
+    """Address to reach one of a chat container's services, as "host:port".
+
+    Two strategies, in order:
+
+    1. The published host port (NetworkSettings.Ports). This is the only one that works on rootless
+       Podman, where containers have no routable per-container IP, and it works on Docker too.
+       Note the host port is NOT the container port — the engine assigns it — so callers must use
+       the returned string whole rather than appending a port of their own.
+    2. The container's IP on the shared network, with `container_port` appended. Used for
+       containers created before ports were published, so an upgrade does not strand sandboxes
+       that are already running.
 
     After deploy (docker-compose down/up), running containers may still be on the
     old compose network with an unreachable IP. This function detects the mismatch
@@ -435,14 +472,21 @@ def get_container_cdp_address(chat_id: str) -> Optional[str]:
         if c.status != "running":
             return None
 
+        published = _published_address(c, container_port)
+        if published:
+            return published
+
         compose_net = _get_compose_network_name()
         networks = c.attrs["NetworkSettings"]["Networks"]
 
+        # Legacy path: reach the container by IP on the shared network. Each branch appends the
+        # port itself, because this function's contract is "host:port" — a bare IP here would
+        # silently produce a URL with no port at the call sites.
         # If container is on the current compose network, use that IP
         if compose_net and compose_net in networks:
             ip = networks[compose_net].get("IPAddress")
             if ip:
-                return ip
+                return f"{ip}:{container_port}"
 
         # Container running but NOT on compose network → fix and retry
         if compose_net and compose_net not in networks:
@@ -453,16 +497,26 @@ def get_container_cdp_address(chat_id: str) -> Optional[str]:
             if compose_net in networks:
                 ip = networks[compose_net].get("IPAddress")
                 if ip:
-                    return ip
+                    return f"{ip}:{container_port}"
 
         # Fallback: first non-bridge IP
         for net_name, net_data in networks.items():
             if net_name != "bridge" and net_data.get("IPAddress"):
-                return net_data["IPAddress"]
+                return f"{net_data['IPAddress']}:{container_port}"
         ip = c.attrs["NetworkSettings"]["IPAddress"]
-        return ip if ip else None
+        return f"{ip}:{container_port}" if ip else None
     except Exception:
         return None
+
+
+def get_container_cdp_address(chat_id: str) -> Optional[str]:
+    """Deprecated: use get_container_service_address(chat_id, CDP_PORT).
+
+    Kept because the old name was importable and the behaviour is unchanged for CDP. Note the
+    return value is now "host:port" rather than a bare host — callers that appended ":9222"
+    themselves must stop doing so.
+    """
+    return get_container_service_address(chat_id, CDP_PORT)
 
 
 def _fix_dead_networks(client, container):
@@ -667,6 +721,18 @@ def _create_container(chat_id: str, container_name: str) -> docker.models.contai
 
     if not ENABLE_NETWORK:
         config["network_disabled"] = True
+    else:
+        # Publish the sandbox's service ports on engine-assigned host ports.
+        #
+        # The orchestrator proxies Chrome DevTools and the web terminal to the browser. Historically
+        # it reached the container by IP on a shared bridge network, which only exists when every
+        # sandbox lives in one network namespace — true for Docker-in-Docker, not for rootless
+        # Podman, where containers get no routable per-container address.
+        #
+        # Publishing works on both engines and needs no bookkeeping here: passing None lets the
+        # engine pick a free host port, read back from NetworkSettings.Ports when an address is
+        # resolved. The engine is the ledger.
+        config["ports"] = {f"{port}/tcp": None for port in SANDBOX_PUBLISHED_PORTS}
 
     try:
         container = client.containers.create(**config)

--- a/computer-use-server/mcp_tools.py
+++ b/computer-use-server/mcp_tools.py
@@ -147,7 +147,7 @@ def _get_default_chat_warning() -> str:
 
 # Docker management extracted to docker_manager.py
 from docker_manager import (
-    get_docker_client, get_container_cdp_address,
+    get_docker_client, get_container_service_address,
     _get_or_create_container, _execute_bash, execute_bash_streaming, _execute_python_with_stdin,
     _reset_shutdown_timer, _get_compose_network_name,
     build_mcp_config, build_mcp_config_write_script,

--- a/tests/orchestrator/test_sandbox_addressing.py
+++ b/tests/orchestrator/test_sandbox_addressing.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+"""Tests for resolving a sandbox service address across container engines.
+
+The orchestrator proxies Chrome DevTools (9222) and the web terminal (7681) from the browser to a
+sandbox container. How it reaches that container differs by engine:
+
+- Docker-in-Docker: every sandbox shares one network namespace, so a bridge network with routable
+  per-container IPs exists and the container can be addressed directly.
+- Rootless Podman: no shared bridge, no routable per-container address. The only portable handle
+  is a published host port, which the engine assigns.
+
+Publishing ports works on both, so it is the primary path, with the IP lookup kept as a fallback
+for containers created before publishing was introduced — an upgrade must not strand a running
+sandbox.
+
+Run: cd computer-use-server && python -m pytest ../tests/orchestrator/test_sandbox_addressing.py -v
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'computer-use-server'))
+
+import docker_manager
+from docker_manager import (
+    _published_address,
+    get_container_service_address,
+    CDP_PORT,
+    TTYD_PORT,
+)
+
+
+def _container(attrs, status="running"):
+    c = MagicMock()
+    c.attrs = attrs
+    c.status = status
+    c.reload = MagicMock()
+    return c
+
+
+class PublishedAddressTests(unittest.TestCase):
+    """_published_address reads the engine's own port mapping."""
+
+    def test_returns_host_port_when_published(self):
+        c = _container({"NetworkSettings": {"Ports": {
+            "9222/tcp": [{"HostIp": "127.0.0.1", "HostPort": "49153"}],
+        }}})
+        self.assertEqual(_published_address(c, 9222), "127.0.0.1:49153")
+
+    def test_host_port_differs_from_container_port(self):
+        """The engine assigns the host side; callers must not assume they match."""
+        c = _container({"NetworkSettings": {"Ports": {
+            "9222/tcp": [{"HostIp": "127.0.0.1", "HostPort": "32768"}],
+        }}})
+        self.assertNotIn(":9222", _published_address(c, 9222))
+
+    def test_wildcard_host_ip_is_narrowed_to_loopback(self):
+        """0.0.0.0 means "all interfaces"; the orchestrator only needs loopback."""
+        for wildcard in ("0.0.0.0", "::", ""):
+            c = _container({"NetworkSettings": {"Ports": {
+                "7681/tcp": [{"HostIp": wildcard, "HostPort": "40000"}],
+            }}})
+            self.assertEqual(_published_address(c, 7681), "127.0.0.1:40000")
+
+    def test_ports_are_resolved_independently(self):
+        """CDP and the terminal get different host ports and must not be confused."""
+        c = _container({"NetworkSettings": {"Ports": {
+            "9222/tcp": [{"HostIp": "127.0.0.1", "HostPort": "49153"}],
+            "7681/tcp": [{"HostIp": "127.0.0.1", "HostPort": "49154"}],
+        }}})
+        self.assertEqual(_published_address(c, CDP_PORT), "127.0.0.1:49153")
+        self.assertEqual(_published_address(c, TTYD_PORT), "127.0.0.1:49154")
+
+    def test_returns_none_when_not_published(self):
+        for ports in ({}, {"9222/tcp": None}, {"9222/tcp": []}):
+            c = _container({"NetworkSettings": {"Ports": ports}})
+            self.assertIsNone(_published_address(c, 9222))
+
+    def test_survives_a_missing_networksettings(self):
+        self.assertIsNone(_published_address(_container({}), 9222))
+
+
+class ServiceAddressTests(unittest.TestCase):
+    """get_container_service_address prefers the published port, falls back to the IP."""
+
+    def setUp(self):
+        self.client = MagicMock()
+        patcher = patch.object(docker_manager, "get_docker_client", return_value=self.client)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_published_port_wins_over_the_network_ip(self):
+        """A container with both must use the port — the IP may be unroutable under Podman."""
+        self.client.containers.get.return_value = _container({"NetworkSettings": {
+            "Ports": {"9222/tcp": [{"HostIp": "127.0.0.1", "HostPort": "49153"}]},
+            "Networks": {"compose_default": {"IPAddress": "172.18.0.5"}},
+            "IPAddress": "",
+        }})
+        with patch.object(docker_manager, "_get_compose_network_name", return_value="compose_default"):
+            self.assertEqual(get_container_service_address("chat-1", CDP_PORT), "127.0.0.1:49153")
+
+    def test_falls_back_to_network_ip_with_the_container_port(self):
+        """Pre-existing containers have no published port; the old path still has to work."""
+        self.client.containers.get.return_value = _container({"NetworkSettings": {
+            "Ports": {},
+            "Networks": {"compose_default": {"IPAddress": "172.18.0.5"}},
+            "IPAddress": "",
+        }})
+        with patch.object(docker_manager, "_get_compose_network_name", return_value="compose_default"):
+            self.assertEqual(
+                get_container_service_address("chat-1", CDP_PORT), "172.18.0.5:9222"
+            )
+
+    def test_fallback_uses_the_requested_port_not_a_hardcoded_one(self):
+        """The terminal and CDP share this resolver; a hardcoded 9222 would break the terminal."""
+        self.client.containers.get.return_value = _container({"NetworkSettings": {
+            "Ports": {},
+            "Networks": {"compose_default": {"IPAddress": "172.18.0.5"}},
+            "IPAddress": "",
+        }})
+        with patch.object(docker_manager, "_get_compose_network_name", return_value="compose_default"):
+            self.assertEqual(
+                get_container_service_address("chat-1", TTYD_PORT), "172.18.0.5:7681"
+            )
+
+    def test_returns_none_when_the_container_is_not_running(self):
+        self.client.containers.get.return_value = _container(
+            {"NetworkSettings": {"Ports": {}, "Networks": {}}}, status="exited"
+        )
+        self.assertIsNone(get_container_service_address("chat-1", CDP_PORT))
+
+    def test_returns_none_when_the_container_is_absent(self):
+        self.client.containers.get.side_effect = Exception("no such container")
+        self.assertIsNone(get_container_service_address("chat-1", CDP_PORT))
+
+    def test_published_port_works_without_any_network(self):
+        """Rootless Podman: no compose network at all, only the published port."""
+        self.client.containers.get.return_value = _container({"NetworkSettings": {
+            "Ports": {"7681/tcp": [{"HostIp": "0.0.0.0", "HostPort": "45000"}]},
+            "Networks": {},
+            "IPAddress": "",
+        }})
+        with patch.object(docker_manager, "_get_compose_network_name", return_value=None):
+            self.assertEqual(
+                get_container_service_address("chat-1", TTYD_PORT), "127.0.0.1:45000"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Makes the orchestrator work on **rootless Podman as well as Docker**, without choosing between them.

## Why

The orchestrator proxies Chrome DevTools (9222) and the web terminal (7681) from the browser into a sandbox container. It reached them by the container's IP on a shared bridge network — which only exists when every sandbox lives in one network namespace. That holds for Docker-in-Docker and does **not** hold for rootless Podman, where containers have no routable per-container address at all.

## What changed

Sandboxes now publish both ports. The engine assigns the host side and reports it under `NetworkSettings.Ports`, identically on both engines — so no port bookkeeping is needed in the app. The engine is the ledger.

`get_container_cdp_address` became `get_container_service_address(chat_id, port)`, because the same resolver serves CDP **and** the terminal. That distinction was load-bearing and easy to miss: two call sites append `:7681`, so a CDP-only resolver would have silently broken the terminal. The old name remains as a thin alias.

The return value is now `"host:port"` rather than a bare host, since the published host port is **not** the container port. All six call sites in `app.py` were updated to stop appending a port of their own.

The IP path is kept as a fallback, so upgrading does not strand sandboxes that are already running without published ports.

## Testing

Run against the **real Docker SDK 7.1.0 inside the running orchestrator image**, not a local stub — 12 cases: published-port resolution, per-port independence (CDP vs terminal), wildcard host-IP narrowing to loopback, the IP fallback using the requested port, and Podman's no-network case.

```
12 passed in 0.28s
```

`test_docker_manager.py` has 3 pre-existing failures; verified they fail identically on unmodified `main`, so they are not from this change.

## Not included

Nothing here removes Docker-in-Docker — this only makes the addressing portable. Switching the deployment to Podman is a separate chart change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved browser and terminal connectivity across sandbox environments.
  - Added support for independently configured browser and terminal service ports.
  - Sandbox services can now use published host ports or network-based fallback connections.
  - Services remain accessible even when network attachment is unavailable.

- **Bug Fixes**
  - Resolved connection issues caused by fixed ports and container IP routing.

- **Tests**
  - Added coverage for published ports, fallback addressing, unavailable containers, and separate service ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->