### PR TITLE
ci(build): pin the four Python test packages (#488)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -501,7 +501,13 @@ jobs:
       - name: Install server deps
         run: |
           pip install -r computer-use-server/requirements.txt
-          pip install pytest pytest-asyncio
+          # Pinned for the same reason requirements.txt is: unpinned, each run
+          # resolves whatever PyPI serves that day, so a red can arrive from an
+          # upstream release nobody here chose. Measured: a June run resolved
+          # pytest 9.0.3, today it resolves 9.1.1 -- the test framework changed
+          # under the suite with no commit. pytest-asyncio 1.4.0 declares
+          # pytest<10,>=8.4, so it accepts this pin.
+          pip install pytest==9.1.1 pytest-asyncio==1.4.0
 
       - name: Run orchestrator pytest
         run: pytest tests/orchestrator/ -v
@@ -617,7 +623,9 @@ jobs:
           python-version: '3.13'
 
       - name: Install test deps
-        run: pip install httpx pytest pytest-timeout
+        # Pinned: see the orchestrator job. pytest-timeout 2.4.0 declares
+        # pytest>=7.0.0, so it accepts this pin.
+        run: pip install httpx==0.28.1 pytest==9.1.1 pytest-timeout==2.4.0
 
       - name: Bring up the integration stack
         run: |


### PR DESCRIPTION
ci(build): pin the four Python test packages (#488)

Two jobs installed pytest, pytest-asyncio, httpx and pytest-timeout with no
version constraint, so each run resolved whatever PyPI served that day. Every
other tool in CI is pinned -- checkov==3.2.314, pyyaml==6.0.2,
@asyncapi/parser@3.4.0, ajv-cli@5.0.0, @redocly/cli@1.34.2, every `uses:` at a
40-hex SHA. These four were the exception.

Not hypothetical: the last successful build resolved pytest 9.0.3 on 2 June,
and today the same line resolves 9.1.1. The test framework changed under the
suite with no commit, which means a red can arrive from an upstream release
nobody here chose and a green cannot be reproduced.

The versions are the ones currently resolving, read off PyPI rather than
guessed, and the two plugin constraints accept them: pytest-asyncio 1.4.0
declares pytest<10,>=8.4, pytest-timeout 2.4.0 declares pytest>=7.0.0.

Probed rather than argued. Both pin sets install clean in a fresh venv, and
the orchestrator suite runs under them: 181 passed, 5 skipped. The first
attempt at that probe pointed pytest at computer-use-server/ and collected
nothing -- exit 5, which is not a pass; CI runs tests/orchestrator/.

`pip install -r computer-use-server/requirements.txt` is untouched: that file
already pins.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build and integration checks by standardizing test tool versions.
  * Increased consistency and reliability across automated validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->