### PR TITLE
ci: lint the helm chart on the pull request, not after the merge

### DIFF
--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -31,6 +31,12 @@ on:
       # the one thing its own gate did not check.
       - "scripts/**"
       - "helm/**"
+      # One filter, six jobs, no per-job conditions — so they fire together or
+      # not at all. That costs a few irrelevant runs (a helm-only PR runs the
+      # contract linters) and buys the property that matters at flip time: no
+      # context can be required-and-absent, which would deadlock a PR that never
+      # triggered it. Splitting the chart into its own workflow would reverse
+      # that trade.
   push:
     branches:
       - next/v1

--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -241,3 +241,15 @@ jobs:
           helm lint helm/computer-use-server \
             --set secrets.mcpApiKey=lint-only \
             --set orchestrator.env.PUBLIC_BASE_URL=https://lint.example.com
+
+      # lint alone is not enough, measured: a template referencing a value that
+      # does not exist — `{{ .Values.missing | required "…" }}` — produces a WARN
+      # and "0 chart(s) failed", so a chart that cannot install passes. --strict
+      # does not change that; rendering does, exiting 1. A gate that misses the
+      # breakage an operator hits first is not worth the minute it costs.
+      - name: helm template — the chart must actually render
+        run: |
+          helm template lint-render helm/computer-use-server \
+            --set secrets.mcpApiKey=lint-only \
+            --set orchestrator.env.PUBLIC_BASE_URL=https://lint.example.com \
+            > /dev/null

--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -30,13 +30,6 @@ on:
       # one breaking its own self-test — triggers none of them: the checker was
       # the one thing its own gate did not check.
       - "scripts/**"
-      - "helm/**"
-      # One filter, six jobs, no per-job conditions — so they fire together or
-      # not at all. That costs a few irrelevant runs (a helm-only PR runs the
-      # contract linters) and buys the property that matters at flip time: no
-      # context can be required-and-absent, which would deadlock a PR that never
-      # triggered it. Splitting the chart into its own workflow would reverse
-      # that trade.
   push:
     branches:
       - next/v1
@@ -223,39 +216,3 @@ jobs:
             exit 1
           fi
           echo "contracts/ is clean"
-
-  chart:
-    name: chart — helm lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-        with:
-          persist-credentials: false
-      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
-      # The chart was linted only by the publish job, which runs on push — so a
-      # PR could break the schema and the failure appeared after the merge, in a
-      # job whose purpose is publishing rather than checking.
-      #
-      # The overrides are the same ones publish uses, and they are load-bearing:
-      # values.yaml ships empty placeholders for the operator to fill, while the
-      # schema demands non-empty, so linting the file as committed always fails.
-      # Red-probed that this still catches a real defect — flipping
-      # secrets.create to false leaves the oneOf with no matching branch and the
-      # lint errors.
-      - name: helm lint the chart as a PR would ship it
-        run: |
-          helm lint helm/computer-use-server \
-            --set secrets.mcpApiKey=lint-only \
-            --set orchestrator.env.PUBLIC_BASE_URL=https://lint.example.com
-
-      # lint alone is not enough, measured: a template referencing a value that
-      # does not exist — `{{ .Values.missing | required "…" }}` — produces a WARN
-      # and "0 chart(s) failed", so a chart that cannot install passes. --strict
-      # does not change that; rendering does, exiting 1. A gate that misses the
-      # breakage an operator hits first is not worth the minute it costs.
-      - name: helm template — the chart must actually render
-        run: |
-          helm template lint-render helm/computer-use-server \
-            --set secrets.mcpApiKey=lint-only \
-            --set orchestrator.env.PUBLIC_BASE_URL=https://lint.example.com \
-            > /dev/null

--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -30,6 +30,7 @@ on:
       # one breaking its own self-test — triggers none of them: the checker was
       # the one thing its own gate did not check.
       - "scripts/**"
+      - "helm/**"
   push:
     branches:
       - next/v1
@@ -216,3 +217,27 @@ jobs:
             exit 1
           fi
           echo "contracts/ is clean"
+
+  chart:
+    name: chart — helm lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
+      # The chart was linted only by the publish job, which runs on push — so a
+      # PR could break the schema and the failure appeared after the merge, in a
+      # job whose purpose is publishing rather than checking.
+      #
+      # The overrides are the same ones publish uses, and they are load-bearing:
+      # values.yaml ships empty placeholders for the operator to fill, while the
+      # schema demands non-empty, so linting the file as committed always fails.
+      # Red-probed that this still catches a real defect — flipping
+      # secrets.create to false leaves the oneOf with no matching branch and the
+      # lint errors.
+      - name: helm lint the chart as a PR would ship it
+        run: |
+          helm lint helm/computer-use-server \
+            --set secrets.mcpApiKey=lint-only \
+            --set orchestrator.env.PUBLIC_BASE_URL=https://lint.example.com

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -22,7 +22,10 @@ on:
       - 'examples/helm/**'
       - '.github/workflows/helm.yml'
   pull_request:
-    branches: [main]
+    # next/v1 too: the chart ships from this branch, and without it a PR
+    # could break the chart with nothing saying so until the publish job ran
+    # after the merge.
+    branches: [main, next/v1]
     paths:
       - 'helm/**'
       - 'examples/helm/**'

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -15,7 +15,10 @@ name: Helm chart
 
 on:
   push:
-    branches: [main]
+    # Both sides for both branches. next/v1 has no branch protection, so a
+    # direct push can reach it without a pull request — checking only the PR
+    # would leave that path unguarded.
+    branches: [main, next/v1]
     tags: ['v*']
     paths:
       - 'helm/**'


### PR DESCRIPTION
`helm lint` ran only inside `release-chart`'s publish job, which triggers on
**push**. A pull request could break the chart schema and nothing said so until
after the merge — and then in a job whose purpose is publishing, where a lint
failure reads as a release problem rather than as the change that caused it.

## The overrides are load-bearing, not decoration

`values.yaml` ships empty placeholders for an operator to fill, while
`values.schema.json` demands non-empty. So linting the committed file always
fails:

```
[ERROR] values.yaml: - at '/secrets': 'oneOf' failed, none matched
  - at '/secrets/mcpApiKey': minLength: got 0, want 1
```

That is why a naive `helm lint helm/computer-use-server` is not a usable check,
and why this one had to be verified rather than assumed. The PR job passes the
same two `--set` overrides the publish job does — confirmed by comparing both
lists, so the halves cannot drift into checking different things.

## Red-probed

A first mutation (`existingSecret: 12345`) did **not** fail the lint, and that
is correct: `oneOf` needs exactly one branch to match, the override satisfies
the `mcpApiKey` branch, and the number breaks only the other one. The mutation
that breaks both branches does fail it:

```
secrets.create: true -> false
[ERROR] values.yaml: - at '/secrets': 'oneOf' failed, none matched
```

So the check discriminates rather than always passing.

`helm/**` joins the path filter beside `scripts/**`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated validation for Helm chart changes in pull requests.
  * Helm charts are now linted and checked for successful template rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->