### PR TITLE
ci(nfr): arm the class half of NFR-SEC-88

### DIFF
--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -226,7 +226,7 @@ jobs:
         # unarmed remainder: that is the state of the layer, no single PR can
         # move it, and a gate nobody can turn green is a gate that gets ignored.
         # The number on every run is the point.
-        run: python3 scripts/check-nfr-coverage.py --min-armed 9
+        run: python3 scripts/check-nfr-coverage.py --min-armed 10
 
       - name: gate enforcement across the platform (report-only until protection is on)
         # The github context reaches the script through env, never by

--- a/scripts/check-ocsf-class-identity.py
+++ b/scripts/check-ocsf-class-identity.py
@@ -4,6 +4,13 @@
 #
 # Binds each audit-fan-in message to the OCSF class it claims.
 #
+# NFR-SEC-88 (class half): the control-plane authentication trail must be an
+# OCSF Authentication (3002) event. This holds the CLASS -- `title: Authentication
+# (OCSF 3002)` is checked against the vendored class file, so re-pointing that
+# message at another class fails here. The emission half (every authentication
+# act produces one, failures counted, fail-open with counted loss) is runtime
+# and is not claimed by this check.
+#
 # The AsyncAPI validator beside this one checks that every payload $ref resolves
 # to a well-formed JSON Schema. It does not check WHICH schema: replacing a
 # vendored OCSF class with `{"type": "integer", "minimum": 5}` passes it (probed


### PR DESCRIPTION
The control-plane authentication trail must be an OCSF **Authentication (3002)** event. The identity gate already holds that half: the message title carries the uid and is checked against the vendored class file.

```
title: Authentication (OCSF 3002)  ->  3004   ::error:: ...:294: 'Authentication' class...
restored                                exit 0
```

**The emission half is not claimed.** Every authentication act producing one, failures counted, fail-open with counted loss — those are runtime properties no lint reaches. The comment says so where the id is named.

**Worth recording for whoever arms the rest:** NFR-SEC-88 is *already* named in `contracts/audit/audit-fanin.asyncapi.yaml`, in prose about emission discipline. The counter does not see it, and should not — `contracts/` is not scanned because a contract is not a gate. The id now sits on the check that enforces the part a check can.

Probes:

```
class swapped 3002 -> 3004        ->  reds by file and line
NFR-SEC-88 renamed out of the gate ->  "dropped to 9"
--min-armed 11 (above reality)     ->  exit 1
```

Coverage moves to **10 of 190**.