### PR TITLE
ci(nfr-sec-89): judge the platform's gates, not only this repository's

### DIFF
--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -125,13 +125,14 @@ jobs:
       #   3. Remove `continue-on-error: true` from sast-semgrep in
       #      security.yml. A required context that cannot fail is green whatever
       #      it finds, which is the exact shape this NFR exists to name.
-      #   4. Retire the `composition` job. It composes the delivering PRs to
-      #      show the sequence still delivers; once they merge, their head
-      #      branches delete, resolution exits 2, and the job reds until it is
-      #      removed. That red is the reminder, but recording it here means
-      #      nobody has to be surprised by it. It is engineering evidence, not
-      #      auditor evidence -- a green on a throwaway composed tree is a
-      #      claim about a future merge, never readiness itself.
+      #   4. DONE. The `composition` job is retired. It composed the delivering
+      #      PRs to show the sequence still delivers; they merged, their head
+      #      branches deleted, and it red exactly as recorded here --
+      #      `origin/feat/e1-userns-admission does not resolve`. That red was
+      #      the reminder and it worked. Nothing replaces it: a green on a
+      #      throwaway composed tree was a claim about a future merge, and the
+      #      merge has happened, so the readiness check below now reads the
+      #      shipped branches instead of predicting them.
       # The readiness claim is worth nothing if it is only ever answered when
       # somebody remembers to ask. Report-only for the same reason as the check
       # below: it reports 0 of 4 today because the legs sit in open pull
@@ -249,36 +250,3 @@ jobs:
             exit 1
           fi
           echo "contracts/ is clean"
-
-  composition:
-    # Minutes of network-bound work; the 360-minute default would hold a runner
-    # for six hours on a wedged clone.
-    timeout-minutes: 15
-    # Its own job: this clones a sibling repo and runs a cold Go build, which is
-    # minutes of network-bound work -- measured, not the 11s a warm cache
-    # suggests. Riding in a contract-validation job would let a clone flake red
-    # "the contract documents are valid".
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
-      # --compose shipped in #448 and ran in no workflow -- the same shape as the
-      # honesty gate #121 wired, one level up.
-      #
-      # Report-only, but NOT for the reason the readiness step above gives. That
-      # one reds until the legs merge; this one exits 0 today. A compose red is
-      # actionable -- it means the sequence stopped delivering -- but only in
-      # ocu-sandbox, never by the PR being tested here.
-      #
-      # `|| [ "$?" -eq 1 ]` tolerates exit 1 (composition does not hold) and lets
-      # exit 2 (CANNOT JUDGE -- auth refused, a head branch gone) red the job.
-      # Flattening both with `|| true` is the pattern this file already records
-      # swallowing an auth failure every run while nobody noticed.
-      - name: composition of the delivering PRs (report-only on exit 1)
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          git clone -q --filter=blob:none \
-            https://github.com/Wide-Moat/ocu-sandbox.git "$RUNNER_TEMP/sandbox"
-          python3 scripts/check-readiness-claim.py --compose "$RUNNER_TEMP/sandbox" \
-            || [ "$?" -eq 1 ]

--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -154,12 +154,26 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: python3 scripts/check-readiness-claim.py || true
 
-      - name: gate enforcement on this branch (report-only until protection is on)
+      - name: gate enforcement across the platform (report-only until protection is on)
         # The github context reaches the script through env, never by
         # interpolation inside the run block. A branch name is
         # attacker-controllable on a fork PR, so interpolating it into the shell
         # would let it close the quote and run its own command on the runner.
         # The SAST gate flags exactly this, and it flagged it here.
+        #
+        # Three repositories, not one. NFR-SEC-89 is a claim about the platform,
+        # and a sandbox or a File Pane that can be merged past its own gates
+        # breaks it exactly as this repository would. Measured while this step
+        # judged only itself: ocu-webui ran CodeQL green on every pull request
+        # while requiring 11 contexts, none of them CodeQL — a finding this step
+        # could not have made, because it never looked. The sibling reads work
+        # from CI on the same token that check-readiness-claim.py already uses to
+        # read ocu-sandbox.
+        #
+        # Each sibling is judged on its own release branch. The continue-on-error
+        # sub-check silently drops for a repository that is not this checkout —
+        # the script says so on stderr — so a sibling verdict covers protection
+        # and rulesets, not the local workflow files.
         env:
           TARGET_REPO: ${{ github.repository }}
           TARGET_BRANCH: ${{ github.base_ref || github.ref_name }}
@@ -172,6 +186,13 @@ jobs:
           python3 scripts/check-gates-are-required.py \
             --repo "$TARGET_REPO" \
             --branch "$TARGET_BRANCH" || true
+          for sibling in Wide-Moat/ocu-sandbox Wide-Moat/ocu-webui; do
+            echo "::group::NFR-SEC-89 — ${sibling}@main"
+            python3 scripts/check-gates-are-required.py \
+              --repo "$sibling" \
+              --branch main || true
+            echo "::endgroup::"
+          done
 
   openapi:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The step read `github.repository`, so it answered for one repository out of three. NFR-SEC-89 is a claim about the platform: a sandbox or a File Pane that can be merged past its own gates breaks it exactly as this repository would.

**The gap is not hypothetical.** `ocu-webui` ran CodeQL on every pull request — `Analyze (actions)`, `Analyze (javascript-typescript)`, `Analyze (python)`, all green — while branch protection required eleven contexts, none of them CodeQL. Every one of those runs was decorative. This step could not have said so, because it never looked; it was found by hand instead — which is the failure mode the NFR names.

**Bound to the finding, not to today's green.** Both siblings pass right now, so a green run proves nothing on its own. Replaying `ocu-webui`'s pre-fix protection through `verdict()`:

```
11 contexts (as it was)  -> required contexts do not cover: codeql
14 contexts (as it is)   -> no problems
```

The extended step would have caught it.

**Scope of a sibling verdict.** The script already refuses to read this checkout's workflow files against another repository's name — it says so on stderr — so a sibling verdict covers protection and rulesets, not `continue-on-error`. Each is judged on its own release branch. The token reaches them: `check-readiness-claim.py` already reads `ocu-sandbox` from this same workflow.

**Still report-only.** Two of the three hold; `open-computer-use` itself does not — no protection on either release branch, and its single ruleset carries `enforcement: disabled`. Until that is on, failing the build here would make the gate that reports the problem the thing that blocks fixing it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded workflow status reporting to include the `ocu-sandbox` and `ocu-webui` main branches.
  * Grouped enforcement checks for clearer visibility in workflow logs.
  * Kept checks report-only, so failures do not block the workflow.
  * Updated readiness documentation to reflect the completion of delivering branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->