### PR TITLE
ci(layer0): require nfr-gates when protection is turned on

### DIFF
--- a/scripts/apply-layer0-protection.sh
+++ b/scripts/apply-layer0-protection.sh
@@ -32,10 +32,18 @@ if [ "${1:-}" = "--dry-run" ]; then DRY_RUN=1; shift; fi
 REPO="${1:-Wide-Moat/open-computer-use}"
 BRANCH="${2:-next/v1}"
 
-# The eight that must be required. The two that must not are named below,
+# The nine that must be required. The two that must not are named below,
 # because "leave them out" is easy to satisfy by accident and easy to undo
 # by accident too.
+#
+# nfr-gates joined the list after the other eight. It carries the
+# deployment-readiness claim, the NFR-coverage ratchet, the pin policy and the
+# cross-repo NFR-SEC-89 verdict -- the checks that measure whether this
+# architecture holds. Leaving it optional would let a merge past the gate that
+# reports the goal, which is the same shape as leaving gitleaks optional: the
+# job would still run and still be green, and nothing would depend on it.
 REQUIRED=(
+  "nfr-gates"
   "secrets — gitleaks"
   "secrets — trufflehog"
   "SAST — semgrep"


### PR DESCRIPTION
The applier pins eight contexts. **`nfr-gates` was created after that list and was not in it** — so switching protection on would have left every NFR check optional: the deployment-readiness claim, the coverage ratchet, the pin policy and the cross-repo NFR-SEC-89 verdict, all mergeable past while staying green.

That is the same shape as leaving `gitleaks` optional. The job runs, the job is green, and nothing depends on it — *presence is not enforcement* is the sentence this script exists to act on.

**Checked before assuming a defect.** The narrow list is deliberate: the comment says *"the eight that must be required"* — Layer 0 is a floor, not a mirror of every blocking job. Twenty-eight other blocking jobs stay out for that reason, and the two deliberate exclusions are untouched:

```
Trivy SARIF upload   reports upload success, not scan findings
CodeRabbit           commit-status surface, not a check run
```

Nine now. Probed against the live head:

```
dry run                       ->  present  nfr-gates
name changed to a typo        ->  ABSENT   nfr-gates-typo
                                  REFUSED: 1 name(s) do not match anything the head reported
```

This is the one thing left that would have made the owner-side protection flip land incomplete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release protection checks to include deployment-readiness, non-functional requirements, pin-policy, and cross-repository validation.
  * Added safeguards to ensure all required quality gates pass before protected changes are accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->