### PR TITLE
ci(nfr): arm NFR-MAINT-AUDIT-SCHEMA, and count the rows the id pattern was skipping

### DIFF
--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -99,6 +99,13 @@ jobs:
       - name: OCSF class identity red-probe (RED-when-swapped, two-sided)
         run: python3 scripts/check-ocsf-class-identity.py --self-test
       - name: OCSF class identity (message title uid == vendored class uid)
+        # NFR-MAINT-AUDIT-SCHEMA. Its verification column asks for an "OCSF JSON
+        # CI gate", which is this step: it binds each fan-in message to the class
+        # it claims, so a vendored file re-pointed at another OCSF version fails
+        # here rather than validating clean. Named so check-nfr-coverage.py counts
+        # the requirement as armed -- and this job blocks, so the name is not
+        # decoration. The bridge-integration half of that row (CEF / ECS / UDM)
+        # has no gate yet and is not claimed by this line.
         run: python3 scripts/check-ocsf-class-identity.py
       # NFR-SEC-89. The self-test is the gate; it drives the verdict against
       # constructed API shapes including the ones that must FAIL, so the check
@@ -181,7 +188,7 @@ jobs:
         # unarmed remainder: that is the state of the layer, no single PR can
         # move it, and a gate nobody can turn green is a gate that gets ignored.
         # The number on every run is the point.
-        run: python3 scripts/check-nfr-coverage.py --min-armed 3
+        run: python3 scripts/check-nfr-coverage.py --min-armed 4
 
       - name: gate enforcement across the platform (report-only until protection is on)
         # The github context reaches the script through env, never by

--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -35,7 +35,13 @@ import pathlib
 import re
 import sys
 
-NFR_ID = re.compile(r"NFR-[A-Z]+-\d+")
+# Not `-\d+`: three rows do not end in a bare number -- NFR-FLEX-07a,
+# NFR-FLEX-07b (lowercase suffix) and NFR-MAINT-AUDIT-SCHEMA (a word). A
+# numeric-only pattern read the
+# manifesto as 187 rows when it holds 190, and an arm on any of the three would
+# have been invisible to the ratchet: the coverage number would not move and
+# nothing would say why.
+NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"
 # Where an executable check can live. Docs are excluded on purpose: an id named
 # in prose is the thing this script measures the absence of.
@@ -146,11 +152,16 @@ def _self_test() -> int:
         (root / MANIFESTO).write_text(
             "Prose mentioning NFR-SEC-99 which is not a row.\n"
             "| NFR-SEC-01 | a real row |\n"
-            "| NFR-SEC-02 | another row, see NFR-SEC-01 |\n",
+            "| NFR-SEC-02 | another row, see NFR-SEC-01 |\n"
+            # Neither of these ends in a bare number. The first pattern here
+            # read only `-\\d+` and silently undercounted the manifesto by
+            # three rows, which also made an arm on any of them invisible.
+            "| NFR-FLEX-07a | a lowercase-suffixed row |\n"
+            "| NFR-MAINT-AUDIT-SCHEMA | a word-suffixed row |\n",
             encoding="utf-8",
         )
         got = declared_ids(root)
-        want = {"NFR-SEC-01", "NFR-SEC-02"}
+        want = {"NFR-SEC-01", "NFR-SEC-02", "NFR-FLEX-07a", "NFR-MAINT-AUDIT-SCHEMA"}
         ok = got == want
         failures += 0 if ok else 1
         print(f"  {'ok' if ok else 'FAIL'}: only table rows count as declared ({sorted(got)})")


### PR DESCRIPTION
The OCSF class-identity step already does what that row's verification column asks for — an *"OCSF JSON CI gate"*. It binds each fan-in message to the class it claims, it blocks (`continue-on-error=False`), and it carries its own red-probe. Naming it there records something true rather than decorating a job that cannot fail.

The row's other half — CEF / ECS / UDM bridge integration — has no gate, and this line does not claim it.

**Arming it exposed a defect in the counter itself.** It matched `NFR-[A-Z]+-\d+`, so three rows were invisible:

```
NFR-FLEX-07a            lowercase suffix
NFR-FLEX-07b            lowercase suffix
NFR-MAINT-AUDIT-SCHEMA  word suffix
```

The denominator read **187 where the manifesto holds 190** — and worse, an arm on any of the three could never register: the count would not move, the ratchet would not notice, and nothing would say why. I found it by arming one of the three and watching the number stay at 3.

Pattern fixed to accept both shapes; the self-test now carries a fixture row of each. Probed: restoring `-\d+` fails that case by name, so the narrow pattern cannot come back quietly.

```
before   NFR coverage: 3 of 187
after    NFR coverage: 4 of 190
```

Ratchet moves to 4.