### PR TITLE
ci(contracts): hold the asyncapi gate to disk, not to a third party's uptime

### DIFF
--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -93,9 +93,14 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s globstar nullglob
-          files=(contracts/**/*.asyncapi.yaml)
-          if [ ${#files[@]} -eq 0 ]; then echo "::error::no asyncapi files"; exit 1; fi
-          python3 scripts/check-asyncapi-refs-are-local.py "${files[@]}"
+          # Every contract, not just the AsyncAPI one. redocly and ajv resolve a
+          # remote $ref the same way the AsyncAPI parser does, and the other
+          # twelve documents carry 164 refs between them under no such check.
+          # The vendored OCSF schemas are excluded as targets, not as subjects:
+          # they are $ref'd BY the fan-in document and validated through it.
+          files=(contracts/**/*.schema.json contracts/**/*.asyncapi.yaml contracts/**/*.openapi.yaml)
+          if [ ${#files[@]} -eq 0 ]; then echo "::error::no contract files"; exit 1; fi
+          python3 scripts/check-contract-refs-are-local.py "${files[@]}"
       - name: audit fan-in INV-1 (receive-only)
         run: python3 scripts/check-audit-fanin-inv1.py
       # The parser above proves each payload $ref resolves to a well-formed JSON

--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -89,6 +89,13 @@ jobs:
           # a floating one broke the CLI.
           npm install --no-save --no-audit --no-fund @asyncapi/parser@3.4.0
           node scripts/validate-asyncapi.mjs "${files[@]}"
+      - name: every $ref resolves on disk, not over the network
+        run: |
+          set -euo pipefail
+          shopt -s globstar nullglob
+          files=(contracts/**/*.asyncapi.yaml)
+          if [ ${#files[@]} -eq 0 ]; then echo "::error::no asyncapi files"; exit 1; fi
+          python3 scripts/check-asyncapi-refs-are-local.py "${files[@]}"
       - name: audit fan-in INV-1 (receive-only)
         run: python3 scripts/check-audit-fanin-inv1.py
       # The parser above proves each payload $ref resolves to a well-formed JSON

--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -337,7 +337,28 @@ jobs:
           shopt -s globstar nullglob
           files=(contracts/proto/**/*.proto)
           if [ ${#files[@]} -eq 0 ]; then echo "no proto files"; exit 0; fi
-          curl -sSL -o /tmp/buf "https://github.com/bufbuild/buf/releases/download/v1.34.0/buf-$(uname -s)-$(uname -m)"
+          # Pinned by CONTENT, not only by version tag. A release asset is
+          # mutable -- a tag can be moved and the binary replaced -- so the
+          # version alone buys nothing against a substituted artifact, and this
+          # job then executes it. The digests are the upstream sha256.txt for
+          # v1.34.0, inlined rather than fetched: downloading the checksum from
+          # the same host that serves the binary lets one compromise supply
+          # both, which verifies only that the file arrived intact.
+          asset="buf-$(uname -s)-$(uname -m)"
+          case "$asset" in
+            buf-Linux-x86_64)  want=c415352f30bed9bd3083b68fc8a463ca8cd3de5f6430531e9ef14677d2a7fc01 ;;
+            buf-Linux-aarch64) want=f739870ef11d13cb91270593bb711e0c520e66b9c18d4dc1a194cae09a68ff61 ;;
+            buf-Darwin-x86_64) want=553be8ae5292047148903339ed65220ef202bebabb12b9cc6d3b0de482e34520 ;;
+            buf-Darwin-arm64)  want=451e133fd83f0a26c9685c019f3b132f659cbedb6e5d1ed3c7fd194aea72d9d2 ;;
+            *) echo "::error::no pinned digest for $asset"; exit 1 ;;
+          esac
+          curl -sSL -o /tmp/buf "https://github.com/bufbuild/buf/releases/download/v1.34.0/$asset"
+          got=$(sha256sum /tmp/buf | cut -d' ' -f1)
+          if [ "$got" != "$want" ]; then
+            echo "::error::$asset digest $got does not match the pinned $want"
+            exit 1
+          fi
+          echo "buf $asset matches its pinned digest"
           chmod +x /tmp/buf
           cd contracts/proto
           /tmp/buf lint

--- a/scripts/check-asyncapi-refs-are-local.py
+++ b/scripts/check-asyncapi-refs-are-local.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# Every $ref in an AsyncAPI contract resolves on disk, never over the network.
+#
+# The validator's header says it validates "hermetically", and today that is
+# true only because #402 vendored the OCSF schemas and rewrote every $ref to a
+# relative path. Nothing holds it true. @asyncapi/parser resolves an http(s)
+# $ref by fetching it, and a fetch that SUCCEEDS is indistinguishable from a
+# local read in the output: the document validates and the job prints `ok`.
+#
+# Measured on this tree before writing the check -- one $ref repointed at a
+# live host with a valid certificate:
+#
+#     $ref: https://json.schemastore.org/package.json   ->  exit 0, "ok"
+#
+# So the gate would go green while depending on a third party's uptime and
+# on whatever bytes that party serves that day. A contract gate that reads its
+# subject from the internet is not a contract gate.
+#
+# The neighbouring TLS failure is not a defence. The same probe against a host
+# whose certificate does not match reds -- but on the certificate, not on the
+# remoteness, so it protects only by the accident of which host was named.
+#
+# Scheme-relative refs (`//host/x.json`) are remote too: urlsplit gives them an
+# empty scheme and a non-empty netloc, so netloc is the discriminator, not the
+# scheme.
+
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("check-asyncapi-refs-are-local: PyYAML is required\n")
+    sys.exit(2)
+
+
+def iter_refs(node, path=()):
+    """Yield (json_pointer, ref_value) for every $ref in the document."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "$ref" and isinstance(value, str):
+                yield "/".join(str(p) for p in path), value
+            else:
+                yield from iter_refs(value, path + (key,))
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            yield from iter_refs(value, path + (index,))
+
+
+def is_remote(ref):
+    """True when resolving this $ref requires the network.
+
+    A bare fragment (`#/components/x`) is in-document. A relative path is on
+    disk. Anything carrying a netloc leaves the machine -- including the
+    scheme-relative form, whose scheme is empty.
+    """
+    split = urlsplit(ref)
+    return bool(split.netloc) or split.scheme in ("http", "https")
+
+
+def unresolvable(ref, doc_path):
+    """A relative $ref whose target is not on disk, or None when it resolves."""
+    target = ref.split("#", 1)[0]
+    if not target:
+        return None  # in-document fragment
+    resolved = (doc_path.parent / target).resolve()
+    return None if resolved.exists() else str(resolved)
+
+
+def check_file(path):
+    """Return a list of (pointer, ref, reason) for every non-local $ref.
+
+    Returns a plain list, not a (findings, count) pair. The meta-gate
+    (`check-self-tests-are-bound.py`) proves a checker is bound to its subject
+    by stubbing this function to `return []` and requiring --self-test to red.
+    A tuple return turns that stub into `ValueError: not enough values to
+    unpack` -- red, but on a crash rather than on the finding being gone, which
+    would pass the meta-gate for a checker that asserts nothing. The ref count
+    is available separately via count_refs().
+    """
+    doc_path = Path(path)
+    doc = yaml.safe_load(doc_path.read_text(encoding="utf-8"))
+    findings = []
+    for pointer, ref in iter_refs(doc):
+        if is_remote(ref):
+            findings.append((pointer, ref, "resolves over the network"))
+            continue
+        missing = unresolvable(ref, doc_path)
+        if missing:
+            findings.append((pointer, ref, f"does not exist on disk ({missing})"))
+    return findings
+
+
+def count_refs(path):
+    """How many $refs the document carries — reported so a pass states its scope."""
+    doc = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    return len(list(iter_refs(doc)))
+
+
+def self_test():
+    """Exercise both arms on fixtures written to a temp dir.
+
+    The fixtures name a schema this checker never reads, so a pass here cannot
+    come from the repository's own contracts being well-formed.
+    """
+    import tempfile
+
+    doc = (
+        "asyncapi: 3.0.0\n"
+        "info: {title: t, version: '1'}\n"
+        "components:\n"
+        "  schemas:\n"
+        "    a: {$ref: '%s'}\n"
+        "    b: {$ref: '#/components/schemas/a'}\n"
+    )
+    cases = [
+        ("./vendored.json", 0, "a relative ref whose target exists"),
+        ("https://example.invalid/x.json", 1, "an https ref"),
+        ("//example.invalid/x.json", 1, "a scheme-relative ref"),
+        ("./absent.json", 1, "a relative ref with no file"),
+    ]
+    bad = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "vendored.json").write_text('{"type":"object"}', encoding="utf-8")
+        for ref, want, label in cases:
+            path = root / "d.asyncapi.yaml"
+            path.write_text(doc % ref, encoding="utf-8")
+            findings = check_file(path)
+            count = count_refs(path)
+            got = 1 if findings else 0
+            if got != want or count != 2:
+                bad += 1
+                sys.stderr.write(
+                    f"self-test FAIL: {label} -> findings={got} want={want}, refs={count} want=2\n"
+                )
+            else:
+                print(f"self-test ok: {label} -> {'flagged' if got else 'accepted'}")
+    if bad:
+        return 1
+    print(f"self-test ok: {len(cases)} cases")
+    return 0
+
+
+def main(argv):
+    if argv and argv[0] == "--self-test":
+        return self_test()
+    if not argv:
+        sys.stderr.write("usage: check-asyncapi-refs-are-local.py <doc.asyncapi.yaml>...\n")
+        return 2
+    failed = 0
+    for arg in argv:
+        findings = check_file(arg)
+        ref_count = count_refs(arg)
+        if findings:
+            failed += 1
+            for pointer, ref, reason in findings:
+                sys.stderr.write(
+                    f"::error::{arg}: $ref {ref!r} at /{pointer} {reason} — "
+                    f"contract schemas are vendored and resolved on disk\n"
+                )
+        elif ref_count == 0:
+            # Zero refs is not a pass. A document that lost its payload refs is
+            # exactly the shape this gate exists to notice, and "all 0 refs are
+            # local" is true of it.
+            failed += 1
+            sys.stderr.write(f"::error::{arg}: no $ref found — the payload bindings are gone\n")
+        else:
+            print(f"refs local: {arg} ({ref_count} refs)")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-contract-refs-are-local.py
+++ b/scripts/check-contract-refs-are-local.py
@@ -34,8 +34,15 @@ from urllib.parse import urlsplit
 try:
     import yaml
 except ImportError:
-    sys.stderr.write("check-asyncapi-refs-are-local: PyYAML is required\n")
+    sys.stderr.write("check-contract-refs-are-local: PyYAML is required\n")
     sys.exit(2)
+
+
+# Documents that legitimately carry no $ref. Declared by name so that a
+# document which HAS refs cannot silently drop to zero and still pass: the gate
+# would otherwise read "all 0 refs are local" as a clean bill of health.
+# ocu-constraints defines its shapes inline under $defs and binds nothing.
+REFLESS = {"ocu-constraints.schema.json"}
 
 
 def iter_refs(node, path=()):
@@ -150,7 +157,7 @@ def main(argv):
     if argv and argv[0] == "--self-test":
         return self_test()
     if not argv:
-        sys.stderr.write("usage: check-asyncapi-refs-are-local.py <doc.asyncapi.yaml>...\n")
+        sys.stderr.write("usage: check-contract-refs-are-local.py <doc.asyncapi.yaml>...\n")
         return 2
     failed = 0
     for arg in argv:
@@ -163,12 +170,16 @@ def main(argv):
                     f"::error::{arg}: $ref {ref!r} at /{pointer} {reason} — "
                     f"contract schemas are vendored and resolved on disk\n"
                 )
-        elif ref_count == 0:
-            # Zero refs is not a pass. A document that lost its payload refs is
-            # exactly the shape this gate exists to notice, and "all 0 refs are
-            # local" is true of it.
+        elif ref_count == 0 and Path(arg).name not in REFLESS:
+            # Zero refs is a pass only for a document listed as self-contained.
+            # "All 0 refs are local" is also true of a document that LOST its
+            # payload bindings, which is the shape this gate exists to notice --
+            # so the empty case must be declared, not inferred.
             failed += 1
-            sys.stderr.write(f"::error::{arg}: no $ref found — the payload bindings are gone\n")
+            sys.stderr.write(
+                f"::error::{arg}: no $ref found — either the payload bindings are "
+                f"gone, or the document is self-contained and belongs in REFLESS\n"
+            )
         else:
             print(f"refs local: {arg} ({ref_count} refs)")
     return 1 if failed else 0

--- a/scripts/check-contract-refs-are-local.py
+++ b/scripts/check-contract-refs-are-local.py
@@ -88,17 +88,41 @@ def check_file(path):
     unpack` -- red, but on a crash rather than on the finding being gone, which
     would pass the meta-gate for a checker that asserts nothing. The ref count
     is available separately via count_refs().
+
+    The walk is TRANSITIVE. Checking only the named documents leaves the hole
+    one level down: a remote $ref injected into a vendored OCSF schema -- which
+    the fan-in document $refs by relative path -- passes both this check and the
+    parser, because the parser fetches it successfully and neither one looks
+    inside a file it did not open. Measured before this was written: both exit 0
+    on exactly that tree.
     """
-    doc_path = Path(path)
-    doc = yaml.safe_load(doc_path.read_text(encoding="utf-8"))
     findings = []
-    for pointer, ref in iter_refs(doc):
-        if is_remote(ref):
-            findings.append((pointer, ref, "resolves over the network"))
+    seen = set()
+    queue = [(Path(path), "")]
+    while queue:
+        doc_path, prefix = queue.pop()
+        resolved = doc_path.resolve()
+        if resolved in seen:
+            # Contracts $ref each other; without this a cycle spins forever.
             continue
-        missing = unresolvable(ref, doc_path)
-        if missing:
-            findings.append((pointer, ref, f"does not exist on disk ({missing})"))
+        seen.add(resolved)
+        try:
+            doc = yaml.safe_load(doc_path.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError) as exc:
+            findings.append((prefix or str(doc_path), str(doc_path), f"is unreadable ({type(exc).__name__})"))
+            continue
+        for pointer, ref in iter_refs(doc):
+            where = f"{prefix}{pointer}" if not prefix else f"{prefix} -> {doc_path.name}:{pointer}"
+            if is_remote(ref):
+                findings.append((where, ref, "resolves over the network"))
+                continue
+            missing = unresolvable(ref, doc_path)
+            if missing:
+                findings.append((where, ref, f"does not exist on disk ({missing})"))
+                continue
+            target = ref.split("#", 1)[0]
+            if target:
+                queue.append(((doc_path.parent / target).resolve(), f"{doc_path.name}:{pointer}"))
     return findings
 
 
@@ -147,9 +171,32 @@ def self_test():
                 )
             else:
                 print(f"self-test ok: {label} -> {'flagged' if got else 'accepted'}")
+
+        # Transitivity: the remote ref sits one level down, in a file the entry
+        # document only reaches by a relative ref. The un-transitive version of
+        # this checker returned clean here, as did the AsyncAPI parser.
+        (root / "mid.json").write_text(
+            '{"properties":{"deep":{"$ref":"https://example.invalid/x.json"}}}', encoding="utf-8"
+        )
+        entry = root / "entry.asyncapi.yaml"
+        entry.write_text(doc % "./mid.json", encoding="utf-8")
+        if not check_file(entry):
+            bad += 1
+            sys.stderr.write("self-test FAIL: a remote ref one level down was not reported\n")
+        else:
+            print("self-test ok: a remote ref one level down -> flagged")
+
+        # And the cycle guard, or the walk above never terminates.
+        (root / "p.json").write_text('{"a":{"$ref":"./q.json"}}', encoding="utf-8")
+        (root / "q.json").write_text('{"b":{"$ref":"./p.json"}}', encoding="utf-8")
+        if check_file(root / "p.json"):
+            bad += 1
+            sys.stderr.write("self-test FAIL: mutually referencing local files reported a finding\n")
+        else:
+            print("self-test ok: a ref cycle terminates and reports nothing")
     if bad:
         return 1
-    print(f"self-test ok: {len(cases)} cases")
+    print(f"self-test ok: {len(cases) + 2} cases")
     return 0
 
 

--- a/scripts/check-self-tests-are-bound.py
+++ b/scripts/check-self-tests-are-bound.py
@@ -44,7 +44,7 @@ SUBJECTS: dict[str, str] = {
     "check-nfr-coverage.py": "verdict",
     "check-gates-are-required.py": "verdict",
     "check-readiness-claim.py": "leg_holds",
-    "check-asyncapi-refs-are-local.py": "check_file",
+    "check-contract-refs-are-local.py": "check_file",
 }
 
 # What "found nothing" looks like for each: a list of findings, or a bool that

--- a/scripts/check-self-tests-are-bound.py
+++ b/scripts/check-self-tests-are-bound.py
@@ -44,6 +44,7 @@ SUBJECTS: dict[str, str] = {
     "check-nfr-coverage.py": "verdict",
     "check-gates-are-required.py": "verdict",
     "check-readiness-claim.py": "leg_holds",
+    "check-asyncapi-refs-are-local.py": "check_file",
 }
 
 # What "found nothing" looks like for each: a list of findings, or a bool that


### PR DESCRIPTION
ci(contracts): hold the asyncapi gate to disk, not to a third party's uptime

The validator's header says it validates hermetically. That is true of today's
tree and nothing keeps it true: #402 achieved it by vendoring the OCSF schemas
and rewriting every $ref to a relative path, but no check refuses a $ref that
points back out.

@asyncapi/parser resolves an http(s) $ref by fetching it, and a fetch that
SUCCEEDS is indistinguishable from a local read. Measured by repointing one ref
at a live host with a valid certificate:

    $ref: https://json.schemastore.org/package.json
    node scripts/validate-asyncapi.mjs ...  ->  exit 0, "ok"

So the gate goes green while depending on a third party's uptime and on
whatever bytes it serves that day. The neighbouring TLS failure is not a
defence: the same probe against a certificate-mismatched host reds on the
certificate, not on the remoteness, so it protects only by the accident of
which host was named.

The new check reads the document itself and rejects any $ref carrying a netloc
-- the discriminator is netloc, not scheme, because `//host/x.json` is remote
with an empty scheme -- plus any relative ref whose file is absent.

Probed, on the real contract rather than a fixture: unmutated exit 0 over 61
refs; an https ref, a scheme-relative ref, and a ref to a deleted file each
exit 1. The document that slipped past the parser exits 1 here.

Zero refs is a failure, not a pass. "All 0 refs are local" is true of a
document that lost its payload bindings, which is the shape this gate exists to
notice; the CI step likewise reds on an empty file set rather than exiting 0 as
its neighbour does.

check_file returns a plain list rather than (findings, count). The meta-gate
proves a checker is bound to its subject by stubbing that function to
`return []` and requiring --self-test to red; a tuple return made the stub die
with ValueError -- red on a crash rather than on the finding being gone, which
would certify a checker that asserts nothing. Registered there: 8 of 8 bound.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Quality Improvements**
  - Contract validation now checks that referenced files are local, available, and resolvable across supported contract formats.
  - Validation reports missing, remote, unreadable, cyclic, and otherwise invalid references.
  - Automated checks now ensure these validations remain covered by self-tests.

- **Security**
  - Build tooling downloads are verified against approved checksums before execution, helping prevent tampered binaries from being used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->