### PR TITLE
ci(gates): report a required context that a path filter can withhold

### DIFF
--- a/scripts/check-gates-trigger-on-canon.py
+++ b/scripts/check-gates-trigger-on-canon.py
@@ -94,6 +94,57 @@ def covers_canon(on):
     return False, f"branches={branches}"
 
 
+APPLIER = Path("scripts/apply-layer0-protection.sh")
+
+
+def required_contexts(root=Path(".")):
+    """The context names the applier marks required, read from its REQUIRED array."""
+    import re
+
+    path = root / APPLIER
+    if not path.is_file():
+        return set()
+    block = re.search(r"^REQUIRED=\((.*?)^\)", path.read_text(encoding="utf-8"), re.S | re.M)
+    return set(re.findall(r'"([^"]*)"', block.group(1))) if block else set()
+
+
+def path_filtered_required(root=Path(".")):
+    """Required contexts published by a workflow that only fires on some paths.
+
+    A required context that does not arrive is not a slow check -- it is a
+    permanent block. Today next/v1 carries no protection (#408), so a PR whose
+    files miss the filter merges anyway and the defect is invisible. It becomes
+    a deadlock on the day protection is switched on, which is exactly when
+    nobody wants to be debugging trigger filters.
+
+    Measured when this was written: contracts-lint.yml owns `asyncapi` and
+    `nfr-gates`, and filters on contracts/**, scripts/** and its own file. A PR
+    touching computer-use-server/ and tests/ produced 14 checks, 8 of the 10
+    required, with those two ABSENT rather than red.
+    """
+    import yaml
+
+    required = required_contexts(root)
+    if not required:
+        return []
+    out = []
+    for path in sorted((root / WORKFLOWS).glob("*.yml")):
+        try:
+            doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except yaml.YAMLError:
+            continue
+        on = doc.get(True) or doc.get("on") or {}
+        pull = on.get("pull_request") if isinstance(on, dict) else None
+        paths = pull.get("paths") if isinstance(pull, dict) else None
+        if not paths:
+            continue
+        jobs = doc.get("jobs") or {}
+        owned = sorted({(job.get("name") or key) for key, job in jobs.items()} & required)
+        if owned:
+            out.append((path.name, owned, paths))
+    return out
+
+
 def findings(root=Path(".")):
     """Return (workflow, reason) for every named gate blind to the canon branch.
 
@@ -169,6 +220,48 @@ def self_test():
         # A workflow in neither set. Without this the classification branch is
         # untested, and the fixture above -- which writes only named gates --
         # can never reach it.
+        # path_filtered_required(): a required context behind a path filter is
+        # only a finding when BOTH hold. Probing one alone would pass a check
+        # that reacts to either.
+        (root / "scripts").mkdir(exist_ok=True)
+        applier = root / APPLIER
+        applier.write_text('REQUIRED=(\n  "gated"\n)\n', encoding="utf-8")
+        wf = root / WORKFLOWS / "gated.yml"
+        wf.write_text(
+            "name: g\non:\n  pull_request:\n    branches: [main, next/v1]\n"
+            "    paths:\n      - 'contracts/**'\njobs:\n  gated:\n    steps: []\n",
+            encoding="utf-8",
+        )
+        if not path_filtered_required(root):
+            bad += 1
+            sys.stderr.write("self-test FAIL: a required context behind a path filter was not reported\n")
+        else:
+            print("self-test ok: a required context behind a path filter is reported")
+
+        wf.write_text(
+            "name: g\non:\n  pull_request:\n    branches: [main, next/v1]\n"
+            "jobs:\n  gated:\n    steps: []\n",
+            encoding="utf-8",
+        )
+        if path_filtered_required(root):
+            bad += 1
+            sys.stderr.write("self-test FAIL: an unfiltered required context was reported\n")
+        else:
+            print("self-test ok: the same job without a path filter is accepted")
+
+        applier.write_text('REQUIRED=(\n  "other"\n)\n', encoding="utf-8")
+        wf.write_text(
+            "name: g\non:\n  pull_request:\n    branches: [main, next/v1]\n"
+            "    paths:\n      - 'contracts/**'\njobs:\n  gated:\n    steps: []\n",
+            encoding="utf-8",
+        )
+        if path_filtered_required(root):
+            bad += 1
+            sys.stderr.write("self-test FAIL: a filtered job that is NOT required was reported\n")
+        else:
+            print("self-test ok: a path-filtered job that is not required is accepted")
+        wf.unlink()
+
         stray = root / WORKFLOWS / "unclassified-probe.yml"
         stray.write_text("name: s\non:\n  pull_request:\n    branches: [main]\n", encoding="utf-8")
         if not any("neither" in why for _, why in findings(root)):
@@ -204,6 +297,15 @@ def main(argv):
         )
     if blind:
         return 1
+    for name, owned, paths in path_filtered_required(root):
+        print(
+            f"::notice::{name} publishes required context(s) {', '.join(owned)} but "
+            f"fires only on {', '.join(paths)}. A PR touching none of those paths "
+            f"produces no such context — harmless while {CANON} is unprotected "
+            f"(#408), a permanent block the day protection is enabled. Either drop "
+            f"the path filter or move those jobs to a workflow without one."
+        )
+
     print(f"every one of {len(MUST_COVER_CANON)} named gates reports on a {CANON} pull request")
     return 0
 


### PR DESCRIPTION
ci(gates): report a required context that a path filter can withhold

Found by checking #508's rollup against the required set instead of counting
green: 14 checks, 8 of the 10 required contexts, and the missing two ABSENT
rather than failed. contracts-lint.yml publishes `asyncapi` and `nfr-gates` and
fires only on contracts/**, scripts/** and its own file; #508 touches
computer-use-server/ and tests/.

Harmless today and only today. next/v1 carries no protection (#408), so a PR
whose files miss the filter merges anyway. The day protection is enabled, that
same PR cannot merge and cannot be made to: a required context that never
arrives is a permanent block, not a slow check. The failure is scheduled rather
than absent, which is the kind this repository keeps finding late.

Reported rather than blocking: the fix is either dropping the filter -- which
runs every contract lint on every PR -- or moving those two jobs to a workflow
without one. That is a CI-shape decision, and the notice makes it visible on
every run instead of on the day it deadlocks.

The finding requires BOTH conditions, so it is probed against both: removing
the path filter reports nothing, de-requiring the contexts reports nothing, the
tree as committed reports one. Three self-test cases pin the same distinction,
and stubbing path_filtered_required() reds the self-test. Meta-gate 9 of 9.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detection for required checks hidden behind pull-request path filters.
  - Reports notices when required checks are associated with workflows that may not run for all changes.

- **Tests**
  - Added coverage for filtered required checks, unfiltered checks, and filtered non-required jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->