### PR TITLE
ci(tests): run the four shell tests that executed nowhere

### DIFF
--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -53,7 +53,15 @@ jobs:
         # resolves whatever PyPI serves that day. test-subagent-runtime.sh
         # drives six pytest files and reports FAIL on "No module named pytest",
         # which reads as a code failure and is an environment one.
-        run: pip install pytest==9.1.1 pytest-asyncio==1.4.0
+        run: |
+          pip install pytest==9.1.1 pytest-asyncio==1.4.0
+          # test-subagent-runtime.sh drives six pytest files, and its fourth,
+          # test-default-model-resolution.py, imports cli_runtime -> docker_manager
+          # -> the docker SDK. Installing the server requirements is not the same
+          # as needing a container: these are wheels, nothing is built or run.
+          # Measured: without them collection ends in ImportError, and locally
+          # the test passed only because the venv already carried them.
+          pip install -r computer-use-server/requirements.txt
       - name: skills name no hardcoded model ids
         run: bash tests/test-skill-no-hardcoded-models.sh
       - name: sub-agent runtime surface

--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: FSL-1.1-Apache-2.0
+# Copyright (c) 2025 Open Computer Use Contributors
+#
+# Runs the tests/ scripts that need neither a built image nor a running server.
+#
+# They existed and executed nowhere. A sweep of every script under tests/ found
+# all eleven unreachable from a next/v1 pull request: four are invoked only by
+# build.yml, whose trigger is `branches: [main]`, and seven were invoked by no
+# workflow on any branch (#503). Four of those seven are plain shell and pass on
+# a clean checkout, so they are wired up here -- no image build, no push, no
+# release-posture decision.
+#
+# Deliberately NOT here:
+#   test-pr88-skills.sh, test-single-user-mode.sh   build or run a container
+#   test-mcp-native-surface.sh                      needs a live server
+#                                                   ("Start the server first")
+#   test_init_sh_unchanged.sh                       asserts byte-identity with a
+#                                                   main-line v0.9.2.0 baseline,
+#                                                   which canon has moved past
+# Those four stay with #503 and #491; wiring them needs a decision, not a file.
+
+name: shell-tests
+
+on:
+  pull_request:
+    branches: [main, next/v1]
+    paths:
+      - "tests/**"
+      - "skills/**"
+      - "openwebui/**"
+      - "computer-use-server/**"
+      - ".github/workflows/shell-tests.yml"
+  push:
+    branches: [main, next/v1]
+
+permissions:
+  contents: read
+
+jobs:
+  shell:
+    name: tests — shell (no image, no server)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # The job token stays in .git/config for every later step without this.
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.12"
+      - name: Install test deps
+        # Pinned for the same reason build.yml's are: unpinned, each run
+        # resolves whatever PyPI serves that day. test-subagent-runtime.sh
+        # drives six pytest files and reports FAIL on "No module named pytest",
+        # which reads as a code failure and is an environment one.
+        run: pip install pytest==9.1.1 pytest-asyncio==1.4.0
+      - name: skills name no hardcoded model ids
+        run: bash tests/test-skill-no-hardcoded-models.sh
+      - name: sub-agent runtime surface
+        run: bash tests/test-subagent-runtime.sh
+      - name: sub-agent model listing
+        run: bash tests/test-list-subagent-models.sh
+      - name: project structure
+        # Reads as a docker test -- it mentions `docker build` seven times --
+        # but every mention is in a message, not a command: it asserts files and
+        # directories exist and passes on a bare checkout (RESULT: STRUCTURE OK,
+        # FAILED: 0). build.yml also runs it, which covers main only.
+        run: bash tests/test-project-structure.sh

--- a/scripts/check-gates-trigger-on-canon.py
+++ b/scripts/check-gates-trigger-on-canon.py
@@ -43,6 +43,10 @@ MUST_COVER_CANON = {
     # Already correct today, listed so a revert is caught rather than noticed:
     # helm.yml lints the chart that ships on this branch.
     "helm.yml",
+    # The four tests/ scripts that need neither an image nor a server. They ran
+    # nowhere before #503; narrowing this workflow back to main would strand
+    # them again.
+    "shell-tests.yml",
 }
 
 # Workflows deliberately outside the set, with the reason, so the next reader


### PR DESCRIPTION
ci(tests): run the four shell tests that executed nowhere

A sweep of tests/ found all eleven scripts unreachable from a next/v1 pull
request (#503): four invoked only by build.yml, whose trigger is
`branches: [main]`, and seven invoked by no workflow on any branch. This wires
up the subset that needs neither a built image nor a running server, so it
costs no release-posture decision -- they are shell scripts that ran nowhere.

Four are in. Each was RUN first, then mutation-probed against its own subject,
because a test nobody executes is also a test nobody has checked:

  test-skill-no-hardcoded-models  plant a model id in the named file -> exit 1
  test-project-structure          remove a required file            -> exit 1
  test-subagent-runtime           invert a pytest assertion         -> exit 1
  test-list-subagent-models       break list-subagent-models        -> exit 1

Every probe restored the tree and re-ran clean at exit 0.

The first probe was aimed wrong and reported a vacuous test: planting a model
id in skills/public/describe-image/SKILL.md changed nothing, because the check
reads a NAMED list of two files and that is not one of them. Mutating
skills/public/sub-agent/SKILL.md reds it. A mutation outside a checker's scope
looks exactly like a checker that does not work.

Four stay out, with the reason in the workflow header: test-pr88-skills and
test-single-user-mode build or run a container; test-mcp-native-surface needs a
live server; test_init_sh_unchanged asserts byte-identity with a main-line
v0.9.2.0 baseline that canon has moved past. Those belong to #503 and #491.

pytest is pinned at the same version build.yml uses. Unpinned,
test-subagent-runtime reports `FAIL: ... (pytest exit 1)` on "No module named
pytest" -- an environment failure that reads as a code failure.

check-gates-trigger-on-canon.py caught the new file as unclassified on its
first run, which is what it is for; shell-tests.yml joins the gate set so
narrowing it back to main reds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated shell-based validation for pull requests and pushes targeting key development branches.
  * Tests run in a consistent, read-only environment with pinned tooling and verify shell functionality without requiring a container image or running server.
  * Documented scenarios that are excluded from this test suite and their additional requirements.
  * Updated required checks so shell-test results are reported for pull requests targeting the next major-version branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->