### PR TITLE
test(image): assert tsx RUNS a file, and say why when it does not

### DIFF
--- a/tests/test-docker-image.sh
+++ b/tests/test-docker-image.sh
@@ -35,6 +35,15 @@ run_in_container() {
     docker run --rm --platform linux/amd64 --entrypoint=bash --user=assistant "$IMAGE" -c "$1" 2>/dev/null
 }
 
+# Same run, but stderr is KEPT. run_in_container discards it, which is correct
+# for an assertion -- a tool's chatter is not the subject -- and useless the
+# moment something fails for a reason only stderr carries. #426 stalled exactly
+# there: the tsx probe failed in CI, the cause was suppressed, and diagnosing it
+# needed a machine that could build the image.
+run_in_container_verbose() {
+    docker run --rm --platform linux/amd64 --entrypoint=bash --user=assistant "$IMAGE" -c "$1" 2>&1
+}
+
 echo "=== Testing Docker image: $IMAGE ==="
 echo ""
 
@@ -108,6 +117,29 @@ for tool in mmdc tsc tsx claude codex opencode; do
     VRESULT=$(run_in_container "$tool --version >/dev/null 2>&1 && echo OK || echo FAIL") || VRESULT=""
     echo "$VRESULT" | grep -q "OK" && pass "$tool --version exit 0" || fail "$tool --version failed"
 done
+
+# tsx must RUN a file, not merely answer --version. #425 removed ts-node because
+# TypeScript 7 deletes the API it consumed, which leaves tsx as the only way a
+# skill executes TypeScript -- so "installed" stopped being a sufficient claim.
+#
+# On failure this prints the command's own stderr. The first attempt at this
+# check (#426) suppressed it, the CI failure said only "FAIL: tsx execution",
+# and finding the cause needed someone who could build and enter the image.
+# A check that cannot say why it failed defers the work rather than doing it.
+TSX_PROBE='cd /tmp && printf "console.log(\"tsx-ok\", 2*2);\n" > tsxprobe.ts && tsx tsxprobe.ts'
+# NOT `|| TSX_OUT="..."`: that fires on a NON-ZERO EXIT, which is exactly the
+# failing case, and overwrites the captured stderr with a placeholder. Probed --
+# it turned a real "Cannot find module" into "<docker run failed>", reproducing
+# the uninformative output this check exists to replace. Capture first, then
+# read the status separately.
+TSX_OUT=$(run_in_container_verbose "$TSX_PROBE"; echo "rc=$?")
+if echo "$TSX_OUT" | grep -q "tsx-ok 4"; then
+    pass "tsx executes a TypeScript file"
+else
+    fail "tsx cannot execute a TypeScript file"
+    echo "    the container said:"
+    echo "$TSX_OUT" | sed 's/^/      /' | head -20
+fi
 
 # list-subagent-models presence + executability (Phase 1 / Plan 01-05 install line)
 RESULT=$(run_in_container "which list-subagent-models >/dev/null 2>&1 && echo OK || echo MISSING") || RESULT=""


### PR DESCRIPTION
The image test checks that `tsx` is on PATH and answers `--version`. Neither proves it can execute TypeScript — and #425 removed `ts-node` (TypeScript 7 deletes the API it consumed), leaving `tsx` as the only way a skill runs a `.ts` file. *Installed* stopped being a sufficient claim.

**Why this was not done in #425.** That attempt failed in CI with `FAIL: tsx execution` and nothing else, because `run_in_container` discards stderr — right for an assertion, useless for a diagnosis. The finding was filed as #426, asking for someone who could build the image and look inside.

**I cannot build it either.** This environment cannot reach Docker Hub: `docker pull ubuntu:24.04` times out, so the `FROM` line never resolves. What I *can* remove is the reason the next person needs a machine at all. The check now runs through a verbose helper that keeps stderr and prints the container's own words on failure.

**One defect in my own check, found by probing rather than reading.** I first wrote:

```sh
TSX_OUT=$(run_in_container_verbose "$PROBE") || TSX_OUT="<docker run failed>"
```

The `||` fires on a **non-zero exit** — exactly the failing case — replacing the captured stderr with a placeholder. Probed with a stub that writes a real error and exits 1:

```
before:  FAIL: tsx cannot execute a TypeScript file
           <docker run failed>            <- reproduces the very problem
after:   FAIL: tsx cannot execute a TypeScript file
           Error: Cannot find module tsx
           rc=1
```

Both arms probed against a stand-in for the container, since the image cannot be built here: a stub printing `tsx-ok 4` passes; a stub failing on stderr fails and shows the error.

Closes the diagnosis half of #426. Whether `tsx` actually works in the image is what the next CI run will now answer, out loud.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a Docker image validation probe for executing temporary TypeScript files with `tsx`.
  * Improved diagnostic reporting by preserving command output and displaying relevant failure details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->