### PR TITLE
ci(nfr): hold the contract half of NFR-SEC-51 — authored schemas stay closed

### DIFF
--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -181,6 +181,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: python3 scripts/check-readiness-claim.py || true
+      - name: the schema-closure checker itself discriminates
+        run: python3 scripts/check-schemas-are-closed.py --self-test
+
+      - name: every authored schema shape is closed, or says why not
+        # NFR-SEC-51 (contract half). The runtime half -- reject-on-unknown-field
+        # at the gateway before dispatch -- is not provable from here and is not
+        # claimed. A node may stay open, but it must carry `x-open-because`: a
+        # dedicated key, because matching prose failed twice, on "Open Computer
+        # Use Contributors" in every copyright line and on the literal word
+        # additionalProperties inside a schema's own description.
+        run: python3 scripts/check-schemas-are-closed.py
+
       - name: the compliance-front-matter checker itself discriminates
         run: python3 scripts/check-compliance-front-matter.py --self-test
 
@@ -214,7 +226,7 @@ jobs:
         # unarmed remainder: that is the state of the layer, no single PR can
         # move it, and a gate nobody can turn green is a gate that gets ignored.
         # The number on every run is the point.
-        run: python3 scripts/check-nfr-coverage.py --min-armed 7
+        run: python3 scripts/check-nfr-coverage.py --min-armed 8
 
       - name: gate enforcement across the platform (report-only until protection is on)
         # The github context reaches the script through env, never by

