### PR TITLE
ci(flex-01): assert the endpoint half, not only the import half

### DIFF
--- a/scripts/check-no-vendor-sdk.py
+++ b/scripts/check-no-vendor-sdk.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import argparse
 import ast
 import pathlib
+import re
 import sys
 
 # Directories holding OCU's own code. Not a denylist of everything -- see the
@@ -62,6 +63,66 @@ def _root(name: str) -> str:
         if name == vendor or name.startswith(vendor + "."):
             return vendor
     return ""
+
+
+# The second half of NFR-FLEX-01. The row asks two things: "zero upstream-vendor
+# SDK imported" -- which vendor_imports() answers -- and "any allow-listed
+# destination is reachable without OCU code changes", which nothing looked at. A
+# hostname compiled into a call site is the exact failure: reaching a different
+# endpoint then needs an edit, not configuration.
+#
+# The rule is that an external host may appear only as a FALLBACK to an
+# environment lookup. Measured on this tree when the check was written:
+# api.anthropic.com appears three times and every one is
+# `os.getenv("ANTHROPIC_BASE_URL") or "https://api.anthropic.com"`, so the
+# requirement holds and nothing enforced it.
+#
+# Prose is not a call site: system_prompt.py names cdnjs.cloudflare.com inside
+# the text handed to the model. That is an instruction to the model, not an
+# endpoint OCU dials, so string literals in module-level prompt text are out of
+# scope -- flagging them would make the check wrong on its first run.
+HOST_LITERAL = re.compile(r"""["']https?://(?!localhost|127\.0\.0\.1)[a-z0-9.-]+\.[a-z]{2,}""", re.I)
+CONFIG_LOOKUP = re.compile(r"os\.(?:getenv|environ)")
+
+# The runtime, not the toolbox. NFR-FLEX-01 is about destinations OCU DIALS, and
+# scripts/ neither serves traffic nor is shipped -- its literals are self-test
+# fixtures (example.invalid) and a documentation URL in an error message.
+# Scanning it produced three findings, all false, which is how a check earns
+# being switched off.
+ENDPOINT_DIRS = ("computer-use-server", "openwebui", "settings-wrapper")
+
+
+def hardcoded_endpoints(source: str, path: str = "") -> list[tuple[int, str]]:
+    """External endpoints that are not a fallback to configuration.
+
+    A literal is configured when its line reads the environment directly, or
+    falls back through a module constant that does. The second case is the one
+    this codebase actually uses and the one a naive two-line window misses:
+
+        ANTHROPIC_BASE_URL = os.getenv("ANTHROPIC_BASE_URL") or "https://..."   # line 86
+        base = (base_url or ANTHROPIC_BASE_URL or "https://...").rstrip("/")    # line 338
+
+    Line 338 is a fallback to line 86's already-configured constant, 250 lines
+    away. Judging it alone reports a violation in code that satisfies the
+    requirement.
+    """
+    env_constants = {
+        m.group(1)
+        for m in re.finditer(r"^([A-Z][A-Z0-9_]*)\s*=\s*os\.(?:getenv|environ)", source, re.M)
+    }
+    findings = []
+    lines = source.splitlines()
+    for number, line in enumerate(lines, 1):
+        match = HOST_LITERAL.search(line)
+        if not match:
+            continue
+        window = (lines[number - 2] + " " + line) if number >= 2 else line
+        if CONFIG_LOOKUP.search(window):
+            continue
+        if any(name in line for name in env_constants):
+            continue
+        findings.append((number, match.group(0).strip("\"'")))
+    return findings
 
 
 def vendor_imports(source: str) -> list[tuple[int, str]]:
@@ -107,6 +168,28 @@ def scan(root: pathlib.Path) -> tuple[dict[str, list[tuple[int, str]]], int]:
     return findings, scanned
 
 
