### PR TITLE
ci(gates): classify every workflow, or the named set answers only for itself

### DIFF
--- a/scripts/check-gates-trigger-on-canon.py
+++ b/scripts/check-gates-trigger-on-canon.py
@@ -40,7 +40,20 @@ MUST_COVER_CANON = {
     "contracts-lint.yml",
     "docs-lint.yml",
     "gate3-rehearsal.yml",
+    # Already correct today, listed so a revert is caught rather than noticed:
+    # helm.yml lints the chart that ships on this branch.
+    "helm.yml",
 }
+
+# Workflows deliberately outside the set, with the reason, so the next reader
+# does not have to re-derive it -- and so adding one silently is a visible
+# omission rather than an oversight.
+#   build.yml         builds and PUSHES images to ghcr.io; extending it to canon
+#                     is a release-posture decision, tracked as an issue
+#   release*.yml      tag-triggered by design
+#   supply-chain.yml  tag-triggered by design
+#   stale.yml         scheduled housekeeping, reports on nothing
+NOT_GATES = {"build.yml", "release.yml", "release-chart.yml", "supply-chain.yml", "stale.yml"}
 
 
 def triggers(doc):
@@ -78,8 +91,16 @@ def covers_canon(on):
 
 
 def findings(root=Path(".")):
-    """Return (workflow, reason) for every named gate blind to the canon branch."""
+    """Return (workflow, reason) for every named gate blind to the canon branch.
+
+    Also refuses a workflow that is in neither set. A named-set check answers
+    only for what it names, so a new workflow added tomorrow would sit outside
+    it silently -- which is the failure this file exists to stop, one level up.
+    """
     out = []
+    present = {p.name for p in (root / WORKFLOWS).glob("*.yml")} if (root / WORKFLOWS).is_dir() else set()
+    for name in sorted(present - MUST_COVER_CANON - NOT_GATES):
+        out.append((name, "is in neither MUST_COVER_CANON nor NOT_GATES — classify it"))
     for name in sorted(MUST_COVER_CANON):
         path = root / WORKFLOWS / name
         if not path.is_file():
@@ -140,6 +161,18 @@ def self_test():
             sys.stderr.write("self-test FAIL: a fully covering tree reported a finding\n")
         else:
             print("self-test ok: findings() accepts a tree where every gate covers canon")
+
+        # A workflow in neither set. Without this the classification branch is
+        # untested, and the fixture above -- which writes only named gates --
+        # can never reach it.
+        stray = root / WORKFLOWS / "unclassified-probe.yml"
+        stray.write_text("name: s\non:\n  pull_request:\n    branches: [main]\n", encoding="utf-8")
+        if not any("neither" in why for _, why in findings(root)):
+            bad += 1
+            sys.stderr.write("self-test FAIL: an unclassified workflow was not reported\n")
+        else:
+            print("self-test ok: findings() reports a workflow in neither set")
+        stray.unlink()
 
         blind = root / WORKFLOWS / sorted(MUST_COVER_CANON)[0]
         blind.write_text("name: x\non:\n  pull_request:\n    branches: [main]\n", encoding="utf-8")


### PR DESCRIPTION
ci(gates): classify every workflow, or the named set answers only for itself

The check named five gates and asked whether each fires on canon. A named-set
check answers only for what it names: a workflow added tomorrow sits outside it
silently, which is the failure this file exists to stop, one level up.

Every workflow is now in exactly one of two sets, and a file in neither is a
finding. NOT_GATES carries the reason per entry -- build.yml pushes images to
ghcr.io so extending it to canon is a release-posture call (tracked
separately), the release and supply-chain workflows are tag-triggered, stale.yml
reports on nothing.

helm.yml moves into the gate set. It already covers canon correctly; listing it
means a revert is caught rather than noticed.

Probed on a copy of the real tree: a new unclassified workflow exits 1,
reverting helm.yml to `branches: [main]` exits 1, the unmutated copy exits 0.

A self-test case was added for the classification branch specifically. The
existing fixture writes only named gates, so it can never reach that code --
the branch would have been live and untested, which is the same shape as a
gate that names one blessed location. Three findings() cases now, meta-gate 9
of 9.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow coverage checks to identify workflows that are neither required nor explicitly excluded.
  * Added Helm workflow coverage to the validation rules.

* **Tests**
  * Expanded validation checks to confirm unclassified workflows are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->