### PR TITLE
ci(nfr): give the NFR gates their own job

### DIFF
--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -110,6 +110,20 @@ jobs:
       # NFR-SEC-89. The self-test is the gate; it drives the verdict against
       # constructed API shapes including the ones that must FAIL, so the check
       # cannot quietly stop discriminating.
+  nfr-gates:
+    # Their own job, not more steps on the AsyncAPI one. They lived there
+    # because that is where the first of them landed, and a failure in
+    # step 3 -- a network validation against a remote schema -- skipped
+    # every one of them SILENTLY: no step with `if:` or continue-on-error,
+    # so an unrelated flake disarmed the whole NFR set and the run still
+    # reported the one failure it had. Measured before splitting: 16 steps
+    # in a job named for contracts, 10 of them about something else.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
       - name: gate-enforcement red-probe (six shapes, one clean)
         run: python3 scripts/check-gates-are-required.py --self-test
       # The live query is REPORT-ONLY today, and deliberately so: it currently
@@ -167,7 +181,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: python3 scripts/check-readiness-claim.py || true
-
       - name: the compliance-front-matter checker itself discriminates
         run: python3 scripts/check-compliance-front-matter.py --self-test
 


### PR DESCRIPTION
The NFR gates lived on the AsyncAPI job because that is where the first of them landed, and they kept accumulating: **16 steps in a job named for contracts, 10 of them about something else.**

**That is not cosmetic.** No step in that job carries `if:` or `continue-on-error`, so a failure at step 3 — a network validation against a remote schema — skips steps 4 through 16 silently:

```
step  3  Validate AsyncAPI documents        <- network, can flake
step  4  audit fan-in INV-1
step  5  OCSF class identity red-probe
...
step 15  how many NFRs are checked
step 16  gate enforcement across the platform
```

One flake would disarm the readiness claim, the coverage ratchet, the pin policy and the compliance count at once — and the run would report only the one failure it had. The gates would be missing and nothing would say so.

Ten steps moved. Verified by comparing the **parsed YAML**, not the diff:

```
moved out of asyncapi: 10
landed in nfr-gates:   10
lost entirely:         none
```

Every gate command is invoked the same number of times as before. Total step count rises by exactly one — the new job's checkout, pinned to the SHA the old job already used.

`asyncapi` keeps its six contract steps. `next/v1` has no required contexts, so a new job name breaks no merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation workflow reliability so readiness and quality checks run even when AsyncAPI validation encounters an issue.
  * Added independent execution and credential handling for these checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->