+def _endpoint_self_test() -> int:
+    """Drive hardcoded_endpoints(). Without this the endpoint half is live and
+    untested, and the meta-gate would certify it stubbed."""
+    cases = [
+        ('BASE = "https://api.example.com"\n', 1, "a bare host literal is caught"),
+        ('import os\nBASE = os.getenv("B") or "https://api.example.com"\n', 0,
+         "the same host behind an env lookup passes"),
+        ('BASE = "http://localhost:8081"\n', 0, "localhost is not an external endpoint"),
+        ('X = os.getenv("B")\nBASE = (\n    X or "https://api.example.com")\n', 0,
+         "a wrapped fallback is judged whole"),
+        ('CFG = os.getenv("BASE_URL")\n\n\ndef f():\n    return CFG or "https://api.example.com"\n', 0,
+         "a fallback through a module constant defined far above passes"),
+    ]
+    failures = 0
+    for source, want, label in cases:
+        got = 1 if hardcoded_endpoints(source) else 0
+        ok = got == want
+        failures += 0 if ok else 1
+        print(f"  {'ok' if ok else 'FAIL'}: {label}")
+    return failures
+
+
 def _self_test() -> int:
     cases = [
         ("a plain import is caught", "import openai\n", 1),
@@ -129,6 +212,8 @@ def _self_test() -> int:
         ok = got == want
         failures += 0 if ok else 1
         print(f"  {'ok' if ok else 'FAIL'}: {name} ({got})")
+    failures += _endpoint_self_test()
+
     print()
     if failures:
         print(f"self-test: {failures} case(s) failed")
@@ -163,9 +248,39 @@ def main(argv: list[str] | None = None) -> int:
                 )
         return 1
 
+    endpoint_hits: dict[str, list[tuple[int, str]]] = {}
+    endpoint_files = 0
+    for directory in ENDPOINT_DIRS:
+        base = root / directory
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            endpoint_files += 1
+            hits = hardcoded_endpoints(path.read_text(encoding="utf-8", errors="ignore"), str(path))
+            if hits:
+                endpoint_hits[str(path.relative_to(root))] = hits
+
+    if endpoint_hits:
+        for path, hits in endpoint_hits.items():
+            for line, host in hits:
+                print(
+                    f"::error file={path},line={line}::{host} is compiled in. "
+                    "NFR-FLEX-01: an allow-listed destination must be reachable by "
+                    "configuration, so a host literal belongs behind an environment "
+                    "lookup as its fallback, not on its own.",
+                    file=sys.stderr,
+                )
+        return 1
+
     print(
         f"NFR-FLEX-01 (import half): {scanned} OCU Python file(s) import no "
         "upstream-vendor SDK."
+    )
+    print(
+        f"NFR-FLEX-01 (endpoint half): {endpoint_files} runtime file(s) name no "
+        "external host except as a fallback to configuration."
     )
     return 0
 


### PR DESCRIPTION
ci(flex-01): assert the endpoint half, not only the import half

NFR-FLEX-01 asks two things: zero upstream-vendor SDK imported, and any
allow-listed destination reachable without OCU code changes. This checker
answered the first and said so in its own success line -- "(import half)".
Nothing answered the second, so a hostname compiled into a call site would have
passed, which is exactly the failure the row names: reaching a different
endpoint then needs an edit rather than configuration.

The rule: an external host literal is allowed only as a fallback to
configuration. The requirement already holds -- api.anthropic.com appears three
times and every one resolves through ANTHROPIC_BASE_URL -- so this makes an
existing property enforced rather than assumed.

Two false positives shaped the rule, and both would have made the check wrong
on its first run.

A two-line window is not enough. `base = (base_url or ANTHROPIC_BASE_URL or
"https://api.anthropic.com")` at docker_manager.py:338 is a fallback to a
constant assigned from os.getenv at line 86, 250 lines above. Judged alone it
reads as compiled-in. The check now recognises module constants defined from
the environment anywhere in the file.

scripts/ is out of scope. Scanning it produced three findings -- two
example.invalid fixtures in a self-test and a documentation URL in an error
message -- none of them a destination OCU dials. A check that reports three
false findings on its first run is one nobody keeps.

Probed on the real tree: a bare literal added to mcp_tools.py exits 1, the same
host behind os.getenv exits 0, restored exits 0. Five self-test cases drive
hardcoded_endpoints() directly, including the module-constant case that caught
my own false positive, and stubbing it reds the self-test. Meta-gate 9 of 9.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added checks for external runtime endpoints and environment-based configuration.
  * Added endpoint self-tests with clear success and error reporting.
  * Localhost endpoints are excluded from external-host detection.
* **Bug Fixes**
  * Improved detection of improperly configured external hosts while preserving existing vendor-import checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->