### PR TITLE
fix(security): validate chat_id by character class, not by banned characters

### DIFF
--- a/computer-use-server/security.py
+++ b/computer-use-server/security.py
@@ -2,25 +2,39 @@
 # Copyright (c) 2025 Open Computer Use Contributors
 """Centralized security utilities for path validation and input sanitization."""
 import os
+import re
 from pathlib import Path
 
 from fastapi import HTTPException
 
 
-def sanitize_chat_id(chat_id: str) -> str:
-    """Validate chat_id — reject path traversal characters.
+CHAT_ID = re.compile(r"^[a-z0-9_-]{1,64}$")
 
-    chat_id can be any string (UUID, "default", etc.),
-    but must NOT contain: '..', '/', '\\', null-bytes.
+
+def sanitize_chat_id(chat_id: str) -> str:
+    """Validate chat_id against a character class, not a list of bad characters.
+
+    The previous rule rejected '..', '/', '\\' and NUL -- path traversal only.
+    Everything else passed, and chat_id reaches an HTML template: `/preview/{id}`
+    interpolates it four times. Those four go through json.dumps, so the value
+    cannot escape its JS string today, and CodeQL's py/reflective-xss on
+    app.py:1147 is not exploitable as written (#495).
+
+    What made it safe was every interpolation staying json.dumps'd -- a property
+    of thirty-two call sites rather than of the input. A quote-bearing id was
+    accepted:
+
+        'x" onload="alert(1)'   accepted by the old rule
+        'a<script>alert(1)'     rejected, but only because of the closing tag's
+                                slash, not because anything looked for markup
+
+    An allow-list moves the guarantee to the data. Measured against every
+    chat_id literal in the repository -- UUIDs, "default", "abc123",
+    "test-123" -- the class accepts all of them and rejects the traversal and
+    markup cases the old rule was reaching for.
     """
     normalized = chat_id.strip().lower()
-    if (
-        not normalized
-        or ".." in normalized
-        or "/" in normalized
-        or "\\" in normalized
-        or "\x00" in normalized
-    ):
+    if not CHAT_ID.fullmatch(normalized):
         raise HTTPException(status_code=400, detail="Invalid chat_id")
     return normalized
 

--- a/tests/security/test_xss_preview.py
+++ b/tests/security/test_xss_preview.py
@@ -6,7 +6,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "computer-use-server"))
 
+import pytest
+
 from app import _generate_preview_html
+from security import sanitize_chat_id
 
 
 VALID_CHAT_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
@@ -44,3 +47,37 @@ class TestPreviewXSS:
         assert 'chatId: "test-id"' in html
         assert 'apiUrl: "/api/test"' in html
         assert 'filesBase: "/files/test"' in html
+
+
+class TestChatIdCharacterClass:
+    """The guarantee belongs to the input, not to thirty-two call sites.
+
+    The tests above prove the template escapes what reaches it. That was the
+    only barrier: sanitize_chat_id rejected '..', '/', '\\' and NUL, so a
+    quote-bearing id was accepted and the endpoint stayed safe purely because
+    every interpolation happened to be json.dumps'd. These bind the allow-list
+    instead -- if it is loosened back to a deny-list, they red.
+    """
+
+    def test_quote_bearing_id_is_refused(self):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException):
+            sanitize_chat_id('x" onload="alert(1)')
+
+    def test_markup_is_refused_without_relying_on_the_slash(self):
+        # '<script>' carries no '/', so the traversal rule never saw it.
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException):
+            sanitize_chat_id("a<script>alert(1)")
+
+    def test_real_values_still_pass(self):
+        for value in (VALID_CHAT_ID, "default", "abc123", "test-123", "Winner"):
+            assert sanitize_chat_id(value) == value.lower()
+
+    def test_length_is_bounded(self):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException):
+            sanitize_chat_id("a" * 65)


### PR DESCRIPTION
fix(security): validate chat_id by character class, not by banned characters

sanitize_chat_id rejected '..', '/', '\' and NUL. Everything else passed, and
chat_id reaches an HTML template -- /preview/{id} interpolates it four times.

Those four are json.dumps'd, so the CodeQL py/reflective-xss at app.py:1147 is
not exploitable as written (#495). What made it safe was every interpolation
staying that way, which is a property of thirty-two call sites rather than of
the input. The old rule accepted `x" onload="alert(1)` outright and rejected
`a<script>alert(1)</script>` only because of the closing tag's slash -- nothing
looked for markup.

`^[a-z0-9_-]{1,64}$` moves the guarantee to the data. Chosen against evidence
rather than taste: swept every chat_id literal in the repository -- UUIDs,
"default", "abc123", "test-123", "qry", "winner" -- and the class accepts all
of them. It rejects the quote, the markup, the traversal and the space cases,
and bounds length, which the old rule did not.

Four tests bind the allow-list, because the existing XSS tests assert the
TEMPLATE escapes what reaches it and would pass either way. Probed: loosening
the class back to a deny-list reds them, restoring greens. Full run 234 passed,
5 skipped -- no regression across the thirty-two call sites.
