### PR TITLE
ci(nfr): arm the storage half of NFR-SEC-87

### DIFF
--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -226,7 +226,7 @@ jobs:
         # unarmed remainder: that is the state of the layer, no single PR can
         # move it, and a gate nobody can turn green is a gate that gets ignored.
         # The number on every run is the point.
-        run: python3 scripts/check-nfr-coverage.py --min-armed 8
+        run: python3 scripts/check-nfr-coverage.py --min-armed 9
 
       - name: gate enforcement across the platform (report-only until protection is on)
         # The github context reaches the script through env, never by

--- a/contracts/mcp/mcp-key-set.schema.json
+++ b/contracts/mcp/mcp-key-set.schema.json
@@ -69,6 +69,7 @@
       ]
     },
     "HashedKeyRecord": {
+      "x-nfr": "NFR-SEC-87 (storage half): the record is closed and carries key_hash + salt only, so a plaintext or unsalted key cannot appear in a set this schema accepts. The issuance half -- sk-ocu- prefix, >=256-bit CSPRNG entropy -- is not expressible here: this artifact holds already-hashed keys, so the un-hashed key never reaches it.",
       "description": "One MCP API key as a salted hash plus its binding metadata. NEVER the plaintext secret. Required: key_id, key_hash, salt, tenant, deployment, status, created_at. Optional: expires_at (absent => non-expiring, so the one-click path is not blocked). additionalProperties:false forbids any extra field smuggling a secret in.",
       "type": "object",
       "additionalProperties": false,

--- a/scripts/check-schemas-are-closed.py
+++ b/scripts/check-schemas-are-closed.py
@@ -3,6 +3,14 @@
 # Copyright (c) 2025 Open Computer Use Contributors
 """Refuse a contract schema that accepts fields nobody declared.
 
+Two requirements rest on this, and only the halves stated here are claimed.
+
+NFR-SEC-87 (storage half): the MCP key set holds `key_hash` + `salt` and the
+record is CLOSED, so a plaintext or unsalted key cannot appear in a set this
+schema accepts -- probed, opening HashedKeyRecord reds by name. The issuance
+half (`sk-ocu-` prefix, >=256-bit CSPRNG entropy) is not expressible in this
+artifact: it holds already-hashed keys, so the un-hashed key never reaches it.
+
 NFR-SEC-51 asks for reject-on-unknown-field at the gateway. That is a runtime
 property and this cannot prove it. What it can prove is the half that lives in
 the contract: an object shape we author closes itself, so a field nobody


### PR DESCRIPTION
The MCP key set holds `key_hash` + `salt`, and `HashedKeyRecord` is closed — so a plaintext or unsalted key cannot appear in a set the schema accepts. That is enforced by the closure checker, which blocks:

```
additionalProperties: true on HashedKeyRecord  ->  caught by name
restored                                        ->  exit 0
```

**The issuance half is not claimed**, and the comment says so at both sites. The `sk-ocu-` prefix and the ≥256-bit CSPRNG floor are properties of a key being *minted*; this artifact holds already-hashed keys, so the un-hashed key never reaches it. Checked before deciding what to claim: the schema mentions the prefix only in prose, never as a constraint.

**The id is named in the checker, not only in the schema.** A name in the artifact records intent; the coverage counter only counts a name where the *check* is. `contracts/` is deliberately not a scanned directory — a schema is not a gate.

Schema verified identical to `next/v1` apart from the `x-nfr` key.

Coverage moves to **9 of 190**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the documented fields accepted for hashed key storage.
  * Documented the scope and limitations of schema validation checks.

* **Chores**
  * Increased the contracts lint workflow threshold to require coverage of nine non-functional requirements.
  * Improved validation guidance for security-related schema checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->