### PR TITLE
ci(nfr): check the pin policy this repo says zizmor enforces

### DIFF
--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -155,6 +155,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: python3 scripts/check-readiness-claim.py || true
 
+      - name: the pin-policy checker itself discriminates
+        run: python3 scripts/check-pin-policy.py --self-test
+
+      - name: every action and container image names an immutable ref
+        # NFR-SEC-18. security.yml states this policy in a header comment and
+        # credits zizmor with enforcing it; zizmor appears in five comments and
+        # in no executed step, so until now the policy was a claim about a tool
+        # that does not run here.
+        run: python3 scripts/check-pin-policy.py
+
       - name: the NFR-coverage checker itself discriminates
         run: python3 scripts/check-nfr-coverage.py --self-test
 
@@ -165,7 +175,7 @@ jobs:
         # unarmed remainder: that is the state of the layer, no single PR can
         # move it, and a gate nobody can turn green is a gate that gets ignored.
         # The number on every run is the point.
-        run: python3 scripts/check-nfr-coverage.py --min-armed 2
+        run: python3 scripts/check-nfr-coverage.py --min-armed 3
 
       - name: gate enforcement across the platform (report-only until protection is on)
         # The github context reaches the script through env, never by

--- a/scripts/check-pin-policy.py
+++ b/scripts/check-pin-policy.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+"""NFR-SEC-18: every action and container image is pinned to an immutable ref.
+
+security.yml states the policy in a header comment and names zizmor as what
+enforces it — `unpinned-uses` "would block merge on its own". Measured: zizmor
+appears in five comments across two workflows and in NO executed step, no
+requirements file, and no script. The policy rested on a tool that does not
+run here, which is worse than an unstated policy: the comment tells the next
+reader the question is already settled.
+
+Two rules, both of which zizmor would have covered:
+
+  1. Every third-party `uses:` names a 40-hex commit SHA, never a tag. A tag is
+     a movable pointer; the account that publishes it can repoint it after
+     review. `actions/*` and `github/*` are NOT exempt — a first-party org is
+     still an upstream.
+  2. Every container `image:` carries `@sha256:<64-hex>`. A `name:tag` image is
+     the same movable pointer wearing different syntax, and the workflows here
+     run third-party containers as job hosts.
+
+Local `./` and `docker://`-less reusable-workflow refs are out of scope: a
+relative path resolves inside this repository, so there is no upstream to move.
+
+    check-pin-policy.py [--root .] [--self-test]
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+# `uses: owner/repo@ref` or `uses: owner/repo/sub/path@ref`. The ref is captured
+# whole rather than matched as hex, so an unpinned one is REPORTED rather than
+# skipped -- a regex demanding 40 hex digits matches nothing on a tag, which
+# would make the check silently pass exactly what it exists to catch.
+USES_RE = re.compile(r"^\s*-?\s*uses:\s*([^\s#]+)")
+IMAGE_RE = re.compile(r"^\s*image:\s*([^\s#]+)")
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+DIGEST = re.compile(r"@sha256:[0-9a-f]{64}$")
+
+
+def unpinned_uses(text: str) -> list[str]:
+    """`uses:` refs that name something movable."""
+    bad = []
+    for line in text.splitlines():
+        m = USES_RE.match(line)
+        if not m:
+            continue
+        ref = m.group(1)
+        # A local composite action or a relative reusable workflow: no upstream.
+        if ref.startswith("./") or ref.startswith(".github/"):
+            continue
+        if "@" not in ref:
+            bad.append(f"{ref} (no ref at all)")
+            continue
+        _, _, pin = ref.rpartition("@")
+        if not SHA40.match(pin):
+            bad.append(ref)
+    return bad
+
+
+def unpinned_images(text: str) -> list[str]:
+    """Container `image:` refs without a digest.
+
+    A matrix entry is a bare name with no registry path and no tag, which is a
+    VALUE being iterated rather than an image being run -- `- open-computer-use`
+    under `matrix.image:`. Those are matched by the list-item form, not by
+    `image:`, so this walks only the key form and still guards against the bare
+    name reaching the digest test.
+    """
+    bad = []
+    for line in text.splitlines():
+        m = IMAGE_RE.match(line)
+        if not m:
+            continue
+        ref = m.group(1)
+        if "${{" in ref:
+            # An expression: the pin lives wherever the expression is defined,
+            # and this check cannot follow it. Reported so it is a decision.
+            bad.append(f"{ref} (expression -- pin at its definition)")
+            continue
+        if not DIGEST.search(ref):
+            bad.append(ref)
+    return bad
+
+
+def scan(root: pathlib.Path) -> dict[str, list[str]]:
+    findings: dict[str, list[str]] = {}
+    wf = root / ".github" / "workflows"
+    paths = sorted(wf.glob("*.yml")) + sorted(wf.glob("*.yaml"))
+    actions = root / ".github" / "actions"
+    if actions.is_dir():
+        paths += sorted(actions.rglob("action.yml"))
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        problems = [f"uses: {u}" for u in unpinned_uses(text)]
+        problems += [f"image: {i}" for i in unpinned_images(text)]
+        if problems:
+            findings[str(path.relative_to(root))] = problems
+    return findings, len(paths)
+
+
+def _self_test() -> int:
+    cases = [
+        ("a tag-pinned action is caught", "      - uses: actions/checkout@v4\n", unpinned_uses, True),
+        ("a sha-pinned action passes", "      - uses: actions/checkout@" + "a" * 40 + "\n", unpinned_uses, False),
+        ("a short sha is caught", "      - uses: o/r@" + "a" * 7 + "\n", unpinned_uses, True),
+        ("a ref-less use is caught", "      - uses: owner/repo\n", unpinned_uses, True),
+        ("a local action is exempt", "      - uses: ./.github/actions/thing\n", unpinned_uses, False),
+        ("a subpath sha passes", "      - uses: github/codeql-action/init@" + "b" * 40 + "\n", unpinned_uses, False),
+        ("a digest image passes", "      image: registry:2@sha256:" + "c" * 64 + "\n", unpinned_images, False),
+        ("a tag-only image is caught", "      image: registry:2\n", unpinned_images, True),
+        ("a bare image name is caught", "      image: postgres\n", unpinned_images, True),
+        ("an expression image is reported", "      image: ${{ matrix.image }}\n", unpinned_images, True),
+        # The matrix VALUE form must not be read as an image ref, or every
+        # workflow iterating image names reds and the check gets switched off.
+        ("a matrix list item is not an image ref", "          - open-computer-use\n", unpinned_images, False),
+    ]
+    failures = 0
+    for name, text, fn, want_bad in cases:
+        got_bad = bool(fn(text))
+        ok = got_bad == want_bad
+        failures += 0 if ok else 1
+        print(f"  {'ok' if ok else 'FAIL'}: {name}")
+    print()
+    if failures:
+        print(f"self-test: {failures} case(s) failed")
+        return 1
+    print("self-test: the check catches a movable ref in each shape and passes an immutable one.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        return _self_test()
+
+    root = pathlib.Path(args.root).resolve()
+    findings, scanned = scan(root)
+    if scanned == 0:
+        print("::error::no workflow files found -- the check scanned nothing", file=sys.stderr)
+        return 2
+
+    if findings:
+        for path, problems in findings.items():
+            for problem in problems:
+                print(f"::error file={path}::unpinned: {problem}", file=sys.stderr)
+        print(
+            f"::error::NFR-SEC-18: {sum(len(v) for v in findings.values())} unpinned "
+            f"ref(s) across {len(findings)} file(s). A tag is a pointer its publisher "
+            "can move after review; a digest is the artifact.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"NFR-SEC-18 holds: every uses: and image: across {scanned} workflow file(s) names an immutable ref.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
`security.yml` states the pinning policy in its header and credits zizmor with holding it — `unpinned-uses` *"would block merge on its own"*.

**zizmor has never run here.** It appears in five comments across two workflows, and in no executed step, no requirements file, and no script:

```
grep for uses:/run: lines invoking zizmor  -> nothing
grep in requirements / pyproject           -> nothing
```

That is worse than an unstated policy. An unstated one invites the next reader to check; a stated one with a named enforcer tells them the question is settled — and this comment has been saying so for as long as it has existed.

The check covers both halves zizmor would have: every third-party `uses:` names a 40-hex commit SHA, and every container `image:` carries `@sha256:`. Neither `actions/*` nor `github/*` is exempt — a first-party org is still an upstream, and a tag is a pointer its publisher can move after review.

**The tree passes today** — 11 workflow files, every ref immutable. The gate lands green rather than as a fix, because the policy was being followed by hand, which is exactly the state that decays without a check.

Probed against the real tree, each restored:

```
actions/checkout@<sha> -> @v4          ->  ::error:: unpinned: uses: actions/checkout@v4
semgrep image, digest stripped         ->  ::error:: unpinned: image: semgrep/semgrep:1.163.0
```

The self-test drives both matchers through eleven shapes, including the two that must **not** red: a local `./` action, and a matrix list item — a value being iterated, not an image ref. Getting that second one wrong would red every workflow that iterates image names, and a gate that cries wolf gets switched off.

One bug the probe caught that reading did not: the failure summary interpolated `{len(findings)}` inside a non-f string and printed literal braces. Fixed and re-probed.

Coverage moves to **3 of 187**, ratchet with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks to ensure workflow actions and container images use immutable references.
  * Added self-tests and clear error reporting for invalid or unresolved references.

* **Tests**
  * Increased the required NFR coverage threshold from 2 to 3.
  * Added validation that the pin-policy checks run successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->