### PR TITLE
feat(readiness): report when a leg's delivery path breaks

### DIFF
--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -132,6 +132,11 @@ jobs:
       # What this buys is that the number is on every run, so the day it becomes
       # 3 of 3 nobody has to take that on trust, and the day it regresses the
       # log says so.
+      # The self-test is the gate. The live query below is report-only, so
+      # without this the delivery reporting could stop discriminating and no
+      # run would notice.
+      - name: delivery reporting red-probe (six outcomes through the report)
+        run: python3 scripts/check-readiness-claim.py --self-test
       - name: deployment-readiness claim (report-only, see NFR §Deployment-readiness)
         # Reads a sibling component's default branch through the contents API.
         # That works from here because the components are public; were one made

--- a/scripts/check-readiness-claim.py
+++ b/scripts/check-readiness-claim.py
@@ -59,6 +59,7 @@ import time
 LEGS = (
     {
         "leg": "proven isolation",
+        "delivered_by": 115,
         "repo": "Wide-Moat/ocu-sandbox",
         "branch": "main",
         "evidence": "func AdmitUIDMap",
@@ -72,6 +73,7 @@ LEGS = (
     },
     {
         "leg": "auditable supply chain",
+        "delivered_by": 118,
         "repo": "Wide-Moat/ocu-sandbox",
         "branch": "main",
         "evidence": "func AdmitImageRef",
@@ -85,6 +87,7 @@ LEGS = (
     },
     {
         "leg": "checkable canon",
+        "delivered_by": 117,
         "repo": "Wide-Moat/ocu-sandbox",
         "branch": "main",
         "evidence": "func TestEveryDecisionNamesAGuardThatExists",
@@ -189,6 +192,51 @@ def _fetch(leg: dict, path: str, encoded: str) -> str:
         raise Unreadable(f"{leg['repo']}:{path}: undecodable content: {exc}") from exc
 
 
+def delivery_intact(leg: dict) -> bool | None:
+    """Does the PR named in `delivered_by` still carry this leg's evidence?
+
+    A leg that does not hold on the shipping branch is expected while its PR is
+    open. What is NOT expected is the delivery path silently emptying: a rebase
+    that drops the call site, a branch renamed out from under the claim, a PR
+    closed without merging. All of those leave the readiness line reading
+    "NOT YET" — identical to healthy work in progress — so the regression hides
+    behind the expected state.
+
+    Returns True when the PR still carries both markers, False when it does not,
+    and None when the answer cannot be read (no token, network, PR gone). None is
+    not False: an unreadable delivery path is reported as unreadable, because
+    treating "could not look" as "broken" would cry wolf on every offline run.
+    """
+    pr = leg.get("delivered_by")
+    if not pr:
+        return None
+    code, out, _ = _run(
+        ["gh", "pr", "view", str(pr), "--repo", leg["repo"],
+         "--json", "headRefName,state", "--jq", ".headRefName + \" \" + .state"]
+    )
+    if code != 0 or not out.strip():
+        return None
+    parts = out.strip().split()
+    if len(parts) != 2:
+        return None
+    ref, state = parts
+    if state != "OPEN":
+        return False
+    for symbol, path in ((leg["evidence"], leg["path"]),
+                         (leg.get("wired"), leg.get("wired_path"))):
+        if not symbol:
+            continue
+        code2, out2, _ = _run(
+            ["gh", "api", f"repos/{leg['repo']}/contents/{path}?ref={ref}",
+             "--jq", ".content"]
+        )
+        if code2 != 0 or not out2.strip():
+            return False
+        if symbol not in _fetch(leg, path, out2):
+            return False
+    return True
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--json", action="store_true", help="machine-readable output")
@@ -201,7 +249,8 @@ def main() -> int:
         except Unreadable as exc:
             print(f"cannot read {leg['leg']}: {exc}", file=sys.stderr)
             return 2
-        results.append({**leg, "holds": holds})
+        intact = None if holds else delivery_intact(leg)
+        results.append({**leg, "holds": holds, "delivery_intact": intact})
 
     if args.json:
         print(json.dumps(results, indent=2))
@@ -211,6 +260,24 @@ def main() -> int:
             print(f"  {mark} {r['leg']}")
             print(f"            {r['means']}")
             print(f"            evidence: {r['evidence']} on {r['repo']}@{r['branch']}")
+            if not r["holds"] and r.get("delivered_by"):
+                intact = r.get("delivery_intact")
+                if intact is True:
+                    print(
+                        f"            delivery: #{r['delivered_by']} is open and "
+                        "still carries this leg"
+                    )
+                elif intact is False:
+                    print(
+                        f"            DELIVERY BROKEN: #{r['delivered_by']} no "
+                        "longer carries this leg (closed, renamed, or rebased "
+                        "away) -- the path to shipping it is gone, not pending"
+                    )
+                else:
+                    print(
+                        f"            delivery: #{r['delivered_by']} could not "
+                        "be read from here"
+                    )
         held = sum(1 for r in results if r["holds"])
         print()
         if held == len(results):

--- a/scripts/check-readiness-claim.py
+++ b/scripts/check-readiness-claim.py
@@ -212,7 +212,7 @@ def delivery_intact(leg: dict) -> bool | None:
         return None
     try:
         return _delivery_intact(leg, pr)
-    except (subprocess.SubprocessError, Unreadable, OSError):
+    except (subprocess.SubprocessError, Unreadable, OSError, ValueError):
         # Containment, not laziness. This function is a REPORT decoration on a
         # verdict main() has already reached. Letting it raise would delete the
         # whole readiness report -- including the HOLDS/NOT YET lines that are
@@ -272,20 +272,17 @@ def _self_test() -> int:
 
     global _run
     real_run = _run
-    real_sleep = time.sleep
-    # The stubs below return transport failures on purpose, which drives _run's
-    # real retry backoff. That is seconds of wall clock per case for a delay
-    # this test is not measuring -- and a self-test slow enough to time out in
-    # CI is a self-test people delete. Neutralise the sleep, not the retry: the
-    # retry LOOP still runs, so a stub that returns a transient error is still
-    # attempted three times exactly as production would.
-    time.sleep = lambda _n: None
     failures = []
 
     def stub(script):
         def _stub(args):
             return script(args)
         return _stub
+
+    _ALL_SYMBOLS = (
+        "func AdmitUIDMap\nm.admitUserns(ctx\nfunc AdmitImageRef\n"
+        "AdmitImageRef(spec.Image)\nfunc TestEveryDecisionNamesAGuardThatExists\n"
+    )
 
     def encoded(text):
         return 0, base64.b64encode(text.encode()).decode(), ""
@@ -300,8 +297,7 @@ def _self_test() -> int:
         ref = next((a for a in args if "ref=" in a), "")
         if "ref=main" in ref:
             return encoded("package x\n")
-        return encoded("func AdmitUIDMap\nm.admitUserns(ctx\nfunc AdmitImageRef\n"
-                       "AdmitImageRef(spec.Image)\nfunc TestEveryDecisionNamesAGuardThatExists\n")
+        return encoded(_ALL_SYMBOLS)
     cases.append(("intact", carries, "is open and still carries", 1))
 
     def closed(args):
@@ -339,6 +335,46 @@ def _self_test() -> int:
         return 1, "", "server error: 502 bad gateway"
     cases.append(("contents transport failure", net_fail_contents, "could not be read", 1))
 
+    # The three cases below each isolate ONE check. Earlier stubs withheld BOTH
+    # symbols at once, so a BROKEN verdict could arrive by either path and the
+    # individual gates were decoration: dropping the state check, the wired
+    # check, or the 404 branch each left every case green.
+    def merged_but_carries(args):
+        # State gate alone: the branch still has both symbols, only the PR died.
+        if args[:2] == ["gh", "pr"]:
+            return 0, "some-branch MERGED", ""
+        ref = next((a for a in args if "ref=" in a), "")
+        if "ref=main" in ref:
+            return encoded("package x\n")
+        return encoded(_ALL_SYMBOLS)
+    cases.append(("merged PR whose branch still carries", merged_but_carries,
+                  "DELIVERY BROKEN", 1))
+
+    def wired_dropped(args):
+        # Wired-symbol check alone: the verdict function is there, the call is not.
+        if args[:2] == ["gh", "pr"]:
+            return 0, "some-branch OPEN", ""
+        ref = next((a for a in args if "ref=" in a), "")
+        if "ref=main" in ref:
+            return encoded("package x\n")
+        path = next((a for a in args if "contents/" in a), "")
+        if "manager.go" in path:
+            return encoded("package x\n")  # call site rebased away
+        return encoded(_ALL_SYMBOLS)
+    cases.append(("call site dropped, verdict kept", wired_dropped,
+                  "DELIVERY BROKEN", 1))
+
+    def contents_gone(args):
+        # 404 branch alone: the PR is open, the FILE is gone from the branch.
+        if args[:2] == ["gh", "pr"]:
+            return 0, "some-branch OPEN", ""
+        ref = next((a for a in args if "ref=" in a), "")
+        if "ref=main" in ref:
+            return encoded("package x\n")
+        return 1, "", "gh: Not Found (HTTP 404)"
+    cases.append(("contents 404 on the PR branch", contents_gone,
+                  "DELIVERY BROKEN", 1))
+
     for label, script, expect, want_exit in cases:
         _run = stub(script)
         buf = _io.StringIO()
@@ -368,7 +404,6 @@ def _self_test() -> int:
     if "is open and still carries" in buf.getvalue():
         failures.append("closed PR reported as intact")
 
-    time.sleep = real_sleep
     for f in failures:
         print(f"FAIL {f}")
     if failures:

--- a/scripts/check-readiness-claim.py
+++ b/scripts/check-readiness-claim.py
@@ -210,6 +210,18 @@ def delivery_intact(leg: dict) -> bool | None:
     pr = leg.get("delivered_by")
     if not pr:
         return None
+    try:
+        return _delivery_intact(leg, pr)
+    except (subprocess.SubprocessError, Unreadable, OSError):
+        # Containment, not laziness. This function is a REPORT decoration on a
+        # verdict main() has already reached. Letting it raise would delete the
+        # whole readiness report -- including the HOLDS/NOT YET lines that are
+        # the reason the step runs at all -- and the caller in CI appends
+        # `|| true`, so the deletion would be silent. Degrade to unreadable.
+        return None
+
+
+def _delivery_intact(leg: dict, pr: int) -> bool | None:
     code, out, _ = _run(
         ["gh", "pr", "view", str(pr), "--repo", leg["repo"],
          "--json", "headRefName,state", "--jq", ".headRefName + \" \" + .state"]
@@ -226,21 +238,161 @@ def delivery_intact(leg: dict) -> bool | None:
                          (leg.get("wired"), leg.get("wired_path"))):
         if not symbol:
             continue
-        code2, out2, _ = _run(
+        code2, out2, _err2 = _run(
             ["gh", "api", f"repos/{leg['repo']}/contents/{path}?ref={ref}",
              "--jq", ".content"]
         )
-        if code2 != 0 or not out2.strip():
+        if code2 != 0:
+            # A 404 means the path is genuinely gone from that branch. Anything
+            # else (transport, auth, rate limit) is a failure to look, and the
+            # docstring promises None for those -- reporting BROKEN on a network
+            # blip is the cry-wolf direction.
+            if "404" in _err2 or "Not Found" in _err2:
+                return False
+            return None
+        if not out2.strip():
             return False
         if symbol not in _fetch(leg, path, out2):
             return False
     return True
 
 
-def main() -> int:
+def _self_test() -> int:
+    """Drive main() over a stubbed _run for every delivery outcome.
+
+    Through main(), not delivery_intact alone. The verdict function being right
+    is not the property that matters -- the property is that the REPORT a reader
+    sees says the right thing, and that a failure inside the decoration cannot
+    take the report with it. A self-test that drove only the function would have
+    passed while the live script died on a slow API call and printed nothing.
+    """
+    import base64
+    import io as _io
+    import contextlib
+
+    global _run
+    real_run = _run
+    real_sleep = time.sleep
+    # The stubs below return transport failures on purpose, which drives _run's
+    # real retry backoff. That is seconds of wall clock per case for a delay
+    # this test is not measuring -- and a self-test slow enough to time out in
+    # CI is a self-test people delete. Neutralise the sleep, not the retry: the
+    # retry LOOP still runs, so a stub that returns a transient error is still
+    # attempted three times exactly as production would.
+    time.sleep = lambda _n: None
+    failures = []
+
+    def stub(script):
+        def _stub(args):
+            return script(args)
+        return _stub
+
+    def encoded(text):
+        return 0, base64.b64encode(text.encode()).decode(), ""
+
+    # Every case pins main()'s printed report AND its exit code.
+    cases = []
+
+    def carries(args):
+        # main branch never has the symbol -> every leg NOT YET; the PR does.
+        if args[:2] == ["gh", "pr"]:
+            return 0, "some-branch OPEN", ""
+        ref = next((a for a in args if "ref=" in a), "")
+        if "ref=main" in ref:
+            return encoded("package x\n")
+        return encoded("func AdmitUIDMap\nm.admitUserns(ctx\nfunc AdmitImageRef\n"
+                       "AdmitImageRef(spec.Image)\nfunc TestEveryDecisionNamesAGuardThatExists\n")
+    cases.append(("intact", carries, "is open and still carries", 1))
+
+    def closed(args):
+        if args[:2] == ["gh", "pr"]:
+            return 0, "some-branch MERGED", ""
+        return encoded("package x\n")
+    cases.append(("closed PR", closed, "DELIVERY BROKEN", 1))
+
+    def rebased_away(args):
+        if args[:2] == ["gh", "pr"]:
+            return 0, "some-branch OPEN", ""
+        return encoded("package x\n")  # PR open but symbol gone
+    cases.append(("rebased away", rebased_away, "DELIVERY BROKEN", 1))
+
+    def unreadable(args):
+        if args[:2] == ["gh", "pr"]:
+            return 1, "", "could not connect"
+        return encoded("package x\n")
+    cases.append(("unreadable PR", unreadable, "could not be read", 1))
+
+    def hangs(args):
+        # THE REGRESSION: a slow API call must not delete the report.
+        if args[:2] == ["gh", "pr"]:
+            raise subprocess.TimeoutExpired(cmd=args, timeout=60)
+        return encoded("package x\n")
+    cases.append(("timeout mid-report", hangs, "could not be read", 1))
+
+    def net_fail_contents(args):
+        # Transport failure fetching the PR's file: unreadable, never BROKEN.
+        if args[:2] == ["gh", "pr"]:
+            return 0, "some-branch OPEN", ""
+        ref = next((a for a in args if "ref=" in a), "")
+        if "ref=main" in ref:
+            return encoded("package x\n")
+        return 1, "", "server error: 502 bad gateway"
+    cases.append(("contents transport failure", net_fail_contents, "could not be read", 1))
+
+    for label, script, expect, want_exit in cases:
+        _run = stub(script)
+        buf = _io.StringIO()
+        try:
+            with contextlib.redirect_stdout(buf):
+                code = main([])
+        except BaseException as exc:  # noqa: BLE001 - a crash IS the finding
+            failures.append(f"{label}: main() raised {type(exc).__name__}: {exc}")
+            continue
+        finally:
+            _run = real_run
+        out = buf.getvalue()
+        if not out.strip():
+            failures.append(f"{label}: main() printed NOTHING (report deleted)")
+            continue
+        if expect not in out:
+            failures.append(f"{label}: report missing {expect!r}")
+        if code != want_exit:
+            failures.append(f"{label}: exit {code}, want {want_exit}")
+
+    # A BROKEN delivery must never be reported as intact.
+    _run = stub(closed)
+    buf = _io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        main([])
+    _run = real_run
+    if "is open and still carries" in buf.getvalue():
+        failures.append("closed PR reported as intact")
+
+    time.sleep = real_sleep
+    for f in failures:
+        print(f"FAIL {f}")
+    if failures:
+        print(f"\n{len(failures)} self-test failure(s)")
+        return 1
+    print(f"delivery reporting: {len(cases)} cases through main(), all as specified")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    # Explicit argv, because _self_test drives main() while sys.argv still says
+    # --self-test. Re-parsing the process argv there sent main() straight back
+    # into the self-test: infinite recursion that appeared only as a subprocess,
+    # since an in-process caller has a clean sys.argv.
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--json", action="store_true", help="machine-readable output")
-    args = ap.parse_args()
+    ap.add_argument(
+        "--self-test",
+        action="store_true",
+        help="drive the report over constructed delivery outcomes and exit",
+    )
+    args = ap.parse_args(argv)
+    if getattr(args, "self_test", False):
+        return _self_test()
 
     results = []
     for leg in LEGS:

--- a/scripts/check-readiness-claim.py
+++ b/scripts/check-readiness-claim.py
@@ -250,8 +250,6 @@ def _delivery_intact(leg: dict, pr: int) -> bool | None:
             if "404" in _err2 or "Not Found" in _err2:
                 return False
             return None
-        if not out2.strip():
-            return False
         if symbol not in _fetch(leg, path, out2):
             return False
     return True


### PR DESCRIPTION
The readiness check prints NOT YET for a leg that has not shipped. It printed the same thing for a leg whose PR was closed, renamed, or rebased until it no longer carried the evidence — so a broken delivery path was indistinguishable from healthy work in progress. The three legs have sat in that state for weeks, which is exactly when the regression would go unnoticed.

Each leg now names the PR that delivers it and verifies that PR still carries both the verdict function and its call site.

Three outcomes rather than two. Unreadable is not broken — an offline run, or one without a token, must not report a regression it could not observe.

Probed in every direction against the live PRs:

| case | result |
|---|---|
| #115 open, carries the leg | intact |
| evidence symbol renamed away | broken |
| call site dropped | broken |
| a genuinely closed PR (#103) | broken |
| PR number that cannot be read | unreadable |

The DELIVERY BROKEN line was rendered through `main()`, not only the function — the report path is what a reader sees, and testing the pieces without their composition is how a check ends up correct and invisible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delivery-readiness reporting to distinguish successful, broken, unreadable, timed-out, and failed delivery paths.
  * Readiness results now include clearer delivery status details when requirements are unmet.

* **Tests**
  * Added automated self-checks covering key readiness-reporting outcomes.
  * Deployment-readiness checks now validate that failures are detected and reported consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->