### PR TITLE
ci(nfr): arm NFR-SEC-19, and raise the ratchet to hold it

### DIFF
--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -165,7 +165,7 @@ jobs:
         # unarmed remainder: that is the state of the layer, no single PR can
         # move it, and a gate nobody can turn green is a gate that gets ignored.
         # The number on every run is the point.
-        run: python3 scripts/check-nfr-coverage.py --min-armed 1
+        run: python3 scripts/check-nfr-coverage.py --min-armed 2
 
       - name: gate enforcement across the platform (report-only until protection is on)
         # The github context reaches the script through env, never by

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -53,6 +53,10 @@ concurrency:
 jobs:
   secrets-gitleaks:
     name: secrets — gitleaks
+    # NFR-SEC-19 (zero secrets in source). Named here so check-nfr-coverage.py
+    # counts this requirement as armed: a row in the manifesto is a claim, and
+    # the claim is only measured while a job that can FAIL carries its id. This
+    # job blocks -- no continue-on-error -- so the name is not decoration.
     runs-on: ubuntu-latest
     steps:
       # Fork-PR-safe two-source pattern. The PR HEAD provides the source
@@ -149,6 +153,9 @@ jobs:
 
   secrets-trufflehog:
     name: secrets — trufflehog
+    # NFR-SEC-19, second reading. Two scanners with different corpora, both
+    # blocking: gitleaks alone leaves the requirement resting on one tool's
+    # rule set.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4


### PR DESCRIPTION
The coverage checker landed reading **1 of 187**. This moves the first requirement, chosen because its gates already exist and already block.

`secrets — gitleaks` and `secrets — trufflehog` both run on every push and carry no `continue-on-error`, so naming NFR-SEC-19 at them records something true rather than decorating a job that cannot fail. Both are named on purpose: one tool's rule set is one corpus, and "zero secrets in source" resting on a single scanner is a narrower claim than the row makes.

The floor moves to 2 in the same commit — a ratchet that stays behind the coverage it protects lets the new arm disappear as quietly as it arrived:

```
NFR-SEC-19 renamed out of security.yml  ->  "armed NFRs dropped to 1,
                                             below the floor of 2", exit 1
--min-armed 3 (above reality)            ->  exit 1
--min-armed 2 (the shipped floor)        ->  exit 0
```

**What I did not do, and why.** `sast-semgrep` and `sca-trivy-fs` both carry `continue-on-error: true` — the exact shape NFR-SEC-89 exists to name, and obligation 3 in `contracts-lint.yml` already calls for removing it from semgrep. But both jobs carry this comment:

> `Temporarily non-blocking by owner direction 2026-08-01. Remove this flag and the line below to restore the gate`

That is a decision, not an oversight, so it is not mine to reverse. **NFR-SEC-20 stays unarmed for exactly that reason** — naming it at a job that reports success whatever it finds would be the decorative arming this checker was written to count.

Two things for whoever revisits that decision:

- Obligation 3 names only `semgrep`, while **both** jobs carry the flag.
- The last five `security.yml` runs on `next/v1` have **zero failing steps inside either job**, so restoring the gates would not red the build today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the minimum required NFR coverage threshold from one to two armed NFRs.
  * Documented secret-scanning checks as blocking security controls.
  * Clarified that two independent secret-scanning checks are performed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->