### PR TITLE
fix(ci): stop leaving the job token in .git/config, and check that it stays gone

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
 
       - name: Free disk space for 8GB+ image + local load
         run: |
@@ -134,6 +137,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
@@ -198,6 +204,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
@@ -262,6 +271,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
@@ -462,6 +474,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
 
       - name: Run structure and English-only tests
         run: |
@@ -475,6 +490,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
@@ -499,6 +517,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
@@ -558,6 +579,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
 
       - name: Free disk space for the workspace image
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
 
       - uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43  # v4.37.5
         with:

--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -42,6 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "20"
@@ -67,6 +70,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "20"
@@ -221,6 +227,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "20"
@@ -240,6 +249,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
       - name: Validate Protobuf definitions
         run: |
           set -euo pipefail
@@ -258,6 +270,9 @@ jobs:
       LEXICON_DENYLIST: ${{ secrets.LEXICON_DENYLIST }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
       - name: naming denylist (contracts)
         run: |
           set -euo pipefail

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -43,6 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
@@ -55,6 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
@@ -67,6 +73,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
       - name: Check
         run: bash scripts/docs-lint/wc-budget.sh
 
@@ -75,6 +84,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
       - name: Check
         env:
           LEXICON_DENYLIST: ${{ secrets.LEXICON_DENYLIST }}
@@ -85,6 +97,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
@@ -97,6 +112,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
@@ -109,6 +127,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@eb5ca3ab411449c66620fe7f1b3c9e10547144b0  # v18.0.0
         with:
@@ -124,6 +145,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
       - name: Run vale
         uses: errata-ai/vale-action@d89dee975228ae261d22c15adcd03578634d429c  # v2.1.1
         with:
@@ -136,6 +160,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
       - name: Run lychee
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2.8.0
         with:

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -40,6 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
 
       - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
         with:
@@ -139,6 +142,8 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
           fetch-depth: 0  # chart-releaser needs full history to detect tag bumps
 
       - name: Configure git identity

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -48,6 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
 
       - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Generate changelog

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,10 +19,10 @@
 #
 # Pinning policy (mandatory for every `uses:` and container `image:`):
 #   - Third-party actions pinned to a 40-char commit SHA, never to a
-#     movable tag (zizmor `unpinned-uses` would block merge on its own).
+#     movable tag (scripts/check-pin-policy.py blocks merge on its own).
 #   - Container images pinned to `name:tag@sha256:<digest>`.
 #   - Every actions/checkout call sets `persist-credentials: false`
-#     (zizmor `artipacked`).
+#     (the same check; zizmor calls this rule `artipacked`).
 
 name: security
 
@@ -522,8 +522,9 @@ jobs:
       # for version X, but running version Y"). Dependabot opens one PR per
       # SUBPATH, so a package used through four paths arrives as four PRs that
       # each break the set in isolation, and the failure names a version
-      # mismatch rather than the split bump behind it. zizmor proves each ref IS
-      # a SHA; nothing proved sibling subpaths share one.
+      # mismatch rather than the split bump behind it. check-pin-policy.py
+      # proves each ref IS a SHA; nothing proved sibling subpaths share one,
+      # which is what the checker below adds.
       - name: Self-test the action-pin checker
         run: python3 scripts/check-action-pin-consistency.py --self-test
 

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -19,9 +19,10 @@
 # `partial` until the release workflow lands.
 #
 # Pinning policy: every `uses:` and container `image:` is pinned to a
-# 40-char commit SHA / `@sha256:<digest>` — zizmor `unpinned-uses` would
-# block merge otherwise. Every actions/checkout sets
-# `persist-credentials: false` (zizmor `artipacked`).
+# 40-char commit SHA / `@sha256:<digest>`, and every actions/checkout sets
+# `persist-credentials: false`. scripts/check-pin-policy.py blocks merge on
+# all three; zizmor names the same rules `unpinned-uses` and `artipacked` but
+# has never run in this repository.
 
 name: supply-chain
 

--- a/scripts/check-pin-policy.py
+++ b/scripts/check-pin-policy.py
@@ -19,6 +19,10 @@ Two rules, both of which zizmor would have covered:
   2. Every container `image:` carries `@sha256:<64-hex>`. A `name:tag` image is
      the same movable pointer wearing different syntax, and the workflows here
      run third-party containers as job hosts.
+  3. Every `actions/checkout` sets `persist-credentials: false` (zizmor calls
+     this `artipacked`). Without it the job token stays in `.git/config` for
+     every later step in the job -- including any third-party action that reads
+     the working tree. No workflow here pushes back, so nothing needs it.
 
 Local `./` and `docker://`-less reusable-workflow refs are out of scope: a
 relative path resolves inside this repository, so there is no upstream to move.
@@ -88,6 +92,36 @@ def unpinned_images(text: str) -> list[str]:
     return bad
 
 
+def persisting_checkouts(text: str) -> list[str]:
+    """`actions/checkout` steps that leave the job token in `.git/config`.
+
+    Reads the step BLOCK, not the file: a `persist-credentials: false` anywhere
+    in the file would otherwise vouch for every checkout in it, which is exactly
+    the shape build.yml has today -- nine checkouts, one flag.
+
+    A step ends at the next line indented no deeper than its own `- `, so the
+    scan is bounded by structure rather than by a fixed line count.
+    """
+    lines = text.splitlines()
+    bad = []
+    for i, line in enumerate(lines):
+        m = re.match(r"^(\s*)-\s+uses:\s*actions/checkout@", line)
+        if not m:
+            continue
+        indent = len(m.group(1))
+        block = []
+        for follow in lines[i + 1:]:
+            if not follow.strip():
+                continue
+            lead = len(follow) - len(follow.lstrip())
+            if lead <= indent:
+                break
+            block.append(follow)
+        if not any("persist-credentials: false" in b for b in block):
+            bad.append(f"line {i + 1}")
+    return bad
+
+
 def scan(root: pathlib.Path) -> dict[str, list[str]]:
     findings: dict[str, list[str]] = {}
     wf = root / ".github" / "workflows"
@@ -99,6 +133,10 @@ def scan(root: pathlib.Path) -> dict[str, list[str]]:
         text = path.read_text(encoding="utf-8")
         problems = [f"uses: {u}" for u in unpinned_uses(text)]
         problems += [f"image: {i}" for i in unpinned_images(text)]
+        problems += [
+            f"actions/checkout at {w} does not set persist-credentials: false"
+            for w in persisting_checkouts(text)
+        ]
         if problems:
             findings[str(path.relative_to(root))] = problems
     return findings, len(paths)
@@ -119,6 +157,34 @@ def _self_test() -> int:
         # The matrix VALUE form must not be read as an image ref, or every
         # workflow iterating image names reds and the check gets switched off.
         ("a matrix list item is not an image ref", "          - open-computer-use\n", unpinned_images, False),
+        # The block-scoped read is the whole point of rule 3: build.yml has nine
+        # checkouts and one flag, so a file-scoped search would have vouched for
+        # all nine on the strength of the ninth.
+        (
+            "a guarded checkout passes",
+            "      - uses: actions/checkout@x\n        with:\n          persist-credentials: false\n",
+            persisting_checkouts,
+            False,
+        ),
+        (
+            "an unguarded checkout is caught",
+            "      - uses: actions/checkout@x\n        with:\n          fetch-depth: 0\n",
+            persisting_checkouts,
+            True,
+        ),
+        (
+            "a checkout with no `with:` at all is caught",
+            "      - uses: actions/checkout@x\n      - run: echo\n",
+            persisting_checkouts,
+            True,
+        ),
+        (
+            "a flag on a LATER step does not vouch for an earlier checkout",
+            "      - uses: actions/checkout@x\n      - uses: actions/checkout@y\n"
+            "        with:\n          persist-credentials: false\n",
+            persisting_checkouts,
+            True,
+        ),
     ]
     failures = 0
     for name, text, fn, want_bad in cases:


