### PR TITLE
docs(components): declare the controls the ADRs already assign

### DIFF
--- a/.github/workflows/contracts-lint.yml
+++ b/.github/workflows/contracts-lint.yml
@@ -243,14 +243,16 @@ jobs:
         run: python3 scripts/check-compliance-front-matter.py --self-test
 
       - name: how many controls each component spec declares
-        # NFR-COMP-17. The field is present in all seven specs and empty in all
-        # seven, and the front-matter validator does not know it exists -- so
-        # nothing has ever looked. This does not fill it in: which controls a
-        # component satisfies is an owner's judgement, and inventing entries to
-        # green a number would hide the gap rather than measure it. The floor is
-        # 0, so the current state passes; it reds when a spec loses its key or
-        # loses declarations it had.
-        run: python3 scripts/check-compliance-front-matter.py --min-declared 0
+        # NFR-COMP-17. The field was empty in all seven specs, and the earlier
+        # reading of that -- "which controls a component satisfies is an owner's
+        # judgement" -- was only half right. It is a judgement, and it was
+        # already made: each spec declares the ADRs that govern it, and 43 of 45
+        # ADRs carry a populated compliance-impact. So the entries are derived
+        # from decisions already accepted rather than invented, and every one of
+        # the 61 traces to an ADR the spec itself names.
+        #
+        # The floor is now 61, not 0. Losing a control citation reds.
+        run: python3 scripts/check-compliance-front-matter.py --min-declared 61
 
       - name: the pin-policy checker itself discriminates
         run: python3 scripts/check-pin-policy.py --self-test

--- a/docs/architecture/components/01-mcp-gateway.md
+++ b/docs/architecture/components/01-mcp-gateway.md
@@ -6,7 +6,7 @@ status: draft
 last-reviewed: 2026-06-27
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
-compliance: []
+compliance: [ISO27001-A.9.4, NYDFS-500.07, SOC2-CC6.1]
 threat-model: 06-threat-model.md
 contract: contracts/mcp/2025-06-18/ocu-constraints.schema.json
 adr: [0027]

--- a/docs/architecture/components/02-control-operator-api.md
+++ b/docs/architecture/components/02-control-operator-api.md
@@ -6,7 +6,7 @@ status: draft
 last-reviewed: 2026-06-14
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
-compliance: []
+compliance: [DORA-Art.28, DORA-Art.9, EU-AI-Act-Art.14, ISO27001-A.8.10, ISO27001-A.8.15, ISO27001-A.8.2, NYDFS-500.15, NYDFS-500.7, SOC2-CC6.1, SOC2-CC6.6, SOC2-CC7.2]
 threat-model: 06-threat-model.md
 contract: [contracts/openapi/operator-rest.openapi.yaml, contracts/openapi/soar-revoke.openapi.yaml, contracts/proto/ocu/control/session/v1/session_setup.proto]
 adr: [0004, 0013, 0017, 0018, 0023]

--- a/docs/architecture/components/04-object-store-service.md
+++ b/docs/architecture/components/04-object-store-service.md
@@ -6,7 +6,7 @@ status: draft
 last-reviewed: 2026-07-07
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
-compliance: []
+compliance: [DORA-Art.28, DORA-Art.30, EU-AI-Act-Art.15, ISO27001-A.8.10, ISO27001-A.8.15, NIST-SP-800-190, NYDFS-500.15, SOC2-CC6.1, SOC2-CC6.6, SOC2-CC7.2]
 threat-model: 06-threat-model.md
 contract: [contracts/storage/mount-config.schema.json, contracts/storage/file-ops.schema.json]
 adr: [0003, 0010, 0013, 0014, 0015, 0016, 0023, 0025]

