### PR TITLE
docs(ci): record that the lychee config tracks the action, not the pin

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -137,6 +137,17 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Run lychee
+        # The action pin fixes the WRAPPER, not the tool: lychee-action
+        # resolves the binary itself, and the config schema moves with it.
+        # 2.8.0 pulls lychee 0.23.0, which wants `include_fragments = true`;
+        # 2.9.0 pulls 0.24.x, which wants the enum lychee.toml now carries and
+        # REFUSES the boolean. A config edit therefore belongs in the same PR
+        # as the action bump: neither value satisfies both, and a config that
+        # is right for the next version is a hard red on this one.
+        #
+        # Measured the wrong way once -- a local lychee accepted the enum and
+        # I took that for proof. The version that decides is the one the job
+        # downloads, which the run log names as lychee-v0.23.0.
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8  # v2.9.0
         with:
           # We only care about *internal* / forward-reference link integrity.


### PR DESCRIPTION
The config was fixed when the action bumped (#480), but nothing said *why* it has the shape it has. The next person to touch either will hit what I hit.

**The action pin fixes the wrapper, not the tool.** `lychee-action` resolves the binary itself, and the config schema moves with it:

```
lychee-action 2.8.0  ->  lychee 0.23.0  ->  include_fragments wants a BOOLEAN
lychee-action 2.9.0  ->  lychee 0.24.x  ->  wants the ENUM, refuses the boolean
```

Neither value satisfies both versions, so a config edit belongs in the same PR as the bump — and a config written for the *next* version is a hard red on the current one.

**I learned that by getting it wrong.** A preemptive PR (#482, now closed) moved `next/v1` to the enum while it still runs 2.8.0, and CI answered:

```
invalid type: string "anchor-only", expected a boolean
See: .../lychee-v0.23.0/lychee.example.toml
```

I had verified against the lychee on my machine — 0.24.2. Same name, different schema.

The note also names where the deciding version is visible: the run log (`lychee-v0.23.0`), not `tool --version`.

`ocu-webui` already carries an equivalent warning at its own call site; this repo did not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added explanatory comments to the documentation link-checking workflow.
  * Clarified tool versions, configuration compatibility, and the version used during checks.
  * No workflow behavior or end-user functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->