### PR TITLE
fix(nfr-coverage): a .pyc is not a check that runs

### DIFF
--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -125,6 +125,15 @@ def armed_ids(root: pathlib.Path, ids: set[str]) -> dict[str, list[str]]:
             # assertion is the failure mode this whole file exists to name.
             if path.resolve() == this_file:
                 continue
+            # Build artifacts are not checks. A .pyc keeps the NFR ids of the
+            # source it was compiled from, so a deleted checker stays "armed"
+            # as long as its cache survives -- measured on a copy of this tree:
+            # delete check-pin-policy.py with __pycache__ present and the
+            # ratchet still reads 11. The id is named by a file that no longer
+            # runs. A clean checkout has no cache, so this also removes a
+            # difference between what CI counts and what a developer counts.
+            if "__pycache__" in path.parts or path.suffix in (".pyc", ".pyo"):
+                continue
             try:
                 body = path.read_text(encoding="utf-8", errors="ignore")
             except OSError:


### PR DESCRIPTION
fix(nfr-coverage): a .pyc is not a check that runs

The ratchet counts an NFR id as armed when a file under scripts/, .github/ or
tests/ names it. It walked __pycache__ too, and a .pyc keeps the ids of the
source it was compiled from -- so a deleted checker stays armed for as long as
its cache survives.

Measured on a copy of this tree rather than argued: compile the scripts, delete
check-pin-policy.py, and the ratchet still reports "holds at 11". The id is
named by a file that no longer runs, which is precisely the claim this counter
exists to refuse.

After the fix the same probe reports

    ::error::armed NFRs dropped to 10, below the floor of 11
    NFR coverage: 10 of 190 ids are named by a check that runs

The count on a clean tree is unchanged -- the cache only ever duplicated a
source that was also counted, so this removes a masking path, not coverage. It
also removes a difference between what CI counts, checking out fresh with no
cache, and what a developer counts locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NFR coverage checks by excluding Python bytecode and cache files from executable check detection.
  * Source files continue to be evaluated normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->