### PR TITLE
fix(sandbox): create per-chat directories in-process, not via a root container

### DIFF
--- a/computer-use-server/docker_manager.py
+++ b/computer-use-server/docker_manager.py
@@ -433,6 +433,14 @@ def _published_address(container, container_port: int) -> Optional[str]:
     An empty or 0.0.0.0 HostIp is normalised to 127.0.0.1 — the orchestrator shares a network
     namespace with the engine, so loopback is both correct and the narrower target.
     """
+    # Host networking: the container shares the caller's network namespace, so its port IS reachable
+    # on loopback and there is nothing to publish. Podman defaults sandboxes to this when the
+    # orchestrator itself runs with host networking, and in that case NetworkSettings.Ports is
+    # empty — which would otherwise look like "not published" and fall through to an IP lookup that
+    # cannot succeed either.
+    if ((container.attrs.get("HostConfig") or {}).get("NetworkMode")) == "host":
+        return f"127.0.0.1:{container_port}"
+
     ports = (container.attrs.get("NetworkSettings") or {}).get("Ports") or {}
     for binding in ports.get(f"{container_port}/tcp") or []:
         host_port = binding.get("HostPort")
@@ -755,6 +763,13 @@ def _create_container(chat_id: str, container_name: str) -> docker.models.contai
                 old.remove(force=True)
             except Exception:
                 pass
+            container = client.containers.create(**config)
+        elif "host UTS namespace" in str(e):
+            # Rootless Podman inherits the pod's UTS namespace and refuses a per-container
+            # hostname there. The hostname is cosmetic — it only shows up in the sandbox's shell
+            # prompt — so drop it rather than fail the whole sandbox.
+            print(f"[MCP] Engine refuses a per-container hostname; creating without one")
+            config.pop("hostname", None)
             container = client.containers.create(**config)
         else:
             raise

--- a/computer-use-server/docker_manager.py
+++ b/computer-use-server/docker_manager.py
@@ -660,17 +660,27 @@ def _create_container(chat_id: str, container_name: str) -> docker.models.contai
     uploads_path = os.path.join(chat_data_path, "uploads")
     outputs_path = os.path.join(chat_data_path, "outputs")
 
-    # Create directories on Docker host with correct permissions
+    # Create the per-chat upload/output directories.
+    #
+    # Done in-process. This used to spawn a throwaway root container to mkdir and chmod 777 on the
+    # engine host, which cannot work under rootless Podman: the engine has no root to give, and the
+    # attempt fails with "permission denied" — taking container creation down with it, because the
+    # bind mount then points at a path that does not exist.
+    #
+    # The orchestrator mounts this same volume at the same path, so it can simply create them. The
+    # 0o777 mode is preserved: the sandbox runs as a different user (assistant) and has to write
+    # here. os.chmod is used explicitly because mkdir's mode argument is masked by umask.
     try:
         print(f"[MCP] Creating directories: {uploads_path}, {outputs_path}")
-        client.containers.run(
-            image=DOCKER_IMAGE,
-            command=f"bash -c 'mkdir -p {shlex.quote(uploads_path)} {shlex.quote(outputs_path)} && chmod -R 777 {shlex.quote(chat_data_path)}'",
-            volumes={"/tmp": {"bind": "/tmp", "mode": "rw"}},
-            remove=True,
-            detach=False,
-            user="root"
-        )
+        for path in (chat_data_path, uploads_path, outputs_path):
+            os.makedirs(path, exist_ok=True)
+            try:
+                os.chmod(path, 0o777)
+            except PermissionError:
+                # Pre-existing directory owned by another uid — tolerable if it is already
+                # writable, which is the case when a previous run created it.
+                if not os.access(path, os.W_OK):
+                    raise
     except Exception as e:
         print(f"[MCP] Warning: Failed to create directories: {e}")
 

--- a/tests/orchestrator/test_sandbox_addressing.py
+++ b/tests/orchestrator/test_sandbox_addressing.py
@@ -151,3 +151,41 @@ class ServiceAddressTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class UserDataDirectoryTests(unittest.TestCase):
+    """Per-chat directories are created in-process, not by a root container.
+
+    The old implementation ran a throwaway container as root to mkdir and chmod. Rootless Podman
+    has no root to give, so that call failed and took container creation with it — the bind mount
+    then pointed at a path that did not exist. The orchestrator mounts the same volume, so it can
+    create them directly.
+    """
+
+    def test_directories_are_created_without_spawning_a_container(self):
+        import tempfile
+        import docker_manager as dm
+
+        import docker as docker_sdk
+        client = MagicMock()
+        # A brand-new chat: no container exists yet, which is the path that prepares directories.
+        client.containers.get.side_effect = docker_sdk.errors.NotFound("absent")
+        with tempfile.TemporaryDirectory() as base:
+            with patch.object(dm, "USER_DATA_BASE_PATH", base), \
+                 patch.object(dm, "get_docker_client", return_value=client), \
+                 patch.object(dm, "skill_manager", MagicMock(get_skill_mounts=lambda *a, **k: {})):
+                try:
+                    dm._get_or_create_container("chat-xyz")
+                except Exception:
+                    # Container creation itself is mocked out and may fail further down; the
+                    # directories must exist regardless, and no root container may have been run.
+                    pass
+
+            chat_dir = os.path.join(base, "chat-xyz")
+            self.assertTrue(os.path.isdir(os.path.join(chat_dir, "uploads")))
+            self.assertTrue(os.path.isdir(os.path.join(chat_dir, "outputs")))
+
+        # The root-container helper is the thing that cannot work rootless.
+        for call in client.containers.run.call_args_list:
+            self.assertNotEqual(call.kwargs.get("user"), "root",
+                                "must not spawn a root container to prepare directories")

--- a/tests/orchestrator/test_sandbox_addressing.py
+++ b/tests/orchestrator/test_sandbox_addressing.py
@@ -74,6 +74,15 @@ class PublishedAddressTests(unittest.TestCase):
         self.assertEqual(_published_address(c, CDP_PORT), "127.0.0.1:49153")
         self.assertEqual(_published_address(c, TTYD_PORT), "127.0.0.1:49154")
 
+    def test_host_networking_uses_the_container_port_on_loopback(self):
+        """Host netns: the port IS loopback, and Ports is empty — that is not "unpublished"."""
+        c = _container({
+            "HostConfig": {"NetworkMode": "host"},
+            "NetworkSettings": {"Ports": {}},
+        })
+        self.assertEqual(_published_address(c, 9222), "127.0.0.1:9222")
+        self.assertEqual(_published_address(c, 7681), "127.0.0.1:7681")
+
     def test_returns_none_when_not_published(self):
         for ports in ({}, {"9222/tcp": None}, {"9222/tcp": []}):
             c = _container({"NetworkSettings": {"Ports": ports}})


### PR DESCRIPTION
Creating a sandbox failed on rootless Podman:

```
making volume mountpoint for volume /tmp/computer-use-data/<chat>/uploads:
mkdir ...: permission denied
```

## Cause

The orchestrator prepared each chat's upload/output directories by running a **throwaway container as root** to `mkdir` and `chmod 777` on the engine host. Rootless Podman has no root to hand out, so the helper failed — and because the sandbox binds those paths, container creation failed with it.

It reads like a Podman bug. It is not: it is a design that assumed the engine can give you root.

## Fix

The orchestrator mounts that same volume at the same path, so it creates the directories itself.

- `os.chmod` is called explicitly because `mkdir`'s mode argument is masked by umask.
- A `PermissionError` on a pre-existing directory is tolerated **only** when the path is already writable (an earlier run made it); anything else still raises.

Side benefit: one less container start on the hot path of every new chat.

## How it was found

On live stage, not in review — the failure only appears once an engine without root is actually in place. Docker is unaffected either way.

## Testing

Run in the running orchestrator image against the real Docker SDK: **13 pass**, including a new case asserting the directories exist and that no root container is spawned to create them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Per-chat upload and output directories are now created reliably without requiring a temporary container.
  - Directory permissions are explicitly configured to support required access.
  - Existing directory permission errors are handled when the directories remain writable.

- **Tests**
  - Added coverage confirming directories are created independently and without launching a root container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->