### PR DESCRIPTION
Two workflows state that *"every actions/checkout sets `persist-credentials: false`"* and credit zizmor's `artipacked` with enforcing it. Measured:

```
checkouts in the tree            37
without persist-credentials      27
zizmor runs                       0
```

Same finding as the pinning half (#455), one rule over.

What that leaves behind is a **job token in `.git/config`, readable by every later step in the job** — including any third-party action that touches the working tree. No workflow here pushes back, so nothing needed the credential persisted; the flag was simply missing.

All 27 fixed. Verified through the **YAML parser** rather than by grepping text I had just written: 37 checkouts parse as steps, 37 carry `with.persist-credentials: false`.

**The checker reads the step BLOCK, not the file.** `build.yml` is why — nine checkouts, one flag, and a file-scoped search would have vouched for all nine on the strength of the ninth. The self-test pins that shape directly: a flag on a *later* step must not cover an earlier checkout.

My own hand count said 25; the gate said 27. **The gate was right** — I had subtracted flags from checkouts per file, which silently credits a flag to whichever checkout happens to need it. Worth stating, because that discrepancy is the reason to trust the block-scoped read.

Probes, each restored:

```
flag removed from codeql.yml         -> ::error:: ...checkout at line 24 does not set...
flag replaced with fetch-depth: 0    -> same finding
```

Also corrected four comments that credited zizmor with enforcement it does not perform. They now name `check-pin-policy.py`, and keep zizmor as the source of the rule *names* — which is what it actually is here.