### PR TITLE
ci(nfr): arm NFR-SEC-07 on the rehearsal, because the release path has never run

### DIFF
--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -214,7 +214,7 @@ jobs:
         # unarmed remainder: that is the state of the layer, no single PR can
         # move it, and a gate nobody can turn green is a gate that gets ignored.
         # The number on every run is the point.
-        run: python3 scripts/check-nfr-coverage.py --min-armed 6
+        run: python3 scripts/check-nfr-coverage.py --min-armed 7
 
       - name: gate enforcement across the platform (report-only until protection is on)
         # The github context reaches the script through env, never by

--- a/.github/workflows/gate3-rehearsal.yml
+++ b/.github/workflows/gate3-rehearsal.yml
@@ -48,6 +48,14 @@ permissions:
 
 jobs:
   rehearsal:
+    # NFR-SEC-07 (supply chain: SBOM + SLSA + cosign per release). The release
+    # workflow that carries the real thing fires on `v*` tags only and has NEVER
+    # RUN -- 24 tags exist and supply-chain.yml has zero runs, because the tags
+    # predate it. So the id is named HERE, on the rehearsal that exercises the
+    # same pipeline on every pull request: syft, cosign, sign, verify, and the
+    # red legs (an empty SBOM, an absent digest, a foreign digest that must not
+    # verify). This job blocks. Naming it on supply-chain.yml instead would
+    # claim a requirement is measured by something no run has ever executed.
     name: release — gate 3 rehearsal (nothing published)
     runs-on: ubuntu-latest
     services:


### PR DESCRIPTION
`supply-chain.yml` carries the real pipeline — syft, cosign, in-toto attestation, signature verification — and fires on `v*` tags only.

**It has zero runs.**

```
tags in the repo                    24
supply-chain.yml runs                0
```

All 24 tags predate the workflow, so the release gate this NFR names has never once executed. Naming the id there would claim a requirement is measured by something no run has ever performed — the exact shape this counter exists to catch, and the easy place to have put it.

`gate3-rehearsal.yml` exercises the same pipeline **on every pull request** against a throwaway registry: syft SBOM, ephemeral keypair, sign by digest, verify — plus three red legs:

```
RED LEG - an SBOM describing nothing must stop the pipeline
RED LEG - an absent digest must be refused before cosign
RED LEG - a different digest must not verify against this signature
```

The job blocks. That is the executable half of NFR-SEC-07, so that is where the id goes.

**What this does not claim:** the per-release half. SLSA L3 provenance and VEX per known CVE on a real release artifact remain unproven until `supply-chain.yml` runs at least once. The comment says so at the naming site rather than letting the arm imply more than it holds.

Probes, each restored:

```
NFR-SEC-07 renamed out  ->  "armed NFRs dropped to 6, below the floor of 7", exit 1
--min-armed 8           ->  exit 1
--min-armed 7           ->  exit 0
```

Coverage moves to **7 of 190**.