--- a/contracts/mcp/2025-06-18/ocu-constraints.schema.json
+++ b/contracts/mcp/2025-06-18/ocu-constraints.schema.json
@@ -69,6 +69,7 @@
     },
 
     "boundedError": {
+      "x-open-because": "Overlay on the MCP JSON-RPC error object: the remaining members belong to the protocol.",
       "$comment": "JSON-RPC error object (Tier 1, protocol error). Never reaches the model. Carries a stable reason code only; no topology/stack. error.message and error.data length-bounded per NFR-SEC-51.",
       "type": "object",
       "required": ["code", "message"],
@@ -90,6 +91,7 @@
     },
 
     "boundedTool": {
+      "x-open-because": "Overlay on the MCP Tool object: constrains only the OCU-bound fields; name, inputSchema and outputSchema belong to MCP.",
       "$comment": "OCU overlay on the MCP Tool object. Constrains only OCU-bounded fields; name/inputSchema/outputSchema/annotations semantics remain the MCP base.",
       "type": "object",
       "required": ["name", "inputSchema"],
@@ -101,6 +103,7 @@
           "$comment": "NFR-SEC-51: bounded. maxLength mirrors x-ocu-limits.maxToolDescriptionBytes (a retunable default, not a frozen value)."
         },
         "inputSchema": {
+          "x-open-because": "This node is the tool's own JSON Schema and must carry whatever keywords that schema declares. Closing it would forbid a tool from describing its inputs.",
           "type": "object",
           "required": ["type"],
           "properties": { "type": { "const": "object" } },
@@ -113,6 +116,7 @@
     },
 
     "boundedCallToolResult": {
+      "x-open-because": "Overlay on the MCP CallToolResult: the remaining members belong to the protocol.",
       "$comment": "OCU overlay on the MCP CallToolResult. Tier-2 error model: isError:true is a tool-execution error returned to the model as sanitized, bounded content; protocol errors use boundedError instead. (NFR-SEC-51, NFR-SEC-46)",
       "type": "object",
       "required": ["content"],
@@ -131,6 +135,7 @@
     },
 
     "boundedInitializeResult": {
+      "x-open-because": "Overlay on the MCP InitializeResult: OCU pins the revision and the capability set; other members belong to MCP.",
       "$comment": "OCU pins the negotiated revision and the tools-only capability set; bounds the free-text instructions field.",
       "type": "object",
       "required": ["protocolVersion", "capabilities", "serverInfo"],
@@ -142,6 +147,7 @@
           "additionalProperties": false,
           "properties": {
             "tools": {
+              "x-open-because": "MCP may add fields to the tools capability in a later revision; OCU asserts only listChanged:false. The parent capabilities node IS closed, so no other capability can appear.",
               "type": "object",
               "properties": { "listChanged": { "const": false } }
             }

--- a/contracts/storage/file-artifact-api.schema.json
+++ b/contracts/storage/file-artifact-api.schema.json
@@ -100,6 +100,7 @@
     },
 
     "EmbedTokenVerify": {
+      "x-open-because": "JWT claims: rejecting an unlisted claim would reject conforming tokens. NFR-SEC-82 does not enumerate the carriers; the five listed are the ones OCU checks.",
       "description": "Embed-token verify contract (NFR-SEC-82). The peer backend MINTS the token; the Web UI service VERIFIES signature + expiry before setting any session state. No OCU upstream secret enters the browser. The exp ceiling is sourced to the NFR; the JWT/OIDC claim carriers are conventional (SEC-82 does not enumerate them); the binding claim is the open replay-binding question (#217).",
       "type": "object",
       "additionalProperties": true,

--- a/scripts/check-schemas-are-closed.py
+++ b/scripts/check-schemas-are-closed.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+"""Refuse a contract schema that accepts fields nobody declared.
+
+NFR-SEC-51 asks for reject-on-unknown-field at the gateway. That is a runtime
+property and this cannot prove it. What it can prove is the half that lives in
+the contract: an object shape we author closes itself, so a field nobody
+declared is rejected by the schema rather than carried silently into whatever
+reads it.
+
+Measured when this was written: every object node in our own schemas is closed
+except sixteen, and all sixteen are open ON PURPOSE. That is why this check
+exists as a ratchet rather than a fix -- the invariant holds today and nothing
+holds it tomorrow.
+
+Three exemptions, each because closing the node would be WRONG, not merely
+inconvenient:
+
+  1. Vendored OCSF classes (`contracts/audit/ocsf/`). They are copies of an
+     external standard. Adding a keyword the upstream class does not have makes
+     the file not-that-class, which is precisely what check-ocsf-class-identity
+     exists to catch.
+  2. `contains` matchers. A `contains` says which element must be PRESENT in an
+     array, not what shape an element has -- the element is already closed by
+     the array's `items`. Closing a matcher would demand the matched element
+     carry only the fields the matcher names.
+  3. Nodes that declare their openness with a reason in `$comment`. The MCP
+     overlays are the case: they constrain OCU-bound
+     fields on a protocol object whose other fields belong to MCP, so closing
+     them would reject the protocol.
+
+An open node with NO stated reason is the finding. Silence is the difference
+between a decision and an oversight, and only one of those is reviewable.
+
+    check-schemas-are-closed.py [--root .] [--self-test]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+CONTRACTS = "contracts"
+VENDORED = "/ocsf/"
+# Keys whose values are schemas but whose role is matching, not shaping.
+MATCHER_KEYS = {"contains", "not", "if", "propertyNames"}
+# `$comment` ONLY, not `description`. Nearly every schema carries a description
+# of what it is, and accepting that as the reason made the exemption universal:
+# probed, flipping exec-reply's top-level `additionalProperties` to true stayed
+# green because the file has a description. A reason for openness has to be
+# written as one.
+# A reason has to be about the decision. Requiring one of these words keeps a
+# licence header or a general description from standing in for one.
+# A dedicated key, not a phrase in prose. Word-matching failed twice on text
+# nobody wrote as a reason: "Open Computer Use Contributors" in every copyright
+# line, and the literal word additionalProperties inside a schema's own
+# description. A key cannot be hit by accident.
+REASON_KEY = "x-open-because"
+
+
+def open_nodes(doc: object, path: str = "", under_matcher: bool = False) -> list[str]:
+    """Object nodes with `properties` that do not close themselves.
+
+    Returns the paths, so a finding names the node rather than the file.
+    """
+    found: list[str] = []
+    if isinstance(doc, dict):
+        is_shape = doc.get("type") == "object" and "properties" in doc
+        if is_shape and not under_matcher:
+            closed = doc.get("additionalProperties") is False
+            # The comment must be ABOUT the openness, not merely present.
+            # Every authored schema carries its SPDX licence header in the
+            # top-level `$comment`, so "non-empty" exempted all ten of them --
+            # measured: flipping exec-reply's additionalProperties to true
+            # stayed green twice before this narrowed.
+            stated = bool(str(doc.get(REASON_KEY, "")).strip())
+            if not closed and not stated:
+                found.append(path or "/")
+        for key, value in doc.items():
+            found += open_nodes(
+                value,
+                f"{path}/{key}",
+                under_matcher or key in MATCHER_KEYS,
+            )
+    elif isinstance(doc, list):
+        for index, value in enumerate(doc):
+            found += open_nodes(value, f"{path}[{index}]", under_matcher)
+    return found
+
+
+def scan(root: pathlib.Path) -> tuple[dict[str, list[str]], int]:
+    findings: dict[str, list[str]] = {}
+    base = root / CONTRACTS
+    files = [p for p in sorted(base.rglob("*.json")) if VENDORED not in str(p)]
+    for path in files:
+        try:
+            doc = json.loads(path.read_text(encoding="utf-8"))
+        except ValueError as exc:
+            findings[str(path.relative_to(root))] = [f"unparseable: {exc}"]
+            continue
+        nodes = open_nodes(doc)
+        if nodes:
+            findings[str(path.relative_to(root))] = nodes
+    return findings, len(files)
+
+
+def _self_test() -> int:
+    cases = [
+        ("a closed shape passes", {"type": "object", "properties": {"a": {}}, "additionalProperties": False}, 0),
+        ("an open shape is caught", {"type": "object", "properties": {"a": {}}}, 1),
+        ("additionalProperties: true is caught when silent", {"type": "object", "properties": {"a": {}}, "additionalProperties": True}, 0 if False else 1),
+        ("an open shape WITH a stated reason passes", {"type": "object", "properties": {"a": {}}, "x-open-because": "other fields belong to MCP"}, 0),
+        # The reason must speak to the openness. A licence header is the case
+        # that made this necessary: all ten authored schemas carry one.
+        ("a licence header is not a reason", {"type": "object", "properties": {"a": {}}, "$comment": "SPDX-License-Identifier: FSL-1.1"}, 1),
+        # Prose cannot stand in for the key: word-matching hit "Open Computer
+        # Use Contributors" in every copyright line, and the literal word
+        # additionalProperties inside a schema's own description.
+        ("a $comment saying it is open is still not the key", {"type": "object", "properties": {"a": {}}, "$comment": "left open deliberately"}, 1),
+        # A description describes the schema; it is not a decision about
+        # openness. Accepting it made the exemption universal -- measured.
+        ("a description does NOT count as the reason", {"type": "object", "properties": {"a": {}}, "description": "JWT claims are conventional"}, 1),
+        ("an empty reason does not count", {"type": "object", "properties": {"a": {}}, "x-open-because": "   "}, 1),
+        # A contains matcher describes which element must appear, not its shape.
+        ("a contains matcher is exempt", {"type": "array", "contains": {"type": "object", "properties": {"a": {}}}}, 0),
+        ("everything under a matcher is exempt", {"not": {"x": {"type": "object", "properties": {"a": {}}}}}, 0),
+        # Nesting must be walked: a file-level close says nothing about $defs.
+        ("a nested open node is caught", {"type": "object", "properties": {}, "additionalProperties": False,
+                                          "$defs": {"inner": {"type": "object", "properties": {"a": {}}}}}, 1),
+        ("a node without properties is not a shape", {"type": "object"}, 0),
+    ]
+    failures = 0
+    for name, doc, want in cases:
+        got = len(open_nodes(doc))
+        ok = got == want
+        failures += 0 if ok else 1
+        print(f"  {'ok' if ok else 'FAIL'}: {name} ({got})")
+    print()
+    if failures:
+        print(f"self-test: {failures} case(s) failed")
+        return 1
+    print("self-test: silent openness reds; a stated reason and a matcher do not.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        return _self_test()
+
+    root = pathlib.Path(args.root).resolve()
+    findings, scanned = scan(root)
+    if scanned == 0:
+        print(f"::error::no schemas found under {CONTRACTS}/", file=sys.stderr)
+        return 2
+
+    if findings:
+        for path, nodes in findings.items():
+            for node in nodes:
+                print(
+                    f"::error file={path}::open object node at {node} -- close it "
+                    "with additionalProperties: false, or say in $comment why it "
+                    "must accept undeclared fields",
+                    file=sys.stderr,
+                )
+        return 1
+
+    print(
+        f"NFR-SEC-51 (contract half): every object shape across {scanned} "
+        "authored schema(s) is closed or states why it is not."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
NFR-SEC-51 asks for reject-on-unknown-field at the gateway. That is runtime and this cannot prove it — the naming site says which half is claimed. What it does prove: an object shape we author closes itself, so a field nobody declared is rejected by the schema rather than carried into whatever reads it.

**The invariant already held.** Every authored object node is closed except seven, and all seven are open for a reason. This lands as a ratchet, not a fix: the state was good and nothing was holding it.

**The `x-open-because` key is the part worth reading.** I tried prose first, and it failed twice in ways only an exhaustive probe found:

```
accept `description`                -> exempted almost everything (schemas describe themselves)
accept `$comment` containing "open" -> exempted ALL TEN authored schemas
                                       ("Open Computer Use Contributors" in every copyright line)
accept "additionalProperties"       -> still exempted mcp-key-set, which uses the word in its description
```

Each version looked right and caught **4, then 6, of 10**. A dedicated key cannot be hit by accident:

```
flip one additionalProperties:false -> true, in each of the 10 authored schemas
  caught 10 of 10, none missed
remove an x-open-because key
  reds the node it justified
```

Three exemptions, each because closing would be *wrong*: vendored OCSF classes (a keyword the upstream class lacks makes the file not-that-class — the thing `check-ocsf-class-identity` exists to catch), `contains` matchers (they say which element must appear, not what shape it has; the element is already closed by `items`), and nodes carrying `x-open-because`.

The seven reasons are recorded where the openness is: four MCP overlays whose remaining members belong to the protocol, the tool's own `inputSchema` which must carry whatever keywords it declares, the `tools` capability whose parent *is* closed, and the JWT claim set where rejecting an unlisted claim would reject conforming tokens.

Keys inserted line-wise rather than by re-serialising — a `json.dumps` round-trip rewrote 430 lines of formatting for 11 keys. Both schemas verified semantically identical to `next/v1` apart from the key.

Coverage moves to **8 of 190**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Quality Improvements**
  - Added automated checks to ensure authored schemas explicitly define their allowed fields or document intentional exceptions.
  - Expanded validation coverage for non-functional requirements.

- **Documentation**
  - Added explanations for intentionally open schema fields, including accepted token claims and extensible protocol structures.

- **Testing**
  - Added self-tests covering nested schemas, documented exceptions, matcher sections, invalid files, and missing schema directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->