### PR TITLE
ci(layer0): require asyncapi, now that it is hermetic

### DIFF
--- a/scripts/apply-layer0-protection.sh
+++ b/scripts/apply-layer0-protection.sh
@@ -32,9 +32,16 @@ if [ "${1:-}" = "--dry-run" ]; then DRY_RUN=1; shift; fi
 REPO="${1:-Wide-Moat/open-computer-use}"
 BRANCH="${2:-next/v1}"
 
-# The nine that must be required. The two that must not are named below,
+# The ten that must be required. The two that must not are named below,
 # because "leave them out" is easy to satisfy by accident and easy to undo
 # by accident too.
+#
+# asyncapi joined once it became hermetic (#384 step 3: "make the job required
+# once it is hermetic -- a gate nobody is blocked by is a gate nobody notices
+# breaking"). It stopped fetching schema.ocsf.io at validation time -- the OCSF
+# classes are vendored and $ref'd locally -- and it carries the audit fan-in
+# INV-1 check plus the OCSF class-identity gate that NFR-MAINT-AUDIT-SCHEMA and
+# half of NFR-SEC-88 rest on.
 #
 # nfr-gates joined the list after the other eight. It carries the
 # deployment-readiness claim, the NFR-coverage ratchet, the pin policy and the
@@ -44,6 +51,7 @@ BRANCH="${2:-next/v1}"
 # job would still run and still be green, and nothing would depend on it.
 REQUIRED=(
   "nfr-gates"
+  "asyncapi"
   "secrets — gitleaks"
   "secrets — trufflehog"
   "SAST — semgrep"


### PR DESCRIPTION
#384 asked for three things. Two are done, and the third was waiting on them: *"make the job required once it is hermetic — a gate nobody is blocked by is a gate nobody notices breaking."*

**Both preconditions met, checked rather than assumed:**

| defect | state |
|---|---|
| the gate could not install its tool (`ETARGET` on an unpublished transitive pin) | fixed — runs a local `scripts/validate-asyncapi.mjs` against a pinned `@asyncapi/parser`, not `npx @asyncapi/cli` |
| validation fetched `schema.ocsf.io` at CI time | fixed — **0** remote `$ref`s, **8** vendored local ones; the validator imports nothing but `node:path` |

Five consecutive `asyncapi` runs on `next/v1` are green.

**Why Layer 0 rather than merely useful.** It passes the same test `nfr-gates` met: it carries the audit fan-in INV-1 check and the OCSF class-identity gate — which `NFR-MAINT-AUDIT-SCHEMA` and half of `NFR-SEC-88` rest on. Leaving it optional means those two are armed against a job a merge can walk past.

Ten now. Probed against the live head:

```
dry run                ->  present  asyncapi
name changed to a typo ->  ABSENT   asyncapi-typo
                           REFUSED: 1 name(s) do not match anything the head reported
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added `asyncapi` to the required Layer-0 validation checks.
  * Updated validation documentation to reflect hermetic checks, vendored schemas, audit fan-in, and related gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->