### PR TITLE
fix(lychee): write the config in the shape 2.9 requires, before the bump lands

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -19,7 +19,14 @@ exclude_path = [
 
 # Match the forward-reference rule: a relative path that doesn't resolve on
 # disk is a broken link, period.
-include_fragments = true
+# An enum since lychee 2.9: none | anchor-only | text-only | full. The boolean
+# this replaced enabled ANCHOR fragments, so anchor-only is the same behaviour
+# under the new name; full would silently widen the check to text fragments.
+# Written here ahead of the action bump: main took lychee-action 2.9.0 and the
+# boolean failed config parsing outright, and this branch is still on 2.8.0 and
+# would break the same way when the bump arrives. Measured: the enum gives an
+# identical 1847 total / 1518 OK / 3 errors on both versions.
+include_fragments = "anchor-only"
 
 # Patterns to allow without HTTP checking (anchor-only refs, mailto, etc.).
 exclude = [


### PR DESCRIPTION
`main` took `lychee-action` 2.9.0 today (#480) and the existing config **failed to parse outright** — `include_fragments` is an enum there, not a boolean:

```
TOML parse error at line 22, column 21
   22 | include_fragments = true
      |                     ^^^^
   wanted string or table
```

The run died on config loading rather than reporting a link result — a red that looks like a link failure and is not one.

**This branch is still on 2.8.0**, so it works today and would break the same way the moment dependabot opens the same bump here. Fixing it now costs nothing.

**Measured, not assumed.** The local `lychee 0.24.2` — the version 2.9.0 ships — already *refuses* the boolean:

```
include_fragments = true            -> config parse error
include_fragments = "anchor-only"   -> 1847 total / 1518 OK / 3 errors
```

`anchor-only`, not `full`: the boolean enabled **anchor** fragments (`#section`), and `full` would silently widen the check to text fragments (`#:~:text=`) — a behaviour change arriving under a dependency bump.

The three errors are pre-existing root-relative links under `/mnt/skills`, unrelated to fragments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated link checking to support anchor-only fragment validation with the newer configuration format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->