### PR TITLE
ci(nfr): arm NFR-SEC-15, and scan tests/ where its check actually lives

### DIFF
--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -214,7 +214,7 @@ jobs:
         # unarmed remainder: that is the state of the layer, no single PR can
         # move it, and a gate nobody can turn green is a gate that gets ignored.
         # The number on every run is the point.
-        run: python3 scripts/check-nfr-coverage.py --min-armed 5
+        run: python3 scripts/check-nfr-coverage.py --min-armed 6
 
       - name: gate enforcement across the platform (report-only until protection is on)
         # The github context reaches the script through env, never by

--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -45,7 +45,13 @@ NFR_ID = re.compile(r"NFR-[A-Z]+-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 MANIFESTO = "docs/architecture/manifesto/02-nfrs.md"
 # Where an executable check can live. Docs are excluded on purpose: an id named
 # in prose is the thing this script measures the absence of.
-CODE_DIRS = ("scripts", ".github")
+#
+# `tests` is here because that is where some checks actually are:
+# NFR-SEC-15's stated verification is the /home/assistant volume-size assertion
+# in tests/test-docker-image.sh, which build.yml runs and which blocks. Naming
+# it anywhere else to satisfy this scanner would put the id away from the
+# assertion that answers it.
+CODE_DIRS = ("scripts", ".github", "tests")
 
 
 def declared_ids(root: pathlib.Path) -> set[str]:

--- a/tests/test-docker-image.sh
+++ b/tests/test-docker-image.sh
@@ -149,6 +149,13 @@ else
 fi
 
 # 9. Volume size
+#
+# NFR-SEC-15 ("user-data volume-only; image carries no PII") is verified as
+# "/home/assistant/ volume <1 MB enforced in CI", which is this assertion. Named
+# here so check-nfr-coverage.py counts the requirement as armed -- and the job
+# that runs this script blocks, so the name is not decoration. Fail-closed by
+# construction: a du that cannot run leaves SIZE_KB empty and the ${SIZE_KB:-999999}
+# default fails rather than passing on a missing measurement.
 echo ""
 echo "[9/14] Volume size"
 SIZE_KB=$(run_in_container "du -sk /home/assistant/ | cut -f1") || SIZE_KB=""


### PR DESCRIPTION
That row's verification column names one thing: *"/home/assistant/ volume <1 MB enforced in CI"*. The assertion exists, it is exact (`du -sk` against 1024 KB), `build.yml` runs it on every push and pull request, and the job blocks — so naming the id there records something true.

It is also **fail-closed**, which is why it was worth arming rather than rewriting: a `du` that cannot run leaves `SIZE_KB` empty and the `${SIZE_KB:-999999}` default fails instead of passing on a missing measurement. Probed all three arms:

```
SIZE_KB=""      -> FAIL   (fail-closed)
SIZE_KB=512     -> PASS
SIZE_KB=2048    -> FAIL
```

**The counter could not see it.** `CODE_DIRS` was `("scripts", ".github")` and this check lives in `tests/`. Moving the id somewhere the scanner already looked would have put it *away* from the assertion that answers it, so the scanner's scope moved instead.

Checked for accidental arms after widening: exactly one NFR id is mentioned anywhere under `tests/`, and it is this one.

Probes, each restored:

```
NFR-SEC-15 renamed out of the test  ->  "armed NFRs dropped to 5, below the floor of 6", exit 1
--min-armed 7 (above reality)        ->  exit 1
--min-armed 6 (the shipped floor)    ->  exit 0
```

Coverage moves to **6 of 190**.