--- a/docs/architecture/components/05-session-sandbox.md
+++ b/docs/architecture/components/05-session-sandbox.md
@@ -6,7 +6,7 @@ status: draft
 last-reviewed: 2026-06-14
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
-compliance: []
+compliance: [DORA-Art.28, DORA-Art.30, EU-AI-Act-Art.15, ISO27001-A.8.10, ISO27001-A.8.24, NIST-SP-800-190, NYDFS-500.15, PCI-DSS-Req.3, SOC2-CC6.1, SOC2-CC6.6]
 threat-model: 06-threat-model.md
 contract: [contracts/exec/exec-channel.schema.json, contracts/control/control-rpc.schema.json]
 adr: [0003, 0005, 0007, 0013, 0014, 0015, 0016, 0017, 0018, 0021]

--- a/docs/architecture/components/06-egress-trust-edge.md
+++ b/docs/architecture/components/06-egress-trust-edge.md
@@ -6,7 +6,7 @@ status: draft
 last-reviewed: 2026-06-15
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
-compliance: []
+compliance: [DORA-Art.28, DORA-Art.30, DORA-Art.9, EU-AI-Act-Art.12, EU-AI-Act-Art.15, ISO27001-A.8.10, ISO27001-A.8.24, NYDFS-500.15, PCI-DSS-Req.3, SOC2-CC6.1, SOC2-CC6.6, SOC2-CC6.7]
 threat-model: 06-threat-model.md
 contract: null
 adr: [0005, 0006, 0007, 0008, 0013, 0016, 0021]

--- a/docs/architecture/components/07-audit-pipeline.md
+++ b/docs/architecture/components/07-audit-pipeline.md
@@ -6,7 +6,7 @@ status: draft
 last-reviewed: 2026-06-06
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
-compliance: []
+compliance: [DORA-Art.10, EU-AI-Act-Art.12, ISO27001-A.8.15, NYDFS-500.06, SOC2-CC7.2]
 threat-model: 06-threat-model.md
 contract: contracts/audit/audit-fanin.asyncapi.yaml
 adr: [0009]

--- a/docs/architecture/components/08-web-ui.md
+++ b/docs/architecture/components/08-web-ui.md
@@ -6,7 +6,7 @@ status: draft
 last-reviewed: 2026-06-15
 owner: "@Wide-Moat/architects"
 applies-to: next/v1
-compliance: []
+compliance: [DORA-Art.28, DORA-Art.30, EU-AI-Act-Art.12, EU-AI-Act-Art.15, ISO27001-A.8.10, ISO27001-A.8.15, NYDFS-500.15, SOC2-CC6.1, SOC2-CC6.6, SOC2-CC7.2]
 threat-model: 06-threat-model.md
 contract: [contracts/storage/file-artifact-api.schema.json]
 adr: [0002, 0013, 0015, 0016, 0017, 0023, 0025]


### PR DESCRIPTION
docs(components): declare the controls the ADRs already assign

NFR-COMP-17 asks for `compliance:` populated on every component spec. It was
`[]` in all seven. The standing reason for leaving it that way -- which
controls a component satisfies is an owner's judgement -- was half right: it is
a judgement, and it had already been made. Each spec declares the ADRs that
govern it in its own `adr:` field, and 43 of 45 ADRs carry a populated
`compliance-impact`. The union of those is the answer.

61 control citations across seven specs, from 0. Nothing is invented: a
verification pass over the result reports 61 controls, 0 not traceable to an
ADR the spec itself names.

The `adr:` field is the source rather than markdown links from ADRs back to
components. Both work, and they disagree -- 06-egress-trust-edge derives 12
controls from its declared ADRs and 16 from inbound links. The declared field
is what the component claims as governing it, which is the narrower and more
defensible reading; the link-derived surplus stays visible in the checker's
notice (41 citations) rather than being silently adopted.

The CI floor moves 0 -> 61, so losing a citation now reds. Probed: removing one
control from 01-mcp-gateway exits 1, the tree as committed exits 0.

00-overview.md is untouched and carries no `compliance:` key, correctly -- it
is the directory index, not a component. A first verification pass flagged it
as malformed, which was the probe's fault for asserting the key on every file
in the directory rather than on the specs that declare one.
