### PR TITLE
docs(nfr-coverage): account for every id a CI gate could answer

### DIFF
--- a/scripts/check-nfr-coverage.py
+++ b/scripts/check-nfr-coverage.py
@@ -39,6 +39,18 @@ commit cannot supply:
     NFR-FLEX-03   needs an IdP integration to be portable across
     NFR-COST-05   needs session accounting that does not exist
     NFR-COMP-25   marked REVISIT, non-gating
+    NFR-SEC-57    the egress tripwire does not exist in the tree -- grep for
+                  it across computer-use-server/ and helm/ returns nothing
+    NFR-SEC-83    frame-ancestors and X-Frame-Options are on no response;
+                  every response.headers assignment in app.py is Cache-Control
+                  (#498). A gate before the header exists reds every PR for a
+                  condition no PR can fix
+    NFR-SEC-86    the artifact-body render substrate does not exist yet
+
+That accounts for every id whose verification column names a CI gate. The rest
+of the 190 are not silent for want of trying: 18 name a running deployment as
+their verification, and the remainder are declarations rather than checkable
+properties. Counting them as coverage debt would misread the manifesto.
 
 That list is the answer to "why not more", and it is here rather than in a
 commit message so the next person reads it before re-deriving it.


### PR DESCRIPTION
docs(nfr-coverage): account for every id a CI gate could answer

The docstring carries a list of ids that are not armed and why, so the next
person reads the reason instead of re-deriving it. The list answered for eleven.
Measured against the manifesto: 190 declared, 11 armed, 11 excused, 168
accounted for by neither.

Most of that 168 is not debt. Classifying the remainder by what its
verification column asks for: 18 name a running deployment, 147 are
declarations rather than checkable properties, and three name a CI gate. Those
three were the real gap, and they are now listed:

    NFR-SEC-57  the egress tripwire is not in the tree -- grep across
                computer-use-server/ and helm/ returns nothing
    NFR-SEC-83  frame-ancestors and X-Frame-Options are on no response; every
                response.headers assignment in app.py is Cache-Control (#498)
    NFR-SEC-86  the artifact-body render substrate does not exist yet

Verified rather than asserted: after the edit, the count of ids that name a CI
gate and are neither armed nor explained is zero, down from three.

A first pass at this reported two STALE excuses -- NFR-SEC-15 and NFR-SEC-89
listed as unarmed while both are armed. False alarm: the probe matched any
mention of an id anywhere in the header, and both appear there in prose
explaining the check rather than in the excuse list. Narrowed to the list's own
shape, stale excuses are zero.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation explaining which security requirements cannot currently be checked.
  * Clarified how the remaining non-functional requirements are accounted